### PR TITLE
Raptor: Replace defensive and utility power-up images with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/powerup_life.svg
+++ b/public/assets/raptor/powerup_life.svg
@@ -1,10 +1,50 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <defs>
-    <radialGradient id="plg" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0%" stop-color="#EC7063"/>
-      <stop offset="100%" stop-color="#B03A2E"/>
+    <linearGradient id="life_body" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#E74C3C"/>
+      <stop offset="100%" stop-color="#922B21"/>
+    </linearGradient>
+    <linearGradient id="life_fluid" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#76D7C4"/>
+      <stop offset="40%" stop-color="#1ABC9C"/>
+      <stop offset="100%" stop-color="#0E6655"/>
+    </linearGradient>
+    <radialGradient id="life_glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#F1948A" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#E74C3C" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="life_cap" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#ABB2B9"/>
+      <stop offset="100%" stop-color="#616A6B"/>
+    </linearGradient>
+    <linearGradient id="life_highlight" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
   </defs>
-  <polygon points="12,1 18,5 22,12 18,19 12,23 6,19 2,12 6,5" fill="url(#plg)" stroke="#F1948A" stroke-width="1"/>
-  <text x="12" y="13" text-anchor="middle" dominant-baseline="central" fill="#FFF" font-family="sans-serif" font-weight="bold" font-size="12">+</text>
+  <!-- Ambient glow -->
+  <circle cx="12" cy="12" r="11" fill="url(#life_glow)"/>
+  <!-- Canister body -->
+  <rect x="7" y="5" width="10" height="16" rx="2" ry="2" fill="url(#life_body)" stroke="#C0392B" stroke-width="0.5"/>
+  <!-- Fluid viewing window -->
+  <rect x="8.5" y="8" width="7" height="9" rx="1" ry="1" fill="url(#life_fluid)" stroke="#48C9B0" stroke-width="0.4"/>
+  <!-- Fluid bubbles -->
+  <circle cx="10.5" cy="14" r="0.5" fill="#A3E4D7" opacity="0.7"/>
+  <circle cx="13" cy="11" r="0.4" fill="#A3E4D7" opacity="0.6"/>
+  <circle cx="11.5" cy="12.5" r="0.3" fill="#D1F2EB" opacity="0.5"/>
+  <!-- Top cap -->
+  <rect x="8" y="3.5" width="8" height="2.5" rx="1" ry="1" fill="url(#life_cap)" stroke="#808B96" stroke-width="0.4"/>
+  <!-- Valve nozzle -->
+  <rect x="10.5" y="2" width="3" height="2" rx="0.5" ry="0.5" fill="#808B96" stroke="#616A6B" stroke-width="0.3"/>
+  <!-- Bottom base -->
+  <rect x="8" y="20" width="8" height="2" rx="1" ry="1" fill="url(#life_cap)" stroke="#808B96" stroke-width="0.4"/>
+  <!-- Rebel Alliance insignia on body (simplified starbird) -->
+  <path d="M12,9.5 L10.5,12.5 L12,11.5 L13.5,12.5 Z" fill="#F1948A" opacity="0.8"/>
+  <path d="M12,9.5 L12,14.5" stroke="#F1948A" stroke-width="0.5" opacity="0.6" stroke-linecap="round"/>
+  <path d="M10.2,13.5 Q12,15 13.8,13.5" fill="none" stroke="#F1948A" stroke-width="0.5" opacity="0.5" stroke-linecap="round"/>
+  <!-- Glass highlight reflection -->
+  <rect x="9" y="8.5" width="1.5" height="5" rx="0.5" ry="0.5" fill="url(#life_highlight)"/>
+  <!-- Red accent bands -->
+  <line x1="7.5" y1="7" x2="16.5" y2="7" stroke="#E74C3C" stroke-width="0.6" stroke-opacity="0.8"/>
+  <line x1="7.5" y1="18.5" x2="16.5" y2="18.5" stroke="#E74C3C" stroke-width="0.6" stroke-opacity="0.8"/>
 </svg>

