### PR TITLE
Raptor: Replace early-level horizon images with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/horizon_coastal.svg
+++ b/public/assets/raptor/terrain/horizon_coastal.svg
@@ -1,20 +1,77 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
-  <!-- Sky gradient -->
   <defs>
-    <linearGradient id="coastal-sky" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#87ceeb"/>
-      <stop offset="100%" style="stop-color:#b8d4e8"/>
+    <linearGradient id="naboo-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#87CEEB"/>
+      <stop offset="60%" style="stop-color:#B8DCF0"/>
+      <stop offset="100%" style="stop-color:#E0F0FF"/>
+    </linearGradient>
+    <linearGradient id="naboo-water" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#6BAED6"/>
+      <stop offset="100%" style="stop-color:#4A90B8"/>
+    </linearGradient>
+    <linearGradient id="naboo-haze" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#E0F0FF;stop-opacity:0"/>
+      <stop offset="100%" style="stop-color:#E0F0FF;stop-opacity:0.6"/>
+    </linearGradient>
+    <linearGradient id="naboo-hill-back" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#5a8a6a"/>
+      <stop offset="100%" style="stop-color:#3d6b4f"/>
+    </linearGradient>
+    <linearGradient id="naboo-hill-front" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#5d9068"/>
+      <stop offset="100%" style="stop-color:#4a7c59"/>
     </linearGradient>
   </defs>
