### PR TITLE
we need a game mechanic where weapon upgrades live on from one level to the next

### DIFF
--- a/src/games/archer/ArcherGame.ts
+++ b/src/games/archer/ArcherGame.ts
@@ -299,9 +299,9 @@ export class ArcherGame implements IGame {
       }
 
       if (hit.grantedUpgrade) {
-        this.upgradeManager.activate(hit.grantedUpgrade, () => {
-          this.arrowsRemaining += 10;
-          this.hud.showAmmoGain(10);
+        this.upgradeManager.activate(hit.grantedUpgrade, (amount: number) => {
+          this.arrowsRemaining += amount;
+          this.hud.showAmmoGain(amount);
           this.sound.play("ammo_gain");
         });
         this.sound.play("upgrade_activate");
@@ -364,6 +364,7 @@ export class ArcherGame implements IGame {
     this.arrowsRemaining = 0;
     this.lowAmmoTriggered = false;
     this.sound.stopLowAmmoWarning();
+    this.upgradeManager.resetAll();
     this.startLevel(0);
   }
 
@@ -380,7 +381,7 @@ export class ArcherGame implements IGame {
     this.obstacles = [];
     this.bow = new Bow(this.width, this.height, this.input.isTouchDevice ? 60 : 30);
     this.spawner.configure(config);
-    this.upgradeManager.reset();
+    this.upgradeManager.resetForNewLevel();
     this.hud.reset();
   }
 
@@ -415,7 +416,9 @@ export class ArcherGame implements IGame {
       this.dt,
       config.level,
       config.name,
-      this.totalScore + (this.state === "playing" ? this.score : 0)
+      this.totalScore + (this.state === "playing" ? this.score : 0),
+      this.upgradeManager.getPermanentUpgrades(),
+      this.upgradeManager.getCollectionCounts()
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
   }

--- a/src/games/archer/rendering/HUD.ts
+++ b/src/games/archer/rendering/HUD.ts
@@ -1,4 +1,5 @@
-import { GameState, UpgradeState } from "../types";
+import { GameState, UpgradeState, UpgradeType } from "../types";
+import { PERMANENT_THRESHOLD } from "../systems/UpgradeManager";
 
 const UPGRADE_DISPLAY: Record<string, { icon: string; color: string; label: string }> = {
   "multi-shot": { icon: "⫸", color: "#3498db", label: "Multi-Shot" },
@@ -64,7 +65,9 @@ export class HUD {
     dt = 0,
     level = 1,
     levelName = "",
-    totalScore = 0
+    totalScore = 0,
+    permanentUpgrades: ReadonlySet<UpgradeType> = new Set(),
+    collectionCounts: ReadonlyMap<UpgradeType, number> = new Map()
   ): void {
     for (const t of this.ammoGainTexts) {
       t.age += dt;
@@ -81,10 +84,10 @@ export class HUD {
         this.renderMenu(ctx, canvasW, canvasH);
         break;
       case "playing":
-        this.renderPlaying(ctx, score, arrowsRemaining, canvasW, activeUpgrades, level, levelName);
+        this.renderPlaying(ctx, score, arrowsRemaining, canvasW, activeUpgrades, level, levelName, permanentUpgrades);
         break;
       case "level_complete":
-        this.renderLevelComplete(ctx, score, level, levelName, canvasW, canvasH);
+        this.renderLevelComplete(ctx, score, level, levelName, canvasW, canvasH, collectionCounts);
         break;
       case "gameover":
         this.renderGameOver(ctx, totalScore, canvasW, canvasH, level, levelName);
@@ -155,7 +158,8 @@ export class HUD {
     w: number,
     activeUpgrades: ReadonlyArray<UpgradeState>,
     level: number,
-    levelName: string
+    levelName: string,
+    permanentUpgrades: ReadonlySet<UpgradeType> = new Set()
   ): void {
     ctx.save();
     ctx.font = "bold 20px sans-serif";
@@ -179,14 +183,24 @@ export class HUD {
       const info = UPGRADE_DISPLAY[upgrade.type];
       if (!info) continue;
 
+      const isPerm = permanentUpgrades.has(upgrade.type);
+      const prefix = isPerm ? "★ " : "";
+
       ctx.font = "bold 15px sans-serif";
       ctx.fillStyle = info.color;
-      ctx.fillText(`${info.icon} ${info.label} ${upgrade.remainingTime.toFixed(1)}s`, 16, yOffset);
+      ctx.fillText(`${prefix}${info.icon} ${info.label} ${upgrade.remainingTime.toFixed(1)}s`, 16, yOffset);
 
       const barX = 16;
       const barW = 120;
       const barH = 4;
       const barY = yOffset + 5;
+
+      if (isPerm) {
+        ctx.strokeStyle = "#FFD700";
+        ctx.lineWidth = 1;
+        ctx.strokeRect(barX - 1, barY - 1, barW + 2, barH + 2);
+      }
+
       ctx.fillStyle = "rgba(255,255,255,0.2)";
       ctx.fillRect(barX, barY, barW, barH);
 
@@ -227,7 +241,8 @@ export class HUD {
     level: number,
     levelName: string,
     w: number,
-    h: number
+    h: number,
+    collectionCounts: ReadonlyMap<UpgradeType, number> = new Map()
   ): void {
     ctx.save();
 
@@ -249,11 +264,35 @@ export class HUD {
     ctx.fillStyle = "#f1c40f";
     ctx.fillText(`Score: ${levelScore}`, w / 2, h / 2 + 30);
 
+    const upgradeTypes: { type: UpgradeType; label: string }[] = [
+      { type: "multi-shot", label: "Multi-Shot" },
+      { type: "piercing", label: "Piercing" },
+      { type: "rapid-fire", label: "Rapid Fire" },
+      { type: "bonus-arrows", label: "Bonus Arrows" },
+    ];
+
+    let progressY = h / 2 + 60;
+    let hasProgress = false;
+    for (const { type, label } of upgradeTypes) {
+      const count = collectionCounts.get(type) ?? 0;
+      if (count === 0) continue;
+      hasProgress = true;
+
+      const dots = Array.from({ length: PERMANENT_THRESHOLD }, (_, i) =>
+        i < count ? "●" : "○"
+      ).join("");
+
+      ctx.font = "16px sans-serif";
+      ctx.fillStyle = "rgba(255,255,255,0.8)";
+      ctx.fillText(`${label} ${dots}`, w / 2, progressY);
+      progressY += 22;
+    }
+
     ctx.fillStyle = "rgba(255,255,255,0.7)";
     ctx.font = "20px sans-serif";
     ctx.fillText(
       this.isTouchDevice ? "Tap to Continue" : "Click to Continue",
-      w / 2, h / 2 + 80
+      w / 2, hasProgress ? progressY + 15 : h / 2 + 80
     );
 
     ctx.restore();

--- a/src/games/archer/systems/UpgradeManager.ts
+++ b/src/games/archer/systems/UpgradeManager.ts
@@ -7,14 +7,32 @@ const DURATIONS: Record<UpgradeType, number> = {
   "bonus-arrows": 0,
 };
 
+export const PERMANENT_THRESHOLD = 3;
+export const PERMANENT_COOLDOWN = 10;
+const BONUS_ARROWS_THRESHOLD_AMOUNT = 25;
+
 export class UpgradeManager {
   private active: UpgradeState[] = [];
+  private collectionCounts: Map<UpgradeType, number> = new Map();
+  private permanentUpgrades: Set<UpgradeType> = new Set();
+  private cooldowns: Map<UpgradeType, number> = new Map();
 
-  activate(type: UpgradeType, onInstant?: () => void): void {
+  activate(type: UpgradeType, onInstant?: (amount: number) => void): void {
+    const prevCount = this.collectionCounts.get(type) ?? 0;
+    const newCount = prevCount + 1;
+    this.collectionCounts.set(type, newCount);
+
     if (type === "bonus-arrows") {
-      onInstant?.();
+      const amount = newCount === PERMANENT_THRESHOLD ? BONUS_ARROWS_THRESHOLD_AMOUNT : 10;
+      onInstant?.(amount);
       return;
     }
+
+    if (newCount >= PERMANENT_THRESHOLD) {
+      this.permanentUpgrades.add(type);
+    }
+
+    this.cooldowns.delete(type);
 
     const existing = this.active.find((u) => u.type === type);
     if (existing) {
@@ -32,11 +50,70 @@ export class UpgradeManager {
     for (const u of this.active) {
       u.remainingTime -= dt;
     }
+
+    const newCooldowns = new Set<UpgradeType>();
+    const expired = this.active.filter(
+      (u) => u.remainingTime <= 0 && this.permanentUpgrades.has(u.type)
+    );
+    for (const u of expired) {
+      if (!this.cooldowns.has(u.type)) {
+        this.cooldowns.set(u.type, PERMANENT_COOLDOWN);
+        newCooldowns.add(u.type);
+      }
+    }
+
     this.active = this.active.filter((u) => u.remainingTime > 0);
+
+    for (const [type, remaining] of this.cooldowns) {
+      if (newCooldowns.has(type)) continue;
+      const newRemaining = remaining - dt;
+      if (newRemaining <= 0) {
+        this.cooldowns.delete(type);
+        this.active.push({ type, remainingTime: DURATIONS[type] });
+      } else {
+        this.cooldowns.set(type, newRemaining);
+      }
+    }
+  }
+
+  resetForNewLevel(): void {
+    this.active = [];
+    this.cooldowns.clear();
+
+    for (const type of this.permanentUpgrades) {
+      this.active.push({ type, remainingTime: DURATIONS[type] });
+    }
+  }
+
+  resetAll(): void {
+    this.active = [];
+    this.collectionCounts.clear();
+    this.permanentUpgrades.clear();
+    this.cooldowns.clear();
   }
 
   reset(): void {
-    this.active = [];
+    this.resetAll();
+  }
+
+  isPermanent(type: UpgradeType): boolean {
+    return this.permanentUpgrades.has(type);
+  }
+
+  getCollectionCount(type: UpgradeType): number {
+    return this.collectionCounts.get(type) ?? 0;
+  }
+
+  getCollectionCounts(): ReadonlyMap<UpgradeType, number> {
+    return this.collectionCounts;
+  }
+
+  getPermanentUpgrades(): ReadonlySet<UpgradeType> {
+    return this.permanentUpgrades;
+  }
+
+  getCooldown(type: UpgradeType): number {
+    return this.cooldowns.get(type) ?? 0;
   }
 
   getActive(): ReadonlyArray<UpgradeState> {

--- a/src/games/archer/types.ts
+++ b/src/games/archer/types.ts
@@ -23,6 +23,15 @@ export interface UpgradeState {
   remainingTime: number;
 }
 
+export interface PersistentUpgradeState {
+  type: UpgradeType;
+  remainingTime: number;
+  cooldownRemaining: number;
+  isPermanent: boolean;
+}
+
+export type UpgradeCollectionMap = Record<UpgradeType, number>;
+
 export type SoundEvent =
   | "arrow_shoot"
   | "balloon_pop"

--- a/tests/upgrades.test.ts
+++ b/tests/upgrades.test.ts
@@ -40,10 +40,11 @@ describe("UpgradeManager", () => {
     expect(mgr.getActive()[0].remainingTime).toBe(5);
   });
 
-  it("bonus-arrows calls onInstant and does not add to active list", () => {
+  it("bonus-arrows calls onInstant with 10 and does not add to active list", () => {
     const fn = jest.fn();
     mgr.activate("bonus-arrows", fn);
     expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(10);
     expect(mgr.getActive()).toHaveLength(0);
     expect(mgr.hasUpgrade("bonus-arrows")).toBe(false);
   });
@@ -84,6 +85,249 @@ describe("UpgradeManager", () => {
     mgr.reset();
     expect(mgr.getActive()).toHaveLength(0);
     expect(mgr.hasUpgrade("multi-shot")).toBe(false);
+  });
+});
+
+// --- Persistent Upgrade System ---
+
+describe("UpgradeManager: collection counting", () => {
+  let mgr: UpgradeManager;
+
+  beforeEach(() => {
+    mgr = new UpgradeManager();
+  });
+
+  it("increments collection count on each activation", () => {
+    mgr.activate("multi-shot");
+    expect(mgr.getCollectionCount("multi-shot")).toBe(1);
+    mgr.activate("multi-shot");
+    expect(mgr.getCollectionCount("multi-shot")).toBe(2);
+  });
+
+  it("tracks collection counts independently per upgrade type", () => {
+    mgr.activate("multi-shot");
+    mgr.activate("multi-shot");
+    mgr.activate("rapid-fire");
+    expect(mgr.getCollectionCount("multi-shot")).toBe(2);
+    expect(mgr.getCollectionCount("rapid-fire")).toBe(1);
+    expect(mgr.getCollectionCount("piercing")).toBe(0);
+  });
+
+  it("returns all collection counts via getCollectionCounts()", () => {
+    mgr.activate("piercing");
+    mgr.activate("piercing");
+    const counts = mgr.getCollectionCounts();
+    expect(counts.get("piercing")).toBe(2);
+  });
+
+  it("tracks bonus-arrows collection counts", () => {
+    const fn = jest.fn();
+    mgr.activate("bonus-arrows", fn);
+    mgr.activate("bonus-arrows", fn);
+    expect(mgr.getCollectionCount("bonus-arrows")).toBe(2);
+  });
+});
+
+describe("UpgradeManager: permanent threshold", () => {
+  let mgr: UpgradeManager;
+
+  beforeEach(() => {
+    mgr = new UpgradeManager();
+  });
+
+  it("upgrade becomes permanent at exactly 3 collections", () => {
+    mgr.activate("multi-shot");
+    mgr.activate("multi-shot");
+    expect(mgr.isPermanent("multi-shot")).toBe(false);
+    mgr.activate("multi-shot");
+    expect(mgr.isPermanent("multi-shot")).toBe(true);
+  });
+
+  it("upgrade is not permanent at 2 collections", () => {
+    mgr.activate("piercing");
+    mgr.activate("piercing");
+    expect(mgr.isPermanent("piercing")).toBe(false);
+  });
+
+  it("4th+ collection keeps upgrade permanent", () => {
+    for (let i = 0; i < 4; i++) mgr.activate("multi-shot");
+    expect(mgr.isPermanent("multi-shot")).toBe(true);
+    expect(mgr.getCollectionCount("multi-shot")).toBe(4);
+  });
+
+  it("bonus-arrows cannot become permanent", () => {
+    const fn = jest.fn();
+    for (let i = 0; i < 3; i++) mgr.activate("bonus-arrows", fn);
+    expect(mgr.isPermanent("bonus-arrows")).toBe(false);
+    expect(mgr.hasUpgrade("bonus-arrows")).toBe(false);
+  });
+
+  it("bonus-arrows 3rd collection grants 25 instead of 10", () => {
+    const fn = jest.fn();
+    mgr.activate("bonus-arrows", fn);
+    mgr.activate("bonus-arrows", fn);
+    mgr.activate("bonus-arrows", fn);
+    expect(fn).toHaveBeenNthCalledWith(1, 10);
+    expect(fn).toHaveBeenNthCalledWith(2, 10);
+    expect(fn).toHaveBeenNthCalledWith(3, 25);
+  });
+
+  it("bonus-arrows 4th collection grants standard 10", () => {
+    const fn = jest.fn();
+    for (let i = 0; i < 4; i++) mgr.activate("bonus-arrows", fn);
+    expect(fn).toHaveBeenNthCalledWith(4, 10);
+  });
+
+  it("getPermanentUpgrades returns all permanent types", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    for (let i = 0; i < 3; i++) mgr.activate("piercing");
+    const perms = mgr.getPermanentUpgrades();
+    expect(perms.has("multi-shot")).toBe(true);
+    expect(perms.has("piercing")).toBe(true);
+    expect(perms.has("rapid-fire")).toBe(false);
+  });
+});
+
+describe("UpgradeManager: resetForNewLevel", () => {
+  let mgr: UpgradeManager;
+
+  beforeEach(() => {
+    mgr = new UpgradeManager();
+  });
+
+  it("preserves permanent upgrades with fresh timers", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    mgr.update(8.1); // expire the timer
+    expect(mgr.hasUpgrade("multi-shot")).toBe(false);
+
+    mgr.resetForNewLevel();
+    expect(mgr.hasUpgrade("multi-shot")).toBe(true);
+    expect(mgr.getActive()[0].remainingTime).toBe(8);
+    expect(mgr.isPermanent("multi-shot")).toBe(true);
+  });
+
+  it("clears non-permanent upgrades", () => {
+    mgr.activate("piercing"); // only 1 collection
+    expect(mgr.hasUpgrade("piercing")).toBe(true);
+
+    mgr.resetForNewLevel();
+    expect(mgr.hasUpgrade("piercing")).toBe(false);
+  });
+
+  it("preserves collection counts across level transitions", () => {
+    mgr.activate("rapid-fire");
+    mgr.activate("rapid-fire");
+    expect(mgr.getCollectionCount("rapid-fire")).toBe(2);
+
+    mgr.resetForNewLevel();
+    expect(mgr.getCollectionCount("rapid-fire")).toBe(2);
+  });
+
+  it("reactivates permanent upgrade that was in cooldown", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("rapid-fire");
+    mgr.update(5.1); // expire timer, enter cooldown
+    mgr.update(3); // partial cooldown elapsed
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(false);
+    expect(mgr.getCooldown("rapid-fire")).toBeGreaterThan(0);
+
+    mgr.resetForNewLevel();
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(true);
+    expect(mgr.getActive().find((u: any) => u.type === "rapid-fire")!.remainingTime).toBe(5);
+    expect(mgr.getCooldown("rapid-fire")).toBe(0);
+  });
+
+  it("player with 0 active upgrades but has permanents gets them reactivated", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    mgr.update(8.1); // expire
+    mgr.update(10.1); // cooldown done, reactivated
+    mgr.update(8.1); // expire again
+    // Now in cooldown again
+
+    mgr.resetForNewLevel();
+    expect(mgr.hasUpgrade("multi-shot")).toBe(true);
+  });
+});
+
+describe("UpgradeManager: resetAll", () => {
+  let mgr: UpgradeManager;
+
+  beforeEach(() => {
+    mgr = new UpgradeManager();
+  });
+
+  it("clears everything including permanent state and collection counts", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    mgr.activate("piercing");
+    mgr.activate("piercing");
+
+    mgr.resetAll();
+
+    expect(mgr.hasUpgrade("multi-shot")).toBe(false);
+    expect(mgr.isPermanent("multi-shot")).toBe(false);
+    expect(mgr.getCollectionCount("multi-shot")).toBe(0);
+    expect(mgr.getCollectionCount("piercing")).toBe(0);
+    expect(mgr.getActive()).toHaveLength(0);
+    expect(mgr.getPermanentUpgrades().size).toBe(0);
+  });
+});
+
+describe("UpgradeManager: permanent upgrade cooldown", () => {
+  let mgr: UpgradeManager;
+
+  beforeEach(() => {
+    mgr = new UpgradeManager();
+  });
+
+  it("permanent upgrade reactivates after 10s cooldown", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("rapid-fire");
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(true);
+
+    mgr.update(5.1); // timer expires
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(false);
+
+    mgr.update(5); // 5s into cooldown
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(false);
+
+    mgr.update(5.1); // cooldown done
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(true);
+    expect(mgr.getActive().find((u: any) => u.type === "rapid-fire")!.remainingTime).toBe(5);
+  });
+
+  it("permanent upgrade in cooldown is still permanent", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    mgr.update(8.1); // expire
+    mgr.update(5); // partial cooldown
+
+    expect(mgr.hasUpgrade("multi-shot")).toBe(false);
+    expect(mgr.isPermanent("multi-shot")).toBe(true);
+  });
+
+  it("re-collecting permanent upgrade during cooldown resets timer and clears cooldown", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    mgr.update(8.1); // expire
+    mgr.update(3); // partial cooldown
+
+    mgr.activate("multi-shot"); // 4th collection
+    expect(mgr.hasUpgrade("multi-shot")).toBe(true);
+    expect(mgr.getActive().find((u: any) => u.type === "multi-shot")!.remainingTime).toBe(8);
+    expect(mgr.getCooldown("multi-shot")).toBe(0);
+  });
+
+  it("multiple permanent upgrades can cycle cooldowns independently", () => {
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    for (let i = 0; i < 3; i++) mgr.activate("piercing");
+
+    mgr.update(5.5); // piercing (6s) still active, rapid would expire if present
+    expect(mgr.hasUpgrade("multi-shot")).toBe(true);
+    expect(mgr.hasUpgrade("piercing")).toBe(true);
+
+    mgr.update(1); // 6.5s total: piercing expired
+    expect(mgr.hasUpgrade("piercing")).toBe(false);
+
+    mgr.update(1.5); // 8s: multi-shot about to expire
+    mgr.update(0.1); // 8.1s: multi-shot expired
+    expect(mgr.hasUpgrade("multi-shot")).toBe(false);
+    expect(mgr.hasUpgrade("piercing")).toBe(false);
   });
 });
 
@@ -312,6 +556,8 @@ function createMockCanvas(): HTMLCanvasElement {
     translate: jest.fn(),
     rotate: jest.fn(),
     createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
+    strokeRect: jest.fn(),
+    roundRect: jest.fn(),
   };
 
   const canvas = {
@@ -557,6 +803,148 @@ describe("Game integration: upgrades", () => {
   });
 });
 
+// --- Game integration: persistent upgrades ---
+
+describe("Game integration: persistent upgrades across levels", () => {
+  let game: any;
+  let internals: ReturnType<typeof getGameInternals>;
+  let randomSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+    const canvas = createMockCanvas();
+    setupDom(canvas);
+    game = new Game("test-canvas");
+    internals = getGameInternals(game);
+    internals.resetGame();
+    internals.state = "playing";
+  });
+
+  afterEach(() => {
+    randomSpy.mockRestore();
+  });
+
+  it("collection counts persist across levels", () => {
+    const mgr = internals.upgradeManager;
+    mgr.activate("rapid-fire");
+    mgr.activate("rapid-fire");
+    expect(mgr.getCollectionCount("rapid-fire")).toBe(2);
+
+    mgr.resetForNewLevel();
+    expect(mgr.getCollectionCount("rapid-fire")).toBe(2);
+  });
+
+  it("permanent upgrade carries over to next level with fresh timer", () => {
+    const mgr = internals.upgradeManager;
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    expect(mgr.isPermanent("multi-shot")).toBe(true);
+
+    mgr.resetForNewLevel();
+    expect(mgr.hasUpgrade("multi-shot")).toBe(true);
+    expect(mgr.getActive().find((u: any) => u.type === "multi-shot")!.remainingTime).toBe(8);
+  });
+
+  it("non-permanent upgrade is cleared on level transition", () => {
+    const mgr = internals.upgradeManager;
+    mgr.activate("piercing");
+    expect(mgr.hasUpgrade("piercing")).toBe(true);
+
+    mgr.resetForNewLevel();
+    expect(mgr.hasUpgrade("piercing")).toBe(false);
+  });
+
+  it("collecting one more after level transition reaches permanent threshold", () => {
+    const mgr = internals.upgradeManager;
+    mgr.activate("piercing");
+    mgr.activate("piercing");
+    expect(mgr.isPermanent("piercing")).toBe(false);
+
+    mgr.resetForNewLevel();
+    mgr.activate("piercing");
+    expect(mgr.isPermanent("piercing")).toBe(true);
+  });
+
+  it("game reset clears all permanent state and collection counts", () => {
+    const mgr = internals.upgradeManager;
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    mgr.activate("piercing");
+    mgr.activate("piercing");
+
+    internals.resetGame();
+    const mgr2 = internals.upgradeManager;
+    expect(mgr2.hasUpgrade("multi-shot")).toBe(false);
+    expect(mgr2.isPermanent("multi-shot")).toBe(false);
+    expect(mgr2.getCollectionCount("multi-shot")).toBe(0);
+    expect(mgr2.getCollectionCount("piercing")).toBe(0);
+  });
+
+  it("bonus-arrows 3rd collection grants +25 arrows via game callback", () => {
+    internals.arrowsRemaining = 50;
+    const mgr = internals.upgradeManager;
+
+    // First two bonus-arrows collections (each +10)
+    const fn1 = jest.fn();
+    mgr.activate("bonus-arrows", fn1);
+    mgr.activate("bonus-arrows", fn1);
+
+    // Third collection via game integration
+    const upgBalloon = new Balloon(400, 300, 60, "bonus-arrows");
+    internals.balloons = [upgBalloon];
+    const arrow = new Arrow({ x: 400, y: 300 }, -Math.PI / 2);
+    internals.arrows = [arrow];
+
+    (internals.input as any).wasClicked = false;
+    internals.updatePlaying(0.016);
+
+    // 50 + 25 = 75
+    expect(internals.arrowsRemaining).toBe(75);
+  });
+
+  it("bonus-arrows 4th collection grants standard +10 arrows", () => {
+    internals.arrowsRemaining = 50;
+    const mgr = internals.upgradeManager;
+
+    const fn = jest.fn();
+    for (let i = 0; i < 3; i++) mgr.activate("bonus-arrows", fn);
+
+    const upgBalloon = new Balloon(400, 300, 60, "bonus-arrows");
+    internals.balloons = [upgBalloon];
+    const arrow = new Arrow({ x: 400, y: 300 }, -Math.PI / 2);
+    internals.arrows = [arrow];
+
+    (internals.input as any).wasClicked = false;
+    internals.updatePlaying(0.016);
+
+    // 50 + 10 = 60
+    expect(internals.arrowsRemaining).toBe(60);
+  });
+
+  it("multiple permanent upgrades active simultaneously on new level", () => {
+    const mgr = internals.upgradeManager;
+    for (let i = 0; i < 3; i++) mgr.activate("multi-shot");
+    for (let i = 0; i < 3; i++) mgr.activate("piercing");
+
+    mgr.resetForNewLevel();
+
+    expect(mgr.hasUpgrade("multi-shot")).toBe(true);
+    expect(mgr.hasUpgrade("piercing")).toBe(true);
+    expect(mgr.getActive()).toHaveLength(2);
+  });
+
+  it("permanent upgrade in cooldown survives level transition", () => {
+    const mgr = internals.upgradeManager;
+    for (let i = 0; i < 3; i++) mgr.activate("rapid-fire");
+    mgr.update(5.1); // expire, enter cooldown
+    mgr.update(3); // partial cooldown
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(false);
+
+    mgr.resetForNewLevel();
+    expect(mgr.hasUpgrade("rapid-fire")).toBe(true);
+    expect(mgr.getActive().find((u: any) => u.type === "rapid-fire")!.remainingTime).toBe(5);
+    expect(mgr.getCooldown("rapid-fire")).toBe(0);
+  });
+});
+
 // --- HUD with active upgrades ---
 
 describe("HUD displays active upgrades", () => {
@@ -589,6 +977,122 @@ describe("HUD displays active upgrades", () => {
       (c: { text: string }) => c.text.includes("Rapid Fire") || c.text.includes("Multi-Shot") || c.text.includes("Piercing")
     );
     expect(upgradeCall).toBeUndefined();
+  });
+
+  it("shows star prefix for permanent upgrades on the HUD", () => {
+    const hud = new HUD();
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+    const fillTextCalls = (canvas as any).__fillTextCalls;
+
+    const permanentSet = new Set<UpgradeType>(["multi-shot" as UpgradeType]);
+
+    hud.render(
+      ctx as any, "playing", 10, 50, 800, 600,
+      [{ type: "multi-shot", remainingTime: 8 }],
+      0.016, 1, "Meadow", 10,
+      permanentSet, new Map()
+    );
+
+    const upgradeCall = fillTextCalls.find(
+      (c: { text: string }) => c.text.includes("★") && c.text.includes("Multi-Shot")
+    );
+    expect(upgradeCall).toBeDefined();
+  });
+
+  it("does not show star prefix for non-permanent upgrades", () => {
+    const hud = new HUD();
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+    const fillTextCalls = (canvas as any).__fillTextCalls;
+
+    hud.render(
+      ctx as any, "playing", 10, 50, 800, 600,
+      [{ type: "multi-shot", remainingTime: 8 }],
+      0.016, 1, "Meadow", 10,
+      new Set(), new Map()
+    );
+
+    const starCall = fillTextCalls.find(
+      (c: { text: string }) => c.text.includes("★")
+    );
+    expect(starCall).toBeUndefined();
+  });
+});
+
+describe("HUD level-complete screen collection progress", () => {
+  it("shows collection progress for upgrades with at least 1 collection", () => {
+    const hud = new HUD();
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+    const fillTextCalls = (canvas as any).__fillTextCalls;
+
+    const counts = new Map<UpgradeType, number>();
+    counts.set("multi-shot", 2);
+    counts.set("piercing", 1);
+
+    hud.render(
+      ctx as any, "level_complete", 20, 50, 800, 600,
+      [], 0, 1, "Meadow", 20,
+      new Set(), counts
+    );
+
+    const multiShotProgress = fillTextCalls.find(
+      (c: { text: string }) => c.text.includes("Multi-Shot") && c.text.includes("●●○")
+    );
+    expect(multiShotProgress).toBeDefined();
+
+    const piercingProgress = fillTextCalls.find(
+      (c: { text: string }) => c.text.includes("Piercing") && c.text.includes("●○○")
+    );
+    expect(piercingProgress).toBeDefined();
+  });
+
+  it("does not show progress for upgrade types with 0 collections", () => {
+    const hud = new HUD();
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+    const fillTextCalls = (canvas as any).__fillTextCalls;
+
+    const counts = new Map<UpgradeType, number>();
+    counts.set("multi-shot", 1);
+
+    hud.render(
+      ctx as any, "level_complete", 20, 50, 800, 600,
+      [], 0, 1, "Meadow", 20,
+      new Set(), counts
+    );
+
+    const rapidFireProgress = fillTextCalls.find(
+      (c: { text: string }) => c.text.includes("Rapid Fire")
+    );
+    expect(rapidFireProgress).toBeUndefined();
+
+    const multiShotProgress = fillTextCalls.find(
+      (c: { text: string }) => c.text.includes("Multi-Shot")
+    );
+    expect(multiShotProgress).toBeDefined();
+  });
+
+  it("shows full dots for upgrade that reached permanent threshold", () => {
+    const hud = new HUD();
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+    const fillTextCalls = (canvas as any).__fillTextCalls;
+
+    const counts = new Map<UpgradeType, number>();
+    counts.set("piercing", 3);
+
+    hud.render(
+      ctx as any, "level_complete", 20, 50, 800, 600,
+      [], 0, 1, "Meadow", 20,
+      new Set(), counts
+    );
+
+    const piercingProgress = fillTextCalls.find(
+      (c: { text: string }) => c.text.includes("Piercing") && c.text.includes("●●●")
+    );
+    expect(piercingProgress).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## PR: Persist weapon upgrades across levels (Issue #356)

### Summary / Why
This PR introduces a **persistent upgrade tier system** so weapon upgrades can “live on” across level transitions and create a sense of build progression within a single run.

Previously, all timed weapon upgrades were cleared when starting a new level via `UpgradeManager.reset()`, making upgrades feel disposable. Now, collecting the same upgrade type **3 times in a run** promotes it to **permanent** status:
- Permanent upgrades **survive level transitions** and restart each level with a **fresh full timer**
- If a permanent upgrade expires mid-level, it **reactivates after a 10s cooldown**
- `bonus-arrows` remains an instant effect; on its **3rd collection** it grants **+25 arrows** (instead of becoming permanent)

### Key changes
- **Upgrade persistence model**
  - Added per-run **collection counting** per upgrade type
  - Added **permanent upgrade set** + **cooldown tracking** for post-expiry reactivation
  - Split reset behavior into:
    - `resetForNewLevel()` (clears only non-permanent timed upgrades; reactivates permanents)
    - `resetAll()` (full wipe for starting a new game)

- **HUD / UX updates**
  - Permanent upgrades show a **“★” prefix** (e.g., `★ Multi-Shot 8.0s`)
  - Permanent upgrade timer bars use a **distinct gold border**
  - Level-complete screen shows **collection progress** (e.g., `Multi-Shot ●●○`)

### Key files modified
- `src/games/archer/types.ts`
  - Added `PersistentUpgradeState` and `UpgradeCollectionMap` types to support persistent/timed state tracking.

- `src/games/archer/systems/UpgradeManager.ts` *(core logic)*
  - Added collection tracking, permanent upgrade state, and cooldown reactivation behavior.
  - Implemented `resetForNewLevel()` and `resetAll()` to correctly handle level transitions vs new game resets.
  - Added query helpers for HUD/level-complete rendering (permanent set + collection counts).

- `src/games/archer/ArcherGame.ts`
  - Uses `resetForNewLevel()` on level start/advance so permanents persist.
  - Uses `resetAll()` on new game to clear all persistent state.

- `src/games/archer/rendering/HUD.ts`
  - Added permanent indicators (star + styling).
  - Added level-complete collection progress rendering.

- `tests/upgrades.test.ts`
  - Added 35+ new tests covering collection counts, permanent thresholds, level transition behavior, cooldown reactivation, bonus-arrows special handling, and full reset behavior.

### Testing notes
- **Unit tests:** Added extensive coverage for `UpgradeManager` including:
  - Collection counts incrementing and persisting across levels
  - Permanent threshold triggering at exactly 3 collections
  - `resetForNewLevel()` preserving permanents while clearing non-permanents
  - Cooldown-based reactivation after expiry
  - `bonus-arrows` 3rd pickup granting +25 once, then reverting to +10 on subsequent pickups
  - `resetAll()` clearing permanent state + counts

- **Manual verification checklist**
  - Collect the same upgrade (e.g., multi-shot) 3 times → HUD shows `★` and it returns each level
  - Let a permanent upgrade expire mid-level → it reactivates after ~10s
  - Level-complete screen shows `●●○` progress for collected upgrades only
  - Start a new game → all permanent upgrades and counts are cleared

Ref: https://github.com/asgardtech/archer/issues/356