--- a/public/assets/raptor/powerup_missile.svg
+++ b/public/assets/raptor/powerup_missile.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="missile_body" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#2C3E50"/>
+      <stop offset="40%" stop-color="#4A6178"/>
+      <stop offset="60%" stop-color="#4A6178"/>
+      <stop offset="100%" stop-color="#1C2833"/>
+    </linearGradient>
+    <linearGradient id="missile_tip" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#F5B041"/>
+      <stop offset="100%" stop-color="#E67E22"/>
+    </linearGradient>
+    <radialGradient id="missile_glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#F5B041" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#E67E22" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="missile_exhaust" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#E67E22"/>
+      <stop offset="50%" stop-color="#D35400"/>
+      <stop offset="100%" stop-color="#E74C3C" stop-opacity="0.3"/>
+    </linearGradient>
+    <linearGradient id="missile_fin" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#34495E"/>
+      <stop offset="100%" stop-color="#1C2833"/>
+    </linearGradient>
+  </defs>
+  <!-- Ambient energy glow -->
+  <circle cx="12" cy="12" r="11" fill="url(#missile_glow)"/>
+  <!-- Exhaust plume -->
+  <polygon points="10,20 12,22 14,20" fill="url(#missile_exhaust)" opacity="0.8"/>
+  <polygon points="10.5,21 12,23.5 13.5,21" fill="#E67E22" opacity="0.4"/>
+  <!-- Warhead body - main fuselage -->
+  <polygon points="10,7 14,7 14.5,18 9.5,18" fill="url(#missile_body)" stroke="#566573" stroke-width="0.4"/>
+  <!-- Nose cone -->
+  <polygon points="12,1.5 14,7 10,7" fill="url(#missile_tip)" stroke="#F5B041" stroke-width="0.4"/>
+  <!-- Bright tip point -->
+  <circle cx="12" cy="2.5" r="0.8" fill="#FDEBD0" opacity="0.9"/>
+  <!-- Stabilizer fins - left -->
+  <polygon points="9.5,15 5.5,19 6.5,19 9.5,17" fill="url(#missile_fin)" stroke="#566573" stroke-width="0.3"/>
+  <!-- Stabilizer fins - right -->
+  <polygon points="14.5,15 18.5,19 17.5,19 14.5,17" fill="url(#missile_fin)" stroke="#566573" stroke-width="0.3"/>
+  <!-- Naquadah energy veins -->
+  <line x1="11" y1="8" x2="11" y2="11" stroke="#F5B041" stroke-width="0.6" stroke-opacity="0.7" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="13" y2="11" stroke="#F5B041" stroke-width="0.6" stroke-opacity="0.7" stroke-linecap="round"/>
+  <line x1="11" y1="12.5" x2="11" y2="15.5" stroke="#E67E22" stroke-width="0.5" stroke-opacity="0.6" stroke-linecap="round"/>
+  <line x1="13" y1="12.5" x2="13" y2="15.5" stroke="#E67E22" stroke-width="0.5" stroke-opacity="0.6" stroke-linecap="round"/>
+  <!-- Alien tech markings - horizontal bands -->
+  <line x1="10.2" y1="10" x2="13.8" y2="10" stroke="#F39C12" stroke-width="0.4" stroke-opacity="0.6"/>
+  <line x1="10.2" y1="12" x2="13.8" y2="12" stroke="#F39C12" stroke-width="0.4" stroke-opacity="0.5"/>
+  <line x1="10.2" y1="14" x2="13.8" y2="14" stroke="#F39C12" stroke-width="0.4" stroke-opacity="0.4"/>
+  <!-- Central Naquadah energy core -->
+  <ellipse cx="12" cy="11" rx="1.2" ry="1.5" fill="#F5B041" opacity="0.6"/>
+  <ellipse cx="12" cy="11" rx="0.6" ry="0.8" fill="#FDEBD0" opacity="0.7"/>
+  <!-- Body highlight reflection -->
+  <rect x="10.5" y="7.5" width="1" height="8" rx="0.5" ry="0.5" fill="#FFFFFF" opacity="0.12"/>
+  <!-- Warhead section ring -->
+  <line x1="9.5" y1="18" x2="14.5" y2="18" stroke="#E67E22" stroke-width="0.8" stroke-opacity="0.7"/>
+</svg>

--- a/public/assets/raptor/powerup_shield.svg
+++ b/public/assets/raptor/powerup_shield.svg
@@ -1,10 +1,48 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <defs>
-    <radialGradient id="pshg" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0%" stop-color="#58D68D"/>
+    <radialGradient id="shield_core" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#82E0AA"/>
+      <stop offset="40%" stop-color="#2ecc71"/>
       <stop offset="100%" stop-color="#1E8449"/>
     </radialGradient>
+    <radialGradient id="shield_glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#58D68D" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#2ecc71" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="shield_emitter" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#F9E79F"/>
+      <stop offset="60%" stop-color="#D4AC0D"/>
+      <stop offset="100%" stop-color="#B7950B"/>
+    </radialGradient>
+    <linearGradient id="shield_ring_fill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#D4AC0D"/>
+      <stop offset="100%" stop-color="#7D6608"/>
+    </linearGradient>
   </defs>
