### PR TITLE
Raptor: Replace late-level horizon and fortress ground images with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/ground_concrete.svg
+++ b/public/assets/raptor/terrain/ground_concrete.svg
@@ -1,13 +1,88 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" fill="#444444"/>
-  <path d="M24 0 L28 64 L32 128" stroke="#3a3a3a" stroke-width="0.5" fill="none"/>
-  <path d="M64 0 L68 48 L72 96 L76 128" stroke="#555555" stroke-width="0.5" fill="none"/>
-  <path d="M96 0 L100 72 L104 128" stroke="#3a3a3a" stroke-width="0.5" fill="none"/>
-  <path d="M0 32 L48 36 L96 40 L128 44" stroke="#4a4a4a" stroke-width="0.5" fill="none"/>
-  <path d="M0 80 L64 84 L128 88" stroke="#555555" stroke-width="0.5" fill="none"/>
-  <path d="M40 0 L42 40 L44 80 L46 128" stroke="#3a3a3a" stroke-width="0.3" fill="none"/>
-  <path d="M88 0 L90 56 L92 128" stroke="#4a4a4a" stroke-width="0.3" fill="none"/>
-  <rect x="8" y="8" width="12" height="12" fill="#3a3a3a" opacity="0.6"/>
-  <rect x="72" y="56" width="16" height="16" fill="#555555" opacity="0.5"/>
-  <rect x="40" y="96" width="10" height="10" fill="#4a4a4a" opacity="0.6"/>
+  <defs>
+    <linearGradient id="hull-base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#434343"/>
+      <stop offset="50%" stop-color="#474747"/>
+      <stop offset="100%" stop-color="#414141"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Base metallic surface -->
+  <rect width="128" height="128" fill="url(#hull-base)"/>
+
+  <!-- Major horizontal panel lines (full width for seamless tiling) -->
+  <line x1="0" y1="0" x2="128" y2="0" stroke="#383838" stroke-width="0.8"/>
+  <line x1="0" y1="32" x2="128" y2="32" stroke="#383838" stroke-width="0.8"/>
+  <line x1="0" y1="64" x2="128" y2="64" stroke="#3c3c3c" stroke-width="1"/>
+  <line x1="0" y1="96" x2="128" y2="96" stroke="#383838" stroke-width="0.8"/>
+
+  <!-- Major vertical panel lines (full height for seamless tiling) -->
+  <line x1="0" y1="0" x2="0" y2="128" stroke="#383838" stroke-width="0.8"/>
+  <line x1="48" y1="0" x2="48" y2="128" stroke="#3c3c3c" stroke-width="0.8"/>
+  <line x1="80" y1="0" x2="80" y2="128" stroke="#383838" stroke-width="0.8"/>
+
+  <!-- Sub-panel divisions (horizontal) -->
+  <line x1="0" y1="16" x2="48" y2="16" stroke="#404040" stroke-width="0.5"/>
+  <line x1="80" y1="48" x2="128" y2="48" stroke="#404040" stroke-width="0.5"/>
+  <line x1="48" y1="80" x2="80" y2="80" stroke="#404040" stroke-width="0.5"/>
+  <line x1="0" y1="112" x2="48" y2="112" stroke="#404040" stroke-width="0.5"/>
+
+  <!-- Sub-panel divisions (vertical) -->
+  <line x1="24" y1="0" x2="24" y2="32" stroke="#3e3e3e" stroke-width="0.4"/>
+  <line x1="24" y1="64" x2="24" y2="96" stroke="#404040" stroke-width="0.5"/>
+  <line x1="64" y1="0" x2="64" y2="32" stroke="#404040" stroke-width="0.5"/>
+  <line x1="104" y1="32" x2="104" y2="64" stroke="#3e3e3e" stroke-width="0.4"/>
+  <line x1="104" y1="96" x2="104" y2="128" stroke="#404040" stroke-width="0.5"/>
+
+  <!-- Panel edge highlights (subtle bevel effect on select panels) -->
+  <line x1="1" y1="33" x2="47" y2="33" stroke="#505050" stroke-width="0.3"/>
+  <line x1="49" y1="1" x2="49" y2="31" stroke="#505050" stroke-width="0.3"/>
+  <line x1="1" y1="65" x2="47" y2="65" stroke="#4e4e4e" stroke-width="0.3"/>
+  <line x1="81" y1="33" x2="81" y2="63" stroke="#505050" stroke-width="0.3"/>
+  <line x1="81" y1="65" x2="127" y2="65" stroke="#4e4e4e" stroke-width="0.3"/>
+  <line x1="49" y1="65" x2="79" y2="65" stroke="#505050" stroke-width="0.3"/>
+  <line x1="1" y1="97" x2="47" y2="97" stroke="#4e4e4e" stroke-width="0.3"/>
+  <line x1="81" y1="97" x2="127" y2="97" stroke="#505050" stroke-width="0.3"/>
+
+  <!-- Rivets at major grid intersections -->
+  <circle cx="0" cy="0" r="1.2" fill="#505050"/>
+  <circle cx="48" cy="0" r="1.2" fill="#505050"/>
+  <circle cx="80" cy="0" r="1.2" fill="#505050"/>
+  <circle cx="0" cy="32" r="1.2" fill="#505050"/>
+  <circle cx="48" cy="32" r="1.2" fill="#505050"/>
+  <circle cx="80" cy="32" r="1.2" fill="#505050"/>
+  <circle cx="0" cy="64" r="1.3" fill="#525252"/>
+  <circle cx="48" cy="64" r="1.3" fill="#525252"/>
+  <circle cx="80" cy="64" r="1.3" fill="#525252"/>
+  <circle cx="0" cy="96" r="1.2" fill="#505050"/>
+  <circle cx="48" cy="96" r="1.2" fill="#505050"/>
+  <circle cx="80" cy="96" r="1.2" fill="#505050"/>
+
+  <!-- Rivets at sub-panel intersections -->
+  <circle cx="24" cy="0" r="1" fill="#4e4e4e"/>
+  <circle cx="24" cy="32" r="1" fill="#4e4e4e"/>
+  <circle cx="24" cy="64" r="1" fill="#4e4e4e"/>
+  <circle cx="24" cy="96" r="1" fill="#4e4e4e"/>
+  <circle cx="64" cy="0" r="1" fill="#4e4e4e"/>
+  <circle cx="64" cy="32" r="1" fill="#4e4e4e"/>
+  <circle cx="104" cy="32" r="1" fill="#4e4e4e"/>
+  <circle cx="104" cy="64" r="1" fill="#4e4e4e"/>
+  <circle cx="104" cy="96" r="1" fill="#4e4e4e"/>
+
+  <!-- Access hatch 1 -->
+  <rect x="6" y="38" width="10" height="10" fill="#3a3a3a" stroke="#353535" stroke-width="0.5" rx="0.5"/>
+  <rect x="8" y="40" width="6" height="6" fill="#363636" rx="0.3"/>
+  <circle cx="11" cy="43" r="1" fill="#424242"/>
+
+  <!-- Access hatch 2 -->
+  <rect x="86" y="70" width="12" height="8" fill="#3a3a3a" stroke="#353535" stroke-width="0.5" rx="0.5"/>
+  <rect x="88" y="72" width="8" height="4" fill="#363636" rx="0.3"/>
+
+  <!-- Surface weathering / carbon scoring (very subtle) -->
+  <rect x="52" y="10" width="8" height="6" fill="#3a3a3a" opacity="0.15" rx="1"/>
+  <rect x="14" y="74" width="6" height="10" fill="#383838" opacity="0.12" rx="1"/>
+  <rect x="90" y="100" width="10" height="8" fill="#3a3a3a" opacity="0.1" rx="1"/>
+  <rect x="56" y="70" width="5" height="5" fill="#383838" opacity="0.15" rx="1"/>
+  <rect x="30" y="100" width="8" height="6" fill="#3a3a3a" opacity="0.12" rx="1"/>
+  <rect x="110" y="40" width="6" height="8" fill="#383838" opacity="0.1" rx="1"/>
 </svg>