-  <rect width="800" height="200" fill="url(#coastal-sky)"/>
-  <!-- Distant clouds -->
-  <ellipse cx="120" cy="45" rx="60" ry="25" fill="#f5f5f5" opacity="0.9"/>
-  <ellipse cx="350" cy="35" rx="80" ry="30" fill="#f0f0f0" opacity="0.85"/>
-  <ellipse cx="600" cy="50" rx="55" ry="22" fill="#f5f5f5" opacity="0.9"/>
-  <!-- Ocean line -->
-  <rect x="0" y="140" width="800" height="60" fill="#4a90b8"/>
-  <!-- Rolling hills - back layer -->
-  <path d="M0,200 L0,160 Q100,120 200,150 Q300,100 400,140 Q500,110 600,150 Q700,130 800,145 L800,200 Z" fill="#3d6b4f"/>
-  <!-- Rolling hills - front layer -->
-  <path d="M0,200 L0,170 Q150,140 250,175 Q350,150 450,180 Q550,155 650,175 Q750,160 800,170 L800,200 Z" fill="#4a7c59"/>
+
+  <!-- Sky background -->
+  <rect width="800" height="200" fill="url(#naboo-sky)"/>
+
+  <!-- Soft distant clouds -->
+  <ellipse cx="90" cy="30" rx="70" ry="18" fill="#f0f6fc" opacity="0.5"/>
+  <ellipse cx="280" cy="22" rx="90" ry="20" fill="#e8f2fa" opacity="0.4"/>
+  <ellipse cx="520" cy="35" rx="65" ry="16" fill="#f0f6fc" opacity="0.45"/>
+  <ellipse cx="700" cy="25" rx="75" ry="18" fill="#e8f2fa" opacity="0.4"/>
+
+  <!-- Lake water -->
+  <rect x="0" y="120" width="800" height="80" fill="url(#naboo-water)"/>
+
+  <!-- Water shimmer highlights -->
+  <line x1="50" y1="135" x2="120" y2="135" stroke="#8ec7e8" stroke-width="1" opacity="0.5"/>
+  <line x1="200" y1="145" x2="290" y2="145" stroke="#8ec7e8" stroke-width="1" opacity="0.4"/>
+  <line x1="400" y1="138" x2="480" y2="138" stroke="#8ec7e8" stroke-width="1" opacity="0.45"/>
+  <line x1="550" y1="150" x2="640" y2="150" stroke="#8ec7e8" stroke-width="1" opacity="0.35"/>
+  <line x1="680" y1="140" x2="760" y2="140" stroke="#8ec7e8" stroke-width="1" opacity="0.4"/>
+
+  <!-- Distant far hills (very faded) -->
+  <path d="M0,130 Q60,100 120,118 Q180,95 240,115 Q320,90 400,110 Q480,88 560,108 Q640,92 720,112 Q760,98 800,108 L800,140 L0,140 Z" fill="#6a9a78" opacity="0.4"/>
+
+  <!-- Naboo dome structures on far shore -->
+  <!-- Large central palace dome -->
+  <ellipse cx="380" cy="105" rx="18" ry="10" fill="#c8d8c8" opacity="0.5"/>
+  <rect x="372" y="105" width="16" height="12" fill="#c0d0c0" opacity="0.5"/>
+  <ellipse cx="380" cy="100" rx="12" ry="8" fill="#d0ddd0" opacity="0.55"/>
+  <line x1="380" y1="92" x2="380" y2="88" stroke="#b8c8b8" stroke-width="1" opacity="0.5"/>
+
+  <!-- Smaller flanking domes -->
+  <ellipse cx="350" cy="110" rx="8" ry="5" fill="#c0d0c0" opacity="0.45"/>
+  <rect x="346" y="110" width="8" height="8" fill="#b8c8b8" opacity="0.45"/>
+  <ellipse cx="415" cy="108" rx="10" ry="6" fill="#c0d0c0" opacity="0.45"/>
+  <rect x="410" y="108" width="10" height="9" fill="#b8c8b8" opacity="0.45"/>
+
+  <!-- Distant small domes at right -->
+  <ellipse cx="620" cy="112" rx="6" ry="4" fill="#c0d0c0" opacity="0.35"/>
+  <rect x="617" y="112" width="6" height="6" fill="#b8c8b8" opacity="0.35"/>
+  <ellipse cx="640" cy="114" rx="5" ry="3" fill="#c8d0c8" opacity="0.3"/>
+
+  <!-- Rolling green hills - back layer -->
+  <path d="M0,200 L0,148 Q50,125 100,142 Q160,115 230,138 Q300,108 370,132 Q430,118 500,135 Q560,112 640,130 Q710,115 760,128 Q790,120 800,125 L800,200 Z" fill="url(#naboo-hill-back)"/>
+
+  <!-- Rolling green hills - front layer -->
+  <path d="M0,200 L0,160 Q80,142 140,165 Q220,145 300,168 Q370,150 440,170 Q520,152 590,168 Q660,148 730,162 Q780,155 800,158 L800,200 Z" fill="url(#naboo-hill-front)"/>
+
+  <!-- Shoreline detail where hills meet water -->
+  <path d="M0,170 Q60,168 120,172 Q200,165 280,170 Q360,163 440,168 Q520,162 600,170 Q680,165 760,168 L800,170" stroke="#3a6048" stroke-width="1" fill="none" opacity="0.4"/>
+
+  <!-- Atmospheric haze overlay -->
+  <rect x="0" y="80" width="800" height="120" fill="url(#naboo-haze)"/>
 </svg>

--- a/public/assets/raptor/terrain/horizon_desert.svg
+++ b/public/assets/raptor/terrain/horizon_desert.svg
@@ -1,18 +1,66 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
-  <!-- Warm sky -->
   <defs>
-    <linearGradient id="desert-sky" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#e8c89c"/>
-      <stop offset="100%" style="stop-color:#d4a574"/>
+    <linearGradient id="abydos-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#87CEEB"/>
+      <stop offset="40%" style="stop-color:#C4AA78"/>
+      <stop offset="100%" style="stop-color:#F4A460"/>
+    </linearGradient>
+    <linearGradient id="abydos-sand" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#c2956a"/>
+      <stop offset="100%" style="stop-color:#a67c52"/>
+    </linearGradient>
+    <linearGradient id="abydos-haze" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#F4D8A0;stop-opacity:0"/>
+      <stop offset="100%" style="stop-color:#F4D8A0;stop-opacity:0.4"/>
+    </linearGradient>
+    <linearGradient id="abydos-pyramid" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#b8956a"/>
+      <stop offset="100%" style="stop-color:#8b6b47"/>
     </linearGradient>
   </defs>