-  <polygon points="12,1 18,5 22,12 18,19 12,23 6,19 2,12 6,5" fill="url(#pshg)" stroke="#82E0AA" stroke-width="1"/>
-  <text x="12" y="13" text-anchor="middle" dominant-baseline="central" fill="#FFF" font-family="sans-serif" font-weight="bold" font-size="10">S</text>
+  <!-- Outer energy glow -->
+  <circle cx="12" cy="12" r="11" fill="url(#shield_glow)"/>
+  <!-- Outermost energy ring -->
+  <circle cx="12" cy="12" r="10.5" fill="none" stroke="#2ecc71" stroke-width="0.7" stroke-opacity="0.3"/>
+  <!-- Third concentric ring -->
+  <circle cx="12" cy="12" r="8.5" fill="none" stroke="#58D68D" stroke-width="0.8" stroke-opacity="0.4"/>
+  <!-- Second concentric ring -->
+  <circle cx="12" cy="12" r="6.5" fill="none" stroke="#82E0AA" stroke-width="1" stroke-opacity="0.6"/>
+  <!-- Device housing - outer gold ring -->
+  <circle cx="12" cy="12" r="5" fill="none" stroke="url(#shield_ring_fill)" stroke-width="1.5"/>
+  <!-- Device housing - inner gold ring -->
+  <circle cx="12" cy="12" r="3.5" fill="url(#shield_emitter)" stroke="#B7950B" stroke-width="0.5"/>
+  <!-- Central emitter core -->
+  <circle cx="12" cy="12" r="2" fill="url(#shield_core)"/>
+  <!-- Core bright highlight -->
+  <circle cx="11.5" cy="11.5" r="0.8" fill="#ABEBC6" opacity="0.7"/>
+  <!-- Energy field shimmer arcs -->
+  <path d="M5,6 Q2,12 5,18" fill="none" stroke="#58D68D" stroke-width="0.5" stroke-opacity="0.5" stroke-linecap="round"/>
+  <path d="M19,6 Q22,12 19,18" fill="none" stroke="#58D68D" stroke-width="0.5" stroke-opacity="0.5" stroke-linecap="round"/>
+  <path d="M6,5 Q12,2 18,5" fill="none" stroke="#58D68D" stroke-width="0.5" stroke-opacity="0.4" stroke-linecap="round"/>
+  <path d="M6,19 Q12,22 18,19" fill="none" stroke="#58D68D" stroke-width="0.5" stroke-opacity="0.4" stroke-linecap="round"/>
+  <!-- Gold device node markers -->
+  <circle cx="12" cy="7" r="0.6" fill="#F9E79F" opacity="0.7"/>
+  <circle cx="12" cy="17" r="0.6" fill="#F9E79F" opacity="0.7"/>
+  <circle cx="7" cy="12" r="0.6" fill="#F9E79F" opacity="0.7"/>
+  <circle cx="17" cy="12" r="0.6" fill="#F9E79F" opacity="0.7"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace defensive and utility power-up images with Star Wars/Stargate themed art (Issue #383)

### Summary (what changed + why)
This PR updates the **defensive/utility power-up SVG assets** used in the Raptor game to match the new **Star Wars/Stargate** art direction (part of epic #378). It replaces the existing placeholder icons for **shield** and **extra life** and **adds the missing missile asset** so the game no longer relies on the fallback-drawn “M” icon for missile drops.

Key goals:
- Improve visual fidelity and thematic consistency
- Ensure each power-up remains **recognizable at ~20×20px**
- Maintain existing rendering pipeline (asset-only change; no code updates needed)

### Key files modified
- `public/assets/raptor/powerup_shield.svg`  
  Replaced the simple green hexagon with a **Stargate Goa'uld personal shield emitter** (gold device housing + concentric green energy rings/shimmer).

- `public/assets/raptor/powerup_life.svg`  
  Replaced the simple red hexagon with a **Star Wars Bacta Tank canister** (cylindrical container + blue-green healing fluid window + insignia + red accents).

- `public/assets/raptor/powerup_missile.svg`  
  **Created** the previously-missing asset: **Stargate Naquadah-enhanced warhead** (dark metallic body + orange energy veins + fins + alien tech markings).

All SVGs:
- Use `viewBox="0 0 24 24"`
- Have **transparent backgrounds**
- Use **prefixed gradient IDs** (`shield_`, `life_`, `missile_`)
- Avoid `<text>`, `<image>`, and external references for reliable `<img>` rendering

### Testing notes
Manual/visual verification:
- Load Raptor and spawn/observe power-ups (shield restore, bonus life, missile weapon).
- Confirm sprites render crisply and are distinguishable at gameplay scale (~20×20px) with the pulsing animation.
- Confirm the **golden glow aura** shows through (SVG transparency preserved).
- Confirm `powerup_missile.svg` now loads successfully (no fallback “M” circle and no asset load warnings).

Automated tests:
- No new tests added (asset-only change). Existing coverage already expects `powerup_missile` to exist in the manifest; this PR completes the on-disk asset to match.

Ref: https://github.com/asgardtech/archer/issues/383