--- a/public/assets/raptor/terrain/horizon_arctic.svg
+++ b/public/assets/raptor/terrain/horizon_arctic.svg
@@ -1,21 +1,95 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
-  <!-- Arctic sky -->
   <defs>
-    <linearGradient id="arctic-sky" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#d0e0ed"/>
-      <stop offset="100%" style="stop-color:#b0d4e8"/>
+    <linearGradient id="hoth-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#95adc4"/>
+      <stop offset="40%" stop-color="#a8bfd4"/>
+      <stop offset="100%" stop-color="#bccfdf"/>
+    </linearGradient>
+    <linearGradient id="hoth-mist" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#bccfdf" stop-opacity="0"/>
+      <stop offset="70%" stop-color="#ccdbe8" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#dce8f0" stop-opacity="0.6"/>
+    </linearGradient>
+    <linearGradient id="hoth-snow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d4e0ea"/>
+      <stop offset="100%" stop-color="#eaf0f6"/>
     </linearGradient>
   </defs>
-  <rect width="800" height="200" fill="url(#arctic-sky)"/>
-  <!-- Distant icebergs -->
-  <polygon points="50,200 80,140 110,200" fill="#e8edf2"/>
-  <polygon points="180,200 220,120 260,200" fill="#d8e4ec"/>
-  <polygon points="320,200 360,100 400,200" fill="#e8edf2"/>
-  <polygon points="450,200 490,130 530,200" fill="#d8e4ec"/>
-  <polygon points="580,200 620,110 660,200" fill="#e8edf2"/>
-  <polygon points="700,200 740,140 780,200" fill="#d8e4ec"/>
-  <!-- Flat snow terrain -->
-  <rect x="0" y="160" width="800" height="40" fill="#e8edf2"/>
-  <!-- Ice formations / texture -->
-  <path d="M0,200 L0,165 Q100,155 200,168 Q300,158 400,170 Q500,160 600,172 Q700,162 800,168 L800,200 Z" fill="#b0d4e8" opacity="0.6"/>
+
+  <rect width="800" height="200" fill="url(#hoth-sky)"/>
+  <rect width="800" height="200" fill="url(#hoth-mist)"/>
+
+  <!-- Far ridge layer (very distant, faint) -->
+  <path d="M0,108 L20,104 L55,107 L90,98 L130,103 L165,95 L200,100 L245,92 L290,97 L330,89 L370,94 L410,87 L450,92 L490,85 L535,90 L575,84 L615,89 L655,82 L700,88 L740,93 L775,88 L800,91 L800,200 L0,200 Z"
+        fill="#c0d4e0" opacity="0.3"/>
+
+  <!-- Mid ridge layer -->
+  <path d="M0,128 L35,123 L70,126 L110,116 L155,120 L195,110 L235,114 L275,106 L320,112 L355,104 L395,108 L435,100 L475,106 L520,98 L560,104 L600,110 L640,104 L680,110 L720,106 L760,112 L800,108 L800,200 L0,200 Z"
+        fill="#c8dce8" opacity="0.5"/>
+
+  <!-- Jagged ice ridge peaks (mid layer accent) -->
+  <polygon points="230,114 238,98 246,114" fill="#d0dfe8" opacity="0.45"/>
+  <polygon points="315,112 325,94 335,112" fill="#c8d8e4" opacity="0.4"/>
+  <polygon points="510,104 522,88 534,104" fill="#d0dfe8" opacity="0.45"/>
+  <polygon points="695,110 706,95 717,110" fill="#c8d8e4" opacity="0.4"/>
+
+  <!-- Near ridge layer -->
+  <path d="M0,144 L45,139 L90,141 L135,133 L180,137 L225,128 L270,132 L315,124 L365,128 L410,131 L455,125 L500,129 L545,134 L590,127 L635,131 L680,126 L725,130 L770,136 L800,133 L800,200 L0,200 Z"
+        fill="#d4e2ec" opacity="0.7"/>
+
+  <!-- Echo Base main structure -->
+  <rect x="332" y="116" width="24" height="14" rx="1" fill="#a8bcc8" opacity="0.4"/>
+  <rect x="337" y="110" width="14" height="7" rx="1" fill="#9eb2c0" opacity="0.35"/>
+  <rect x="341" y="105" width="6" height="6" fill="#96aab8" opacity="0.3"/>
+  <!-- Antenna mast -->
+  <line x1="355" y1="100" x2="355" y2="116" stroke="#98acba" stroke-width="1" opacity="0.35"/>
+  <line x1="350" y1="103" x2="360" y2="103" stroke="#98acba" stroke-width="0.8" opacity="0.3"/>
+  <!-- Shield generator dome -->
+  <circle cx="340" cy="110" r="3" fill="none" stroke="#a0b4c2" stroke-width="0.6" opacity="0.3"/>
+
+  <!-- Secondary distant structure -->
+  <rect x="575" y="122" width="16" height="9" rx="1" fill="#a8bcc8" opacity="0.35"/>
+  <rect x="579" y="117" width="8" height="6" rx="1" fill="#9eb2c0" opacity="0.3"/>
+  <!-- Small antenna -->
+  <line x1="587" y1="112" x2="587" y2="117" stroke="#98acba" stroke-width="0.7" opacity="0.25"/>
+
+  <!-- Foreground snow terrain layers -->
+  <path d="M0,158 Q45,153 90,156 Q135,150 180,154 Q225,148 270,152 Q315,146 360,150 Q405,144 450,148 Q495,142 540,146 Q585,140 630,144 Q675,148 720,143 Q765,147 800,145 L800,200 L0,200 Z"
+        fill="url(#hoth-snow)"/>
+
+  <path d="M0,170 Q55,166 110,168 Q165,162 220,166 Q275,160 330,164 Q385,158 440,162 Q495,156 550,160 Q605,154 660,158 Q715,162 760,157 Q785,160 800,159 L800,200 L0,200 Z"
+        fill="#eaf0f6"/>
+
+  <path d="M0,184 Q40,180 80,182 Q120,178 160,181 Q200,176 240,179 Q280,174 320,178 Q360,173 400,176 Q440,172 480,175 Q520,170 560,174 Q600,170 640,173 Q680,176 720,172 Q760,175 800,173 L800,200 L0,200 Z"
+        fill="#f0f5f9"/>
+
+  <!-- Blowing snow particles -->
+  <circle cx="50" cy="128" r="1.2" fill="#e0eaf2" opacity="0.5"/>
+  <circle cx="115" cy="112" r="0.9" fill="#d8e4ee" opacity="0.4"/>
+  <circle cx="195" cy="122" r="1.3" fill="#e0eaf2" opacity="0.45"/>
+  <circle cx="260" cy="108" r="0.8" fill="#d8e4ee" opacity="0.35"/>
+  <circle cx="370" cy="134" r="1.1" fill="#e0eaf2" opacity="0.5"/>
+  <circle cx="440" cy="115" r="0.9" fill="#d8e4ee" opacity="0.4"/>
+  <circle cx="530" cy="126" r="1.2" fill="#e0eaf2" opacity="0.45"/>
+  <circle cx="610" cy="105" r="0.8" fill="#d8e4ee" opacity="0.35"/>
+  <circle cx="690" cy="118" r="1" fill="#e0eaf2" opacity="0.5"/>
+  <circle cx="755" cy="138" r="0.7" fill="#d8e4ee" opacity="0.4"/>
+  <circle cx="30" cy="150" r="0.8" fill="#e8eff5" opacity="0.45"/>
+  <circle cx="160" cy="145" r="1" fill="#e8eff5" opacity="0.4"/>
+  <circle cx="310" cy="140" r="0.7" fill="#e8eff5" opacity="0.35"/>
+  <circle cx="490" cy="148" r="0.9" fill="#e8eff5" opacity="0.45"/>
+  <circle cx="650" cy="142" r="0.8" fill="#e8eff5" opacity="0.4"/>
+  <circle cx="780" cy="150" r="1" fill="#e8eff5" opacity="0.35"/>
+
+  <!-- Wind-driven snow streaks -->
+  <line x1="35" y1="143" x2="58" y2="141" stroke="#e4ecf3" stroke-width="0.5" opacity="0.35"/>
+  <line x1="145" y1="136" x2="172" y2="134" stroke="#dce6ef" stroke-width="0.4" opacity="0.3"/>
+  <line x1="275" y1="140" x2="302" y2="138" stroke="#e4ecf3" stroke-width="0.5" opacity="0.35"/>
+  <line x1="420" y1="133" x2="448" y2="131" stroke="#dce6ef" stroke-width="0.4" opacity="0.3"/>
+  <line x1="565" y1="138" x2="590" y2="136" stroke="#e4ecf3" stroke-width="0.5" opacity="0.35"/>
+  <line x1="670" y1="130" x2="698" y2="128" stroke="#dce6ef" stroke-width="0.4" opacity="0.3"/>
+  <line x1="85" y1="155" x2="114" y2="153" stroke="#ecf2f7" stroke-width="0.5" opacity="0.35"/>
+  <line x1="340" y1="150" x2="370" y2="148" stroke="#ecf2f7" stroke-width="0.5" opacity="0.35"/>
+  <line x1="510" y1="148" x2="540" y2="146" stroke="#ecf2f7" stroke-width="0.5" opacity="0.3"/>
+  <line x1="715" y1="154" x2="742" y2="152" stroke="#ecf2f7" stroke-width="0.5" opacity="0.3"/>
 </svg>