-  <rect width="800" height="200" fill="url(#desert-sky)"/>
-  <!-- Distant mesa/butte shapes -->
-  <polygon points="0,200 80,120 160,200" fill="#a67c52"/>
-  <polygon points="120,200 220,90 320,200" fill="#8b6b47"/>
-  <polygon points="280,200 380,100 480,200" fill="#a67c52"/>
-  <polygon points="440,200 540,80 640,200" fill="#8b6b47"/>
-  <polygon points="600,200 700,110 800,200" fill="#a67c52"/>
-  <!-- Sand dunes silhouette -->
-  <path d="M0,200 L0,165 Q80,140 160,170 Q240,150 320,175 Q400,155 480,180 Q560,160 640,172 Q720,150 800,165 L800,200 Z" fill="#c2956a"/>
+
+  <!-- Sky background -->
+  <rect width="800" height="200" fill="url(#abydos-sky)"/>
+
+  <!-- Sun disc (bleached, high in sky) -->
+  <circle cx="600" cy="35" r="22" fill="#FFF8DC" opacity="0.6"/>
+  <circle cx="600" cy="35" r="16" fill="#FFFCE8" opacity="0.7"/>
+
+  <!-- Sun glow -->
+  <circle cx="600" cy="35" r="40" fill="#FFF0C0" opacity="0.15"/>
+
+  <!-- Distant pyramid silhouette (Goa'uld temple / Ha'tak) -->
+  <polygon points="280,140 320,80 360,140" fill="url(#abydos-pyramid)" opacity="0.45"/>
+  <!-- Pyramid stepped detail -->
+  <line x1="300" y1="110" x2="340" y2="110" stroke="#a08050" stroke-width="0.5" opacity="0.3"/>
+  <line x1="306" y1="100" x2="334" y2="100" stroke="#a08050" stroke-width="0.5" opacity="0.3"/>
+  <line x1="312" y1="90" x2="328" y2="90" stroke="#a08050" stroke-width="0.5" opacity="0.3"/>
+
+  <!-- Small distant secondary pyramid -->
+  <polygon points="220,145 240,115 260,145" fill="#9a7a58" opacity="0.3"/>
+
+  <!-- Tiny far-off structure (obelisk) -->
+  <rect x="180" y="130" width="3" height="15" fill="#8b7a60" opacity="0.25"/>
+
+  <!-- Far distant dune ridge -->
+  <path d="M0,150 Q80,130 160,145 Q240,125 340,140 Q420,128 500,142 Q580,130 660,138 Q740,125 800,135 L800,160 L0,160 Z" fill="#a67c52" opacity="0.5"/>
+
+  <!-- Mid-ground sand dunes -->
+  <path d="M0,200 L0,155 Q60,135 130,158 Q200,130 290,152 Q370,128 460,148 Q540,132 620,155 Q700,138 770,150 L800,145 L800,200 Z" fill="#b8875c"/>
+
+  <!-- Front dune layer -->
+  <path d="M0,200 L0,168 Q90,150 170,172 Q260,155 350,175 Q430,158 520,178 Q600,162 680,174 Q750,160 800,165 L800,200 Z" fill="url(#abydos-sand)"/>
+
+  <!-- Heat shimmer wavy lines near ground -->
+  <path d="M0,158 Q40,155 80,158 Q120,161 160,158 Q200,155 240,158 Q280,161 320,158 Q360,155 400,158 Q440,161 480,158 Q520,155 560,158 Q600,161 640,158 Q680,155 720,158 Q760,161 800,158" stroke="#e8c890" stroke-width="0.8" fill="none" opacity="0.3"/>
+  <path d="M0,163 Q50,160 100,163 Q150,166 200,163 Q250,160 300,163 Q350,166 400,163 Q450,160 500,163 Q550,166 600,163 Q650,160 700,163 Q750,166 800,163" stroke="#e8c890" stroke-width="0.6" fill="none" opacity="0.25"/>
+  <path d="M0,168 Q45,165 90,168 Q135,171 180,168 Q225,165 270,168 Q315,171 360,168 Q405,165 450,168 Q495,171 540,168 Q585,165 630,168 Q675,171 720,168 Q765,165 800,168" stroke="#d8b878" stroke-width="0.5" fill="none" opacity="0.2"/>
+
+  <!-- Windblown sand wisps -->
+  <path d="M100,170 Q130,168 160,172" stroke="#c8a060" stroke-width="0.5" fill="none" opacity="0.2"/>
+  <path d="M400,165 Q440,162 480,166" stroke="#c8a060" stroke-width="0.5" fill="none" opacity="0.2"/>
+  <path d="M620,172 Q660,169 700,173" stroke="#c8a060" stroke-width="0.5" fill="none" opacity="0.2"/>
+
+  <!-- Heat haze overlay -->
+  <rect x="0" y="100" width="800" height="100" fill="url(#abydos-haze)"/>
 </svg>

