### PR TITLE
a better resolution for the raptor game

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -92,19 +92,18 @@ export class RaptorGame implements IGame {
 
   private boundResize: (() => void) | null = null;
   private resizeTimer: ReturnType<typeof setTimeout> | undefined;
+  private dpr = 1;
 
   public onExit: (() => void) | null = null;
 
   constructor(canvas: HTMLCanvasElement, private width = 800, private height = 600) {
     this.canvas = canvas;
-    this.canvas.width = width;
-    this.canvas.height = height;
 
     const ctx = this.canvas.getContext("2d");
     if (!ctx) throw new Error("Failed to get 2D rendering context");
     this.ctx = ctx;
 
-    this.input = new InputManager(this.canvas);
+    this.input = new InputManager(this.canvas, width, height);
     this.collisions = new CollisionSystem();
     this.spawner = new EnemySpawner();
     this.powerUpManager = new PowerUpManager();
@@ -127,6 +126,9 @@ export class RaptorGame implements IGame {
 
   private setupResize(): void {
     const resize = () => {
+      const oldDpr = this.dpr;
+      this.dpr = window.devicePixelRatio || 1;
+
       const vw = window.innerWidth;
       const vh = window.innerHeight;
       const targetRatio = this.width / this.height;
@@ -140,6 +142,14 @@ export class RaptorGame implements IGame {
       }
       this.canvas.style.width = `${cssW}px`;
       this.canvas.style.height = `${cssH}px`;
+
+      this.canvas.width = Math.round(this.width * this.dpr);
+      this.canvas.height = Math.round(this.height * this.dpr);
+
+      if (oldDpr !== this.dpr) {
+        this.generateProceduralAssets();
+        if (this.thrustSheet) this.player.setThrustSheet(this.thrustSheet);
+      }
     };
     this.boundResize = () => {
       clearTimeout(this.resizeTimer);
@@ -185,11 +195,11 @@ export class RaptorGame implements IGame {
 
   private generateProceduralAssets(): void {
     try {
-      const explosionCanvas = generateExplosionSheet(8, 64);
-      this.explosionSheet = new SpriteSheet(explosionCanvas, 64, 64, 8);
+      const explosionCanvas = generateExplosionSheet(8, 64, this.dpr);
+      this.explosionSheet = new SpriteSheet(explosionCanvas, 64, 64, 8, this.dpr);
 
-      const thrustCanvas = generateThrustSheet(4, 16, 24);
-      this.thrustSheet = new SpriteSheet(thrustCanvas, 16, 24, 4);
+      const thrustCanvas = generateThrustSheet(4, 16, 24, this.dpr);
+      this.thrustSheet = new SpriteSheet(thrustCanvas, 16, 24, 4, this.dpr);
     } catch (e) {
       console.warn("[RaptorGame] Failed to generate procedural assets:", e);
     }
@@ -733,6 +743,8 @@ export class RaptorGame implements IGame {
   }
 
   private render(): void {
+    this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+
     if (this.state === "loading") {
       this.hud.renderLoadingScreen(this.ctx, this.assets.progress, this.width, this.height);
       return;

--- a/src/games/raptor/rendering/SpriteSheet.ts
+++ b/src/games/raptor/rendering/SpriteSheet.ts
@@ -4,18 +4,21 @@ export class SpriteSheet {
   private fh: number;
   private cols: number;
   private _frameCount: number;
+  private dpr: number;
 
   constructor(
     image: HTMLImageElement | HTMLCanvasElement,
     frameWidth: number,
     frameHeight: number,
-    totalFrames?: number
+    totalFrames?: number,
+    dpr = 1
   ) {
     this.image = image;
     this.fw = frameWidth;
     this.fh = frameHeight;
-    this.cols = Math.floor(image.width / frameWidth);
-    const rows = Math.floor(image.height / frameHeight);
+    this.dpr = dpr;
+    this.cols = Math.floor(image.width / (frameWidth * dpr));
+    const rows = Math.floor(image.height / (frameHeight * dpr));
     this._frameCount = totalFrames ?? this.cols * rows;
   }
 
@@ -34,20 +37,23 @@ export class SpriteSheet {
     const f = Math.max(0, Math.min(frame, this._frameCount - 1));
     const col = f % this.cols;
     const row = Math.floor(f / this.cols);
-    const sx = col * this.fw;
-    const sy = row * this.fh;
+    const srcW = this.fw * this.dpr;
+    const srcH = this.fh * this.dpr;
+    const sx = col * srcW;
+    const sy = row * srcH;
     const dw = w ?? this.fw;
     const dh = h ?? this.fh;
 
-    ctx.drawImage(this.image, sx, sy, this.fw, this.fh, x - dw / 2, y - dh / 2, dw, dh);
+    ctx.drawImage(this.image, sx, sy, srcW, srcH, x - dw / 2, y - dh / 2, dw, dh);
   }
 }
 
-export function generateExplosionSheet(frames = 8, frameSize = 64): HTMLCanvasElement {
+export function generateExplosionSheet(frames = 8, frameSize = 64, dpr = 1): HTMLCanvasElement {
   const canvas = document.createElement("canvas");
-  canvas.width = frameSize * frames;
-  canvas.height = frameSize;
+  canvas.width = frameSize * frames * dpr;
+  canvas.height = frameSize * dpr;
   const ctx = canvas.getContext("2d")!;
+  ctx.scale(dpr, dpr);
 
   for (let f = 0; f < frames; f++) {
     const cx = f * frameSize + frameSize / 2;
@@ -102,11 +108,12 @@ export function generateExplosionSheet(frames = 8, frameSize = 64): HTMLCanvasEl
   return canvas;
 }
 
-export function generateThrustSheet(frames = 4, frameWidth = 16, frameHeight = 24): HTMLCanvasElement {
+export function generateThrustSheet(frames = 4, frameWidth = 16, frameHeight = 24, dpr = 1): HTMLCanvasElement {
   const canvas = document.createElement("canvas");
-  canvas.width = frameWidth * frames;
-  canvas.height = frameHeight;
+  canvas.width = frameWidth * frames * dpr;
+  canvas.height = frameHeight * dpr;
   const ctx = canvas.getContext("2d")!;
+  ctx.scale(dpr, dpr);
 
   for (let f = 0; f < frames; f++) {
     const cx = f * frameWidth + frameWidth / 2;

--- a/src/games/raptor/systems/InputManager.ts
+++ b/src/games/raptor/systems/InputManager.ts
@@ -8,6 +8,8 @@ export class InputManager {
   public readonly isTouchDevice: boolean;
 
   private canvas: HTMLCanvasElement;
+  private logicalWidth: number;
+  private logicalHeight: number;
   private activeTouchId: number | null = null;
   private keys = new Set<string>();
 
@@ -19,11 +21,13 @@ export class InputManager {
   private boundKeyDown: (e: KeyboardEvent) => void;
   private boundKeyUp: (e: KeyboardEvent) => void;
 
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(canvas: HTMLCanvasElement, logicalWidth?: number, logicalHeight?: number) {
     this.canvas = canvas;
+    this.logicalWidth = logicalWidth ?? canvas.width;
+    this.logicalHeight = logicalHeight ?? canvas.height;
     this.isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
-    this.targetX = canvas.width / 2;
-    this.targetY = canvas.height * 0.8;
+    this.targetX = this.logicalWidth / 2;
+    this.targetY = this.logicalHeight * 0.8;
 
     this.boundMouseMove = (e) => this.onMouseMove(e);
     this.boundMouseDown = (e) => this.onMouseDown(e);
@@ -71,12 +75,12 @@ export class InputManager {
 
   private toCanvasX(clientX: number): number {
     const rect = this.canvas.getBoundingClientRect();
-    return (clientX - rect.left) * (this.canvas.width / rect.width);
+    return (clientX - rect.left) * (this.logicalWidth / rect.width);
   }
 
   private toCanvasY(clientY: number): number {
     const rect = this.canvas.getBoundingClientRect();
-    return (clientY - rect.top) * (this.canvas.height / rect.height);
+    return (clientY - rect.top) * (this.logicalHeight / rect.height);
   }
 
   private onMouseMove(e: MouseEvent): void {

--- a/src/launcher/Launcher.ts
+++ b/src/launcher/Launcher.ts
@@ -35,6 +35,7 @@ export class Launcher {
   private boundResize: () => void;
   private resizeTimer: ReturnType<typeof setTimeout> | undefined;
   private lastTime = 0;
+  private dpr = 1;
 
   constructor(canvasId: string) {
     const el = document.getElementById(canvasId);
@@ -42,8 +43,6 @@ export class Launcher {
       throw new Error(`Canvas element "${canvasId}" not found`);
     }
     this.canvas = el;
-    this.canvas.width = this.width;
-    this.canvas.height = this.height;
 
     const ctx = this.canvas.getContext("2d");
     if (!ctx) throw new Error("Failed to get 2D rendering context");
@@ -84,6 +83,7 @@ export class Launcher {
   }
 
   private resize(): void {
+    this.dpr = window.devicePixelRatio || 1;
     const vw = window.innerWidth;
     const vh = window.innerHeight;
     const targetRatio = this.width / this.height;
@@ -97,15 +97,15 @@ export class Launcher {
     }
     this.canvas.style.width = `${cssW}px`;
     this.canvas.style.height = `${cssH}px`;
+    this.canvas.width = Math.round(this.width * this.dpr);
+    this.canvas.height = Math.round(this.height * this.dpr);
   }
 
   private toCanvasCoords(clientX: number, clientY: number): { x: number; y: number } {
     const rect = this.canvas.getBoundingClientRect();
-    const scaleX = this.canvas.width / rect.width;
-    const scaleY = this.canvas.height / rect.height;
     return {
-      x: (clientX - rect.left) * scaleX,
-      y: (clientY - rect.top) * scaleY,
+      x: (clientX - rect.left) * (this.width / rect.width),
+      y: (clientY - rect.top) * (this.height / rect.height),
     };
   }
 
@@ -211,6 +211,7 @@ export class Launcher {
   }
 
   private render(dt: number): void {
+    this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
     const ctx = this.ctx;
     const w = this.width;
     const h = this.height;

--- a/tests/game-collection.test.ts
+++ b/tests/game-collection.test.ts
@@ -38,6 +38,7 @@ function createMockCanvas(): HTMLCanvasElement {
     rotate: jest.fn(),
     createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
     measureText: jest.fn(() => ({ width: 50 })),
+    setTransform: jest.fn(),
   };
 
   const canvas = {
@@ -68,6 +69,7 @@ function setupDom(canvas: HTMLCanvasElement): void {
     removeEventListener: jest.fn(),
     innerWidth: 800,
     innerHeight: 600,
+    devicePixelRatio: 1,
   };
   (global as any).navigator = { maxTouchPoints: 0 };
   (global as any).performance = { now: jest.fn(() => 0) };

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -31,6 +31,7 @@ function createMockCanvas(): HTMLCanvasElement {
     rotate: jest.fn(),
     createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
     measureText: jest.fn(() => ({ width: 50 })),
+    setTransform: jest.fn(),
   };
 
   const canvas = {
@@ -61,6 +62,7 @@ function setupDom(canvas: HTMLCanvasElement): void {
     removeEventListener: jest.fn(),
     innerWidth: 800,
     innerHeight: 600,
+    devicePixelRatio: 1,
   };
   (global as any).navigator = { maxTouchPoints: 0 };
   (global as any).performance = { now: jest.fn(() => 0) };


### PR DESCRIPTION
## PR: High-DPI resolution support for Raptor Skies (Issue #367)

### Summary (what changed & why)
Raptor Skies (and the shared Launcher canvas) previously rendered to a fixed **800×600** backing buffer and relied on **CSS scaling** to fit the viewport. On high-DPI screens (e.g., Retina with `devicePixelRatio` 2–3), this caused noticeable blur because the browser was upscaling a low-resolution canvas.

This PR makes rendering **DPR-aware** by scaling the canvas backing store to `logicalSize * devicePixelRatio` and applying a per-frame `ctx.setTransform(dpr, 0, 0, dpr, 0, 0)`. Game logic remains in the **same 800×600 logical coordinate space**, preserving gameplay balance while making visuals crisp on any display.

### Key changes
- **DPR-scaled canvas backing store** for both Raptor Skies and Launcher (`canvas.width/height = logical * dpr`)
- **Per-frame transform reset** via `ctx.setTransform(...)` to avoid transform accumulation and keep all rendering in logical pixels
- **Procedural sprite sheets regenerated at DPR** (explosions / thrust) so effects stay sharp
- **Input coordinate mapping fixed** so mouse/touch input still resolves to correct logical coordinates under DPR scaling
- **Test fixtures updated** to support DPR + `setTransform` usage

### Key files modified
- `src/games/raptor/RaptorGame.ts`
  - DPR-aware resize behavior (backing store sizing)
  - `ctx.setTransform(dpr, ...)` applied each frame
  - Regenerates DPR-dependent procedural assets when DPR changes (e.g., moving between monitors)
- `src/launcher/Launcher.ts`
  - Same DPR-aware buffer sizing and per-frame transform as the game
- `src/games/raptor/rendering/SpriteSheet.ts`
  - `generateExplosionSheet()` / `generateThrustSheet()` accept DPR and scale offscreen canvases accordingly
  - `drawFrame()` reads from DPR-scaled source rectangles
- `src/shared/input/InputManager.ts` (or equivalent InputManager location)
  - Maps pointer coordinates using **logical dimensions** so clicks/touches remain correct at any DPR
- Tests (fixtures/mocks)
  - Add support for `devicePixelRatio` and mocking `ctx.setTransform`

### Testing notes
- **Manual**
  - Verify on high-DPI (or emulate via Chrome DevTools DPR=2/3):
    - Sprites/text/HUD look crisp (no blur from upscaling)
    - Explosions/thrust procedural effects render sharply
  - Resize window and/or move between monitors with different DPR:
    - Canvas backing store updates correctly
    - Game continues without interruption
  - Mouse/touch:
    - Clicking/tapping canvas center registers as logical `(400, 300)` at DPR=2
- **Automated**
  - Updated tests/mocks to include `devicePixelRatio` and `setTransform` so render paths don’t fail in unit test environments.

### Notes / non-goals
- This does **not** change the logical resolution or expand the gameplay area dynamically; it keeps the 800×600 coordinate system to avoid altering spawn positions, boundaries, or balance.

Ref: https://github.com/asgardtech/archer/issues/367