### PR TITLE
Raptor: Replace offensive power-up images with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/powerup_laser.svg
+++ b/public/assets/raptor/powerup_laser.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <radialGradient id="laser_core" cx="0.5" cy="0.4" r="0.5">
+      <stop offset="0%" stop-color="#D7BDE2"/>
+      <stop offset="40%" stop-color="#9b59b6"/>
+      <stop offset="100%" stop-color="#4A235A"/>
+    </radialGradient>
+    <linearGradient id="laser_shaft" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#BB8FCE"/>
+      <stop offset="50%" stop-color="#8E44AD"/>
+      <stop offset="100%" stop-color="#4A235A"/>
+    </linearGradient>
+    <radialGradient id="laser_glow" cx="0.5" cy="0.35" r="0.5">
+      <stop offset="0%" stop-color="#D7BDE2" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#9b59b6" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="laser_tip" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#E8DAEF"/>
+      <stop offset="100%" stop-color="#8E44AD"/>
+    </linearGradient>
+  </defs>
+  <!-- Ambient glow -->
+  <circle cx="12" cy="11" r="10" fill="url(#laser_glow)"/>
+  <!-- Energy arcs (alien lightning) -->
+  <polyline points="5,7 7,9 5.5,11 7.5,13" stroke="#BB8FCE" stroke-width="0.6" stroke-opacity="0.6" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="19,7 17,9 18.5,11 16.5,13" stroke="#BB8FCE" stroke-width="0.6" stroke-opacity="0.6" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="6,16 8,14.5 6.5,13" stroke="#D7BDE2" stroke-width="0.5" stroke-opacity="0.4" fill="none" stroke-linecap="round"/>
+  <polyline points="18,16 16,14.5 17.5,13" stroke="#D7BDE2" stroke-width="0.5" stroke-opacity="0.4" fill="none" stroke-linecap="round"/>
+  <!-- Staff body - vertical crystalline shaft -->
+  <polygon points="10.5,8 13.5,8 13,20 11,20" fill="url(#laser_shaft)" stroke="#BB8FCE" stroke-width="0.4"/>
+  <!-- Staff weapon tip - pointed angular top -->
+  <polygon points="12,1 16,8 13.5,8 12,5 10.5,8 8,8" fill="url(#laser_tip)" stroke="#D7BDE2" stroke-width="0.5"/>
+  <!-- Crystal facets on tip -->
+  <polygon points="12,1 12,5 10.5,8 8,8" fill="#9b59b6" opacity="0.4"/>
+  <polygon points="12,1 12,5 13.5,8 16,8" fill="#6C3483" opacity="0.3"/>
+  <!-- Central energy core -->
+  <ellipse cx="12" cy="8" rx="2" ry="1.2" fill="#D7BDE2" opacity="0.6"/>
+  <!-- Alien rune markings on shaft -->
+  <line x1="11.5" y1="11" x2="12.5" y2="11" stroke="#D7BDE2" stroke-width="0.5" stroke-opacity="0.5"/>
+  <line x1="11.5" y1="13" x2="12.5" y2="13" stroke="#D7BDE2" stroke-width="0.5" stroke-opacity="0.4"/>
+  <line x1="11.5" y1="15" x2="12.5" y2="15" stroke="#D7BDE2" stroke-width="0.5" stroke-opacity="0.3"/>
+  <circle cx="12" cy="17" r="0.6" fill="#BB8FCE" opacity="0.4"/>
+  <!-- Base flare -->
+  <polygon points="10,20 14,20 15,22 9,22" fill="#6C3483" stroke="#BB8FCE" stroke-width="0.3" opacity="0.7"/>
+</svg>

--- a/public/assets/raptor/powerup_rapid.svg
+++ b/public/assets/raptor/powerup_rapid.svg
@@ -1,10 +1,44 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <defs>
-    <radialGradient id="prg" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0%" stop-color="#F5B041"/>
-      <stop offset="100%" stop-color="#CA6F1E"/>
+    <radialGradient id="rapid_core" cx="0.5" cy="0.45" r="0.5">
+      <stop offset="0%" stop-color="#FDEBD0"/>
+      <stop offset="30%" stop-color="#F5B041"/>
+      <stop offset="100%" stop-color="#B7950B"/>
+    </radialGradient>
+    <linearGradient id="rapid_facet_l" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F9E79F"/>
+      <stop offset="100%" stop-color="#D4AC0D"/>
+    </linearGradient>
+    <linearGradient id="rapid_facet_r" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F39c12"/>
+      <stop offset="100%" stop-color="#7D6608"/>
+    </linearGradient>
+    <radialGradient id="rapid_glow" cx="0.5" cy="0.45" r="0.45">
+      <stop offset="0%" stop-color="#F9E79F" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F39c12" stop-opacity="0"/>
     </radialGradient>
   </defs>