--- a/public/assets/raptor/terrain/horizon_fortress.svg
+++ b/public/assets/raptor/terrain/horizon_fortress.svg
@@ -1,38 +1,148 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
-  <!-- Dark sky -->
   <defs>
-    <linearGradient id="fortress-sky" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#1a1a2e"/>
-      <stop offset="100%" style="stop-color:#0f0f1a"/>
+    <linearGradient id="ds-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a0a14"/>
+      <stop offset="100%" stop-color="#1a1a2e"/>
     </linearGradient>
-    <linearGradient id="glow" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#ff6b35;stop-opacity:0.4"/>
-      <stop offset="100%" style="stop-color:#ff6b35;stop-opacity:0"/>
+    <linearGradient id="ds-glow" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#ff6b35" stop-opacity="0.35"/>
+      <stop offset="40%" stop-color="#ff4500" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#ff4500" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="ds-glow-spot1" cx="200" cy="180" r="100" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ff6b35" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#ff4500" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="ds-glow-spot2" cx="620" cy="175" r="90" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ff4500" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#ff4500" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="ds-trench" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f0f1a"/>
+      <stop offset="100%" stop-color="#080810"/>
     </linearGradient>
   </defs>
-  <rect width="800" height="200" fill="url(#fortress-sky)"/>
-  <!-- Orange glow from below -->
-  <rect width="800" height="80" y="120" fill="url(#glow)"/>
-  <!-- Industrial skyline - buildings -->
-  <rect x="0" y="140" width="60" height="60" fill="#1a1a2e"/>
-  <rect x="70" y="110" width="50" height="90" fill="#2d2d44"/>
-  <rect x="130" y="130" width="45" height="70" fill="#1a1a2e"/>
-  <rect x="185" y="95" width="55" height="105" fill="#2d2d44"/>
-  <!-- Smoke stack -->
-  <rect x="250" y="60" width="25" height="140" fill="#2d2d44"/>
-  <rect x="245" y="50" width="35" height="15" fill="#1a1a2e"/>
-  <!-- More buildings -->
-  <rect x="285" y="120" width="50" height="80" fill="#1a1a2e"/>
-  <rect x="345" y="100" width="40" height="100" fill="#2d2d44"/>
-  <rect x="395" y="130" width="55" height="70" fill="#1a1a2e"/>
-  <!-- Second smoke stack -->
-  <rect x="460" y="70" width="22" height="130" fill="#2d2d44"/>
-  <rect x="455" y="60" width="32" height="15" fill="#1a1a2e"/>
-  <!-- Buildings continued -->
-  <rect x="492" y="115" width="45" height="85" fill="#1a1a2e"/>
-  <rect x="547" y="90" width="50" height="110" fill="#2d2d44"/>
-  <rect x="607" y="125" width="40" height="75" fill="#1a1a2e"/>
-  <rect x="657" y="105" width="55" height="95" fill="#2d2d44"/>
-  <rect x="722" y="135" width="45" height="65" fill="#1a1a2e"/>
-  <rect x="777" y="150" width="23" height="50" fill="#2d2d44"/>
+
+  <!-- Deep space sky -->
+  <rect width="800" height="200" fill="url(#ds-sky)"/>
+
+  <!-- Ambient glow from surface fires -->
+  <rect width="800" height="120" y="80" fill="url(#ds-glow)"/>
+  <rect x="120" y="130" width="200" height="70" fill="url(#ds-glow-spot1)"/>
+  <rect x="520" y="120" width="200" height="80" fill="url(#ds-glow-spot2)"/>
+
+  <!-- Death Star surface base -->
+  <rect x="0" y="80" width="800" height="120" fill="#1a1a2e"/>
+
+  <!-- Surface macro grid (horizontal) -->
+  <line x1="0" y1="90" x2="800" y2="90" stroke="#252540" stroke-width="0.5"/>
+  <line x1="0" y1="105" x2="800" y2="105" stroke="#202038" stroke-width="0.5"/>
+  <line x1="0" y1="120" x2="800" y2="120" stroke="#252540" stroke-width="0.7"/>
+  <line x1="0" y1="140" x2="800" y2="140" stroke="#202038" stroke-width="0.5"/>
+  <line x1="0" y1="155" x2="800" y2="155" stroke="#252540" stroke-width="0.5"/>
+  <line x1="0" y1="170" x2="800" y2="170" stroke="#202038" stroke-width="0.7"/>
+  <line x1="0" y1="185" x2="800" y2="185" stroke="#252540" stroke-width="0.5"/>
+
+  <!-- Surface macro grid (vertical) -->
+  <line x1="50" y1="80" x2="50" y2="200" stroke="#202038" stroke-width="0.5"/>
+  <line x1="120" y1="80" x2="120" y2="200" stroke="#252540" stroke-width="0.5"/>
+  <line x1="200" y1="80" x2="200" y2="200" stroke="#202038" stroke-width="0.5"/>
+  <line x1="280" y1="80" x2="280" y2="200" stroke="#252540" stroke-width="0.7"/>
+  <line x1="350" y1="80" x2="350" y2="200" stroke="#202038" stroke-width="0.5"/>
+  <line x1="440" y1="80" x2="440" y2="200" stroke="#252540" stroke-width="0.5"/>
+  <line x1="520" y1="80" x2="520" y2="200" stroke="#202038" stroke-width="0.7"/>
+  <line x1="600" y1="80" x2="600" y2="200" stroke="#252540" stroke-width="0.5"/>
+  <line x1="680" y1="80" x2="680" y2="200" stroke="#202038" stroke-width="0.5"/>
+  <line x1="760" y1="80" x2="760" y2="200" stroke="#252540" stroke-width="0.5"/>
+
+  <!-- Major horizontal trench -->
+  <rect x="0" y="118" width="800" height="6" fill="url(#ds-trench)"/>
+  <line x1="0" y1="118" x2="800" y2="118" stroke="#2d2d44" stroke-width="0.8"/>
+  <line x1="0" y1="124" x2="800" y2="124" stroke="#2d2d44" stroke-width="0.8"/>
+
+  <!-- Major vertical trenches -->
+  <rect x="276" y="80" width="8" height="120" fill="url(#ds-trench)"/>
+  <line x1="276" y1="80" x2="276" y2="200" stroke="#2d2d44" stroke-width="0.8"/>
+  <line x1="284" y1="80" x2="284" y2="200" stroke="#2d2d44" stroke-width="0.8"/>
+
+  <rect x="517" y="80" width="6" height="120" fill="url(#ds-trench)"/>
+  <line x1="517" y1="80" x2="517" y2="200" stroke="#2d2d44" stroke-width="0.8"/>
+  <line x1="523" y1="80" x2="523" y2="200" stroke="#2d2d44" stroke-width="0.8"/>
+
+  <!-- Raised surface panel sections -->
+  <rect x="55" y="85" width="60" height="30" fill="#2d2d44" opacity="0.6"/>
+  <rect x="130" y="90" width="65" height="25" fill="#252540" opacity="0.5"/>
+  <rect x="290" y="85" width="55" height="28" fill="#2d2d44" opacity="0.5"/>
+  <rect x="360" y="90" width="75" height="25" fill="#252540" opacity="0.6"/>
+  <rect x="530" y="88" width="65" height="28" fill="#2d2d44" opacity="0.5"/>
+  <rect x="610" y="85" width="60" height="30" fill="#252540" opacity="0.6"/>
+  <rect x="690" y="90" width="65" height="25" fill="#2d2d44" opacity="0.5"/>
+
+  <!-- Turbolaser tower 1 -->
+  <rect x="158" y="52" width="10" height="38" fill="#2d2d44"/>
+  <rect x="155" y="46" width="16" height="8" fill="#252540"/>
+  <rect x="160" y="38" width="6" height="10" fill="#2d2d44"/>
+  <circle cx="163" cy="36" r="4" fill="#252540" stroke="#2d2d44" stroke-width="0.5"/>
+  <line x1="163" y1="32" x2="163" y2="24" stroke="#2d2d44" stroke-width="1.5"/>
+  <line x1="158" y1="28" x2="168" y2="28" stroke="#252540" stroke-width="0.5"/>
+
+  <!-- Turbolaser tower 2 -->
+  <rect x="490" y="46" width="12" height="44" fill="#2d2d44"/>
+  <rect x="487" y="39" width="18" height="9" fill="#252540"/>
+  <rect x="492" y="30" width="8" height="11" fill="#2d2d44"/>
+  <circle cx="496" cy="28" r="5" fill="#252540" stroke="#2d2d44" stroke-width="0.5"/>
+  <line x1="496" y1="23" x2="496" y2="14" stroke="#2d2d44" stroke-width="1.8"/>
+  <line x1="490" y1="18" x2="502" y2="18" stroke="#252540" stroke-width="0.6"/>
+
+  <!-- Turbolaser tower 3 (smaller, more distant) -->
+  <rect x="715" y="60" width="8" height="30" fill="#2d2d44"/>
+  <rect x="713" y="55" width="12" height="7" fill="#252540"/>
+  <rect x="716" y="48" width="5" height="9" fill="#2d2d44"/>
+  <circle cx="718.5" cy="46" r="3.5" fill="#252540" stroke="#2d2d44" stroke-width="0.5"/>
+  <line x1="718.5" y1="42.5" x2="718.5" y2="36" stroke="#2d2d44" stroke-width="1.2"/>
+
+  <!-- Hangar bay 1 -->
+  <rect x="78" y="128" width="32" height="20" fill="#080810"/>
+  <rect x="80" y="130" width="28" height="16" fill="#0a0a14" stroke="#2d2d44" stroke-width="0.5"/>
+  <line x1="94" y1="130" x2="94" y2="146" stroke="#252540" stroke-width="0.3"/>
+  <rect x="82" y="138" width="24" height="6" fill="#ff6b35" opacity="0.12"/>
+
+  <!-- Hangar bay 2 -->
+  <rect x="398" y="143" width="36" height="22" fill="#080810"/>
+  <rect x="400" y="145" width="32" height="18" fill="#0a0a14" stroke="#2d2d44" stroke-width="0.5"/>
+  <line x1="416" y1="145" x2="416" y2="163" stroke="#252540" stroke-width="0.3"/>
+  <rect x="402" y="155" width="28" height="6" fill="#ff6b35" opacity="0.1"/>
+
+  <!-- Hangar bay 3 -->
+  <rect x="648" y="133" width="28" height="18" fill="#080810"/>
+  <rect x="650" y="135" width="24" height="14" fill="#0a0a14" stroke="#2d2d44" stroke-width="0.5"/>
+  <rect x="652" y="143" width="20" height="4" fill="#ff6b35" opacity="0.1"/>
+
+  <!-- Lower surface detail panels -->
+  <rect x="10" y="158" width="35" height="22" fill="#252540" opacity="0.4"/>
+  <rect x="130" y="155" width="42" height="26" fill="#2d2d44" opacity="0.3"/>
+  <rect x="300" y="162" width="45" height="22" fill="#252540" opacity="0.4"/>
+  <rect x="450" y="168" width="38" height="20" fill="#2d2d44" opacity="0.3"/>
+  <rect x="558" y="158" width="34" height="24" fill="#252540" opacity="0.4"/>
+  <rect x="700" y="172" width="42" height="18" fill="#2d2d44" opacity="0.3"/>
+
+  <!-- Fine detail grid lines -->
+  <line x1="0" y1="95" x2="270" y2="95" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="288" y1="95" x2="514" y2="95" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="526" y1="95" x2="800" y2="95" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="0" y1="110" x2="270" y2="110" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="288" y1="110" x2="514" y2="110" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="526" y1="110" x2="800" y2="110" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="0" y1="150" x2="800" y2="150" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="0" y1="175" x2="800" y2="175" stroke="#1f1f35" stroke-width="0.3"/>
+  <line x1="0" y1="192" x2="800" y2="192" stroke="#1f1f35" stroke-width="0.3"/>
+
+  <!-- Surface fire/glow spots -->
+  <circle cx="195" cy="175" r="8" fill="#ff6b35" opacity="0.15"/>
+  <circle cx="195" cy="175" r="4" fill="#ff4500" opacity="0.2"/>
+  <circle cx="580" cy="185" r="6" fill="#ff6b35" opacity="0.12"/>
+  <circle cx="580" cy="185" r="3" fill="#ff4500" opacity="0.18"/>
+  <circle cx="350" cy="190" r="5" fill="#ff6b35" opacity="0.1"/>
+  <circle cx="350" cy="190" r="2.5" fill="#ff4500" opacity="0.15"/>
+  <circle cx="720" cy="192" r="4" fill="#ff6b35" opacity="0.08"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace late-level terrain images with Star Wars/Stargate themed art (Issue #386)

### Summary (what changed & why)
This PR replaces **three late-game terrain SVG assets** in the Raptor game with **high-quality Star Wars/Stargate themed artwork** to improve the visual identity and thematic consistency of **levels 4 and 5**.  

This is a **pure asset swap**: no rendering logic, manifests, or level configuration were changed. The new SVGs are drop-in replacements that **preserve the renderer’s size/viewBox contracts**, are designed to look correct under the renderer’s opacity settings, and keep file sizes within budget.

### What’s included
- **Level 4 horizon (`horizon_arctic`)** re-themed to **Hoth**: layered ice ridges, subtle Echo Base-like structures, blowing snow, cold blue-grey palette.
- **Level 5 horizon (`horizon_fortress`)** re-themed to the **Death Star surface**: trenches/panel geometry, turbolaser towers, hangar bays, and subtle red/orange ambient glow.
- **Level 5 ground texture (`ground_concrete`)** re-themed to **Imperial hull plating**: panel grid, rivets, access hatches; **seamless 128×128 tiling** for scrolling.

### Key files modified
- `public/assets/raptor/terrain/horizon_arctic.svg`  
  - Replaced with Hoth ice fields panoramic strip  
  - Preserves `width="800" height="200" viewBox="0 0 800 200"`
- `public/assets/raptor/terrain/horizon_fortress.svg`  
  - Replaced with Death Star surface panoramic strip  
  - Preserves `width="800" height="200" viewBox="0 0 800 200"`
- `public/assets/raptor/terrain/ground_concrete.svg`  
  - Replaced with Imperial/Death Star plating tile  
  - Preserves `width/height` + `viewBox="0 0 128 128"` and tiles seamlessly

### Implementation notes
- Kept all SVGs compatible with the existing renderer contracts:
  - Horizons render as **200px tall** at ~**15% from top** at **60% opacity**
  - Ground texture tiles at **128×128** at **40% opacity** over `groundColor: #3a3a3a`
- Used **file-scoped gradient ID prefixes** to avoid collisions:
  - `hoth-*`, `ds-*`, `hull-*`
- No changes to:
  - `src/games/raptor/rendering/assets.ts`
  - `src/games/raptor/levels.ts`
  - `src/games/raptor/rendering/TerrainRenderer.ts`

### Testing / QA notes
- **Manual visual verification**
  - Launch Raptor and play to:
    - **Level 4**: confirm `horizon_arctic` renders correctly and complements sky gradient `#B0C4DE → #D3D3D3`
    - **Level 5**: confirm `horizon_fortress` renders correctly and complements sky gradient `#2F1B14 → #1a1a1a`
    - **Level 5 ground**: confirm `ground_concrete` blends appropriately over `#3a3a3a` and remains subtle at 40% opacity
- **Seam check**
  - Verified `ground_concrete.svg` tiles seamlessly (no visible seams when repeated in a grid / during scrolling)
- **Regression**
  - Run: `npm test` (no code changes expected, but confirms no initialization/asset regressions)

### Related
- Fixes: **Issue #386**
- Part of epic: **#378**

Ref: https://github.com/asgardtech/archer/issues/386