--- a/public/assets/raptor/terrain/horizon_mountain.svg
+++ b/public/assets/raptor/terrain/horizon_mountain.svg
@@ -1,19 +1,90 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
-  <!-- Sky -->
   <defs>
-    <linearGradient id="mountain-sky" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#5a6a7a"/>
-      <stop offset="100%" style="stop-color:#3d4a5a"/>
+    <linearGradient id="chulak-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#4A6670"/>
+      <stop offset="100%" style="stop-color:#8BA8B7"/>
+    </linearGradient>
+    <linearGradient id="chulak-mist-lower" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#8BA8B7;stop-opacity:0"/>
+      <stop offset="50%" style="stop-color:#8BA8B7;stop-opacity:0.3"/>
+      <stop offset="100%" style="stop-color:#8BA8B7;stop-opacity:0.5"/>
+    </linearGradient>
+    <linearGradient id="chulak-mist-upper" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#6a8a98;stop-opacity:0"/>
+      <stop offset="100%" style="stop-color:#6a8a98;stop-opacity:0.35"/>
+    </linearGradient>
+    <linearGradient id="chulak-forest" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#3a5040"/>
+      <stop offset="100%" style="stop-color:#2d3d35"/>
     </linearGradient>
   </defs>
-  <rect width="800" height="200" fill="url(#mountain-sky)"/>
-  <!-- Distant mountain range - back -->
-  <path d="M0,200 L50,120 L120,160 L200,90 L280,140 L360,70 L440,130 L520,85 L600,150 L680,95 L750,130 L800,100 L800,200 Z" fill="#2d3748"/>
-  <!-- Closer peaks with snow caps -->
-  <path d="M0,200 L80,140 L150,180 L220,110 L300,160 L380,100 L460,150 L540,95 L620,155 L700,105 L780,145 L800,130 L800,200 Z" fill="#4a5568"/>
-  <!-- Snow caps -->
-  <polygon points="200,90 240,130 280,140 260,100" fill="#e8edf2"/>
-  <polygon points="360,70 400,110 440,130 420,90" fill="#e8edf2"/>
-  <polygon points="520,85 560,120 600,150 580,100" fill="#e8edf2"/>
-  <polygon points="680,95 720,130 750,130 730,105" fill="#e8edf2"/>
+
+  <!-- Sky background -->
+  <rect width="800" height="200" fill="url(#chulak-sky)"/>
+
+  <!-- Distant mountain range - far back (faded) -->
+  <path d="M0,130 L40,95 L80,115 L130,75 L180,105 L230,65 L280,100 L330,60 L390,90 L440,55 L500,85 L550,62 L610,88 L660,58 L720,82 L770,68 L800,78 L800,140 L0,140 Z" fill="#2d3748" opacity="0.6"/>
+
+  <!-- Snow caps on far peaks -->
+  <polygon points="130,75 155,95 175,105 160,85" fill="#e8edf2" opacity="0.4"/>
+  <polygon points="230,65 258,88 275,100 260,78" fill="#e8edf2" opacity="0.45"/>
+  <polygon points="330,60 360,82 385,90 365,72" fill="#e8edf2" opacity="0.4"/>
+  <polygon points="440,55 470,78 495,85 475,68" fill="#e8edf2" opacity="0.45"/>
+  <polygon points="550,62 578,80 605,88 585,72" fill="#e8edf2" opacity="0.4"/>
+  <polygon points="660,58 688,78 715,82 695,68" fill="#e8edf2" opacity="0.45"/>
+
+  <!-- Upper mist layer between far and mid mountains -->
+  <rect x="0" y="80" width="800" height="50" fill="url(#chulak-mist-upper)"/>
+
+  <!-- Middle mountain range -->
+  <path d="M0,155 L60,120 L110,145 L170,100 L230,130 L290,95 L350,125 L410,90 L470,118 L530,92 L590,120 L650,95 L710,115 L760,100 L800,110 L800,160 L0,160 Z" fill="#3d4f5c"/>
+
+  <!-- Snow caps on mid peaks -->
+  <polygon points="170,100 195,118 225,130 205,110" fill="#e8edf2" opacity="0.5"/>
+  <polygon points="290,95 318,115 345,125 325,105" fill="#e8edf2" opacity="0.5"/>
+  <polygon points="410,90 438,110 465,118 445,100" fill="#e8edf2" opacity="0.5"/>
+  <polygon points="530,92 558,110 585,120 565,102" fill="#e8edf2" opacity="0.5"/>
+  <polygon points="650,95 675,112 705,115 685,102" fill="#e8edf2" opacity="0.45"/>
+
+  <!-- Jaffa temple structures partially hidden in the valley mist -->
+  <!-- Temple 1: stepped pyramid shape -->
+  <polygon points="240,138 255,118 270,138" fill="#4a5a68" opacity="0.4"/>
+  <rect x="248" y="128" width="14" height="10" fill="#4a5a68" opacity="0.35"/>
+  <rect x="251" y="124" width="8" height="4" fill="#4f6070" opacity="0.35"/>
+
+  <!-- Temple 2: tall obelisk-like pillar -->
+  <rect x="485" y="115" width="4" height="25" fill="#4a5a68" opacity="0.35"/>
+  <polygon points="483,115 487,108 491,115" fill="#4f6070" opacity="0.35"/>
+
+  <!-- Temple 3: distant archway -->
+  <rect x="615" y="125" width="3" height="15" fill="#4a5a68" opacity="0.3"/>
+  <rect x="625" y="125" width="3" height="15" fill="#4a5a68" opacity="0.3"/>
+  <path d="M615,125 Q621,120 628,125" stroke="#4a5a68" stroke-width="2" fill="none" opacity="0.3"/>
+
+  <!-- Dense alien forest in valleys -->
+  <path d="M0,200 L0,155 Q30,145 60,158 Q90,140 130,155 Q160,138 200,152 Q230,135 270,150 Q310,140 350,155 Q380,142 420,155 Q450,138 490,152 Q530,142 570,155 Q600,140 640,152 Q680,138 720,150 Q760,142 800,148 L800,200 Z" fill="url(#chulak-forest)"/>
+
+  <!-- Forest canopy texture (individual tree-top shapes) -->
+  <path d="M20,158 Q25,150 30,158" fill="#3a5545" opacity="0.5"/>
+  <path d="M60,155 Q68,146 76,155" fill="#345040" opacity="0.5"/>
+  <path d="M110,156 Q118,148 126,156" fill="#3a5545" opacity="0.5"/>
+  <path d="M170,152 Q178,143 186,152" fill="#345040" opacity="0.5"/>
+  <path d="M240,150 Q248,142 256,150" fill="#3a5545" opacity="0.5"/>
+  <path d="M320,154 Q328,146 336,154" fill="#345040" opacity="0.5"/>
+  <path d="M390,153 Q398,144 406,153" fill="#3a5545" opacity="0.5"/>
+  <path d="M460,152 Q468,143 476,152" fill="#345040" opacity="0.5"/>
+  <path d="M540,154 Q548,146 556,154" fill="#3a5545" opacity="0.5"/>
+  <path d="M610,152 Q618,144 626,152" fill="#345040" opacity="0.5"/>
+  <path d="M690,150 Q698,142 706,150" fill="#3a5545" opacity="0.5"/>
+  <path d="M750,148 Q758,140 766,148" fill="#345040" opacity="0.5"/>
+
+  <!-- Lower mist overlay across valleys -->
+  <rect x="0" y="130" width="800" height="70" fill="url(#chulak-mist-lower)"/>
+
+  <!-- Wisps of fog -->
+  <ellipse cx="150" cy="145" rx="60" ry="8" fill="#8BA8B7" opacity="0.2"/>
+  <ellipse cx="400" cy="140" rx="80" ry="10" fill="#8BA8B7" opacity="0.18"/>
+  <ellipse cx="650" cy="148" rx="55" ry="7" fill="#8BA8B7" opacity="0.2"/>
+  <ellipse cx="50" cy="155" rx="45" ry="6" fill="#7a98a8" opacity="0.15"/>
+  <ellipse cx="550" cy="152" rx="50" ry="7" fill="#7a98a8" opacity="0.15"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace early-level horizon images with Star Wars/Stargate themed art