-  <polygon points="12,1 18,5 22,12 18,19 12,23 6,19 2,12 6,5" fill="url(#prg)" stroke="#F8C471" stroke-width="1"/>
-  <text x="12" y="13" text-anchor="middle" dominant-baseline="central" fill="#FFF" font-family="sans-serif" font-weight="bold" font-size="10">R</text>
+  <!-- Ambient glow -->
+  <circle cx="12" cy="11" r="10" fill="url(#rapid_glow)"/>
+  <!-- Speed lines (rapid-fire visual cue) -->
+  <line x1="1" y1="8" x2="5" y2="8" stroke="#F5B041" stroke-width="0.7" stroke-opacity="0.5" stroke-linecap="round"/>
+  <line x1="2" y1="11" x2="5.5" y2="11" stroke="#F9E79F" stroke-width="0.8" stroke-opacity="0.6" stroke-linecap="round"/>
+  <line x1="1" y1="14" x2="5" y2="14" stroke="#F5B041" stroke-width="0.7" stroke-opacity="0.5" stroke-linecap="round"/>
+  <line x1="19" y1="8" x2="23" y2="8" stroke="#F5B041" stroke-width="0.7" stroke-opacity="0.5" stroke-linecap="round"/>
+  <line x1="18.5" y1="11" x2="22" y2="11" stroke="#F9E79F" stroke-width="0.8" stroke-opacity="0.6" stroke-linecap="round"/>
+  <line x1="19" y1="14" x2="23" y2="14" stroke="#F5B041" stroke-width="0.7" stroke-opacity="0.5" stroke-linecap="round"/>
+  <!-- Crystal body - main shard (asymmetric faceted shape) -->
+  <polygon points="12,2 16,7 15,18 12,22 9,18 8,7" fill="url(#rapid_core)" stroke="#D4AC0D" stroke-width="0.6"/>
+  <!-- Left facet -->
+  <polygon points="8,7 12,2 12,12 9,18" fill="url(#rapid_facet_l)" opacity="0.6"/>
+  <!-- Right facet -->
+  <polygon points="16,7 12,2 12,12 15,18" fill="url(#rapid_facet_r)" opacity="0.5"/>
+  <!-- Internal refraction lines -->
+  <line x1="12" y1="4" x2="10" y2="14" stroke="#FDEBD0" stroke-width="0.5" stroke-opacity="0.7"/>
+  <line x1="12" y1="4" x2="14" y2="12" stroke="#FDEBD0" stroke-width="0.4" stroke-opacity="0.5"/>
+  <!-- Bright center highlight -->
+  <ellipse cx="11.5" cy="9" rx="1.5" ry="2.5" fill="#FDEBD0" opacity="0.5"/>
+  <!-- Small facet sparkles -->
+  <circle cx="10" cy="6" r="0.6" fill="#FFF" opacity="0.7"/>
+  <circle cx="13.5" cy="10" r="0.4" fill="#FFF" opacity="0.5"/>
 </svg>

--- a/public/assets/raptor/powerup_spread.svg
+++ b/public/assets/raptor/powerup_spread.svg
@@ -1,10 +1,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <defs>
-    <radialGradient id="psg" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0%" stop-color="#5DADE2"/>
-      <stop offset="100%" stop-color="#2471A3"/>
+    <radialGradient id="spread_core" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#AED6F1"/>
+      <stop offset="40%" stop-color="#5DADE2"/>
+      <stop offset="100%" stop-color="#1A5276"/>
+    </radialGradient>
+    <linearGradient id="spread_face_top" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#85C1E9"/>
+      <stop offset="100%" stop-color="#3498db"/>
+    </linearGradient>
+    <linearGradient id="spread_face_left" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2E86C1"/>
+      <stop offset="100%" stop-color="#1A5276"/>
+    </linearGradient>
+    <linearGradient id="spread_face_right" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3498db"/>
+      <stop offset="100%" stop-color="#1B4F72"/>
+    </linearGradient>
+    <radialGradient id="spread_glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#AED6F1" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#3498db" stop-opacity="0"/>
     </radialGradient>
   </defs>
-  <polygon points="12,1 18,5 22,12 18,19 12,23 6,19 2,12 6,5" fill="url(#psg)" stroke="#85C1E9" stroke-width="1"/>
-  <text x="12" y="13" text-anchor="middle" dominant-baseline="central" fill="#FFF" font-family="sans-serif" font-weight="bold" font-size="10">W</text>
+  <!-- Outer energy glow -->
+  <circle cx="12" cy="12" r="11" fill="url(#spread_glow)"/>
+  <!-- Energy beams radiating outward (spread shot visual) -->
+  <line x1="12" y1="12" x2="2" y2="3" stroke="#5DADE2" stroke-width="0.8" stroke-opacity="0.7" stroke-linecap="round"/>
+  <line x1="12" y1="12" x2="22" y2="3" stroke="#5DADE2" stroke-width="0.8" stroke-opacity="0.7" stroke-linecap="round"/>
+  <line x1="12" y1="12" x2="2" y2="21" stroke="#5DADE2" stroke-width="0.8" stroke-opacity="0.7" stroke-linecap="round"/>
+  <line x1="12" y1="12" x2="22" y2="21" stroke="#5DADE2" stroke-width="0.8" stroke-opacity="0.7" stroke-linecap="round"/>
+  <line x1="12" y1="12" x2="12" y2="1" stroke="#85C1E9" stroke-width="0.6" stroke-opacity="0.5" stroke-linecap="round"/>
+  <line x1="12" y1="12" x2="12" y2="23" stroke="#85C1E9" stroke-width="0.6" stroke-opacity="0.5" stroke-linecap="round"/>
+  <!-- Holocron cube - top face -->
+  <polygon points="12,5 18,8 12,11 6,8" fill="url(#spread_face_top)" stroke="#AED6F1" stroke-width="0.5"/>
+  <!-- Holocron cube - left face -->
+  <polygon points="6,8 12,11 12,18 6,15" fill="url(#spread_face_left)" stroke="#85C1E9" stroke-width="0.4"/>
+  <!-- Holocron cube - right face -->
+  <polygon points="18,8 12,11 12,18 18,15" fill="url(#spread_face_right)" stroke="#85C1E9" stroke-width="0.4"/>
+  <!-- Ancient markings on faces -->
+  <line x1="9" y1="9.5" x2="9" y2="13" stroke="#AED6F1" stroke-width="0.4" stroke-opacity="0.6"/>
+  <line x1="7.5" y1="11" x2="10.5" y2="11" stroke="#AED6F1" stroke-width="0.4" stroke-opacity="0.6"/>
+  <line x1="15" y1="9.5" x2="15" y2="13" stroke="#AED6F1" stroke-width="0.4" stroke-opacity="0.5"/>
+  <line x1="13.5" y1="11" x2="16.5" y2="11" stroke="#AED6F1" stroke-width="0.4" stroke-opacity="0.5"/>
+  <!-- Central bright core -->
+  <circle cx="12" cy="11" r="1.5" fill="url(#spread_core)" opacity="0.8"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace offensive power-up images with Star Wars/Stargate themed art (Issue #382, part of #378)

### Summary (what changed & why)
This PR updates the **three offensive power-up SVG assets** used by the Raptor game to replace the previous (problematic) images with **high-quality, thematically consistent Star Wars/Stargate-inspired artwork**.  
This is an **asset-only change**: no rendering logic, manifests, or gameplay code needed updates. The goal is to improve visual quality, ensure the icons are **distinct and readable at ~20×20px**, and align each power-up with a clear color/function identity (blue/yellow/purple).

### What’s included
- **Spread-shot (`powerup_spread`)**: now a **blue Jedi Holocron** with outward energy beams to suggest multi-directional fire.
- **Rapid-fire (`powerup_rapid`)**: now a **yellow/amber Kyber Crystal** with internal glow and speed-line styling.
- **Laser weapon (`powerup_laser`)**: now a **purple/violet Goa’uld power crystal** with alien energy arcs (and this file is now present on disk).

All SVGs:
- use `viewBox="0 0 24 24"`
- have **transparent backgrounds**
- use **unique gradient IDs**
- are designed with **bold silhouettes** for readability at the in-game render size (~20×20px) and pulse scaling.

### Key files modified
- `public/assets/raptor/powerup_spread.svg` — replaced with Jedi Holocron (blue)
- `public/assets/raptor/powerup_rapid.svg` — replaced with Kyber Crystal (yellow/amber)
- `public/assets/raptor/powerup_laser.svg` — created/replaced with Goa’uld power crystal (purple/violet)

### Testing notes
- **Manual visual QA**
  - Launch Raptor and spawn/collect each offensive power-up type:
    - `spread-shot` → `powerup_spread`
    - `rapid-fire` → `powerup_rapid`
    - `weapon-laser` → `powerup_laser`
  - Confirm icons are recognizable at ~20×20px (including pulse extremes) and render cleanly over the existing golden aura.
  - Confirm **no console warnings** from asset loading (notably for `powerup_laser`, which was previously referenced but could be missing).

- **Automated**
  - Run existing test suite (no test changes expected): `npm test`
  - Relevant coverage: `tests/raptor-qa.test.ts`, `tests/raptor-weapons-qa.test.ts`

### Notes / scope
- No source code changes were required; existing asset manifest + loader + fallback rendering remain unchanged.

Ref: https://github.com/asgardtech/archer/issues/382