### Summary (what + why)
This PR updates the **horizon background art for Raptor levels 1–3** by replacing the existing SVG horizon strips with **high-quality Star Wars/Stargate themed panoramas**. The goal is to improve early-level visual immersion while keeping the existing rendering pipeline unchanged (drop-in asset replacement).

- **Level 1 (“Coastal Patrol”)**: `horizon_coastal.svg` updated to a **Naboo lakeland**-inspired shoreline (domed structures, green hills, calm water, atmospheric haze).
- **Level 2 (“Desert Strike”)**: `horizon_desert.svg` updated to an **Abydos desert** horizon (dunes, distant pyramid silhouette, heat shimmer, sun-bleached sky).
- **Level 3 (“Mountain Assault”)**: `horizon_mountain.svg` updated to **Chulak forested mountains** (misty valley forest, rugged peaks, subtle Jaffa temple forms).

These are designed to blend naturally with each level’s **sky gradients** given horizons render at **60% opacity**, stretched to **full canvas width × 200px**, with slow parallax scrolling.

Part of epic **#378**.

---

### Key files modified
Asset-only changes (no TypeScript/config updates required):

- `public/assets/raptor/terrain/horizon_coastal.svg`
- `public/assets/raptor/terrain/horizon_desert.svg`
- `public/assets/raptor/terrain/horizon_mountain.svg`

Notes on compatibility:
- Maintains `viewBox="0 0 800 200"` and `width="800" height="200"`
- **Self-contained SVGs** (no external references)
- Uses **uniquely prefixed gradient IDs** to avoid ID collisions
- Color palettes tuned to blend with the corresponding level sky gradients at 60% alpha

---

### Testing notes
**Manual / visual verification**
- Launch Raptor and play **Levels 1–3**:
  - Horizon renders correctly as a **200px strip** near the top portion of the canvas
  - No clipping, stretching artifacts beyond expected full-width scaling, or “black rectangle” rendering
  - Thematic elements are recognizable but not distracting (subtle silhouettes / haze)
  - Horizon blends cleanly with the level sky gradient (no muddy color mixing at 60% opacity)
- Confirm **no console errors** on load related to asset fetching/decoding

**Regression**
- Verified this is **asset-only**; no changes to:
  - `src/games/raptor/rendering/assets.ts` (keys/paths unchanged)
  - `src/games/raptor/levels.ts` (level mappings unchanged)
  - `src/games/raptor/rendering/TerrainRenderer.ts` (rendering unchanged)
- Sanity-check levels **4–5** unaffected (no horizon asset changes there)

---

Ref: https://github.com/asgardtech/archer/issues/385