### PR TITLE
Raptor: Replace natural ground texture images with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/ground_grass.svg
+++ b/public/assets/raptor/terrain/ground_grass.svg
@@ -1,18 +1,50 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" fill="#4d8c3f"/>
-  <rect x="8" y="12" width="6" height="5" fill="#4a7c40"/>
-  <rect x="42" y="8" width="4" height="6" fill="#5a8c4a"/>
-  <rect x="78" y="22" width="5" height="4" fill="#3d6b35"/>
-  <rect x="16" y="48" width="5" height="5" fill="#4a7c40"/>
-  <rect x="96" y="36" width="6" height="4" fill="#5a8c4a"/>
-  <rect x="4" y="72" width="4" height="6" fill="#3d6b35"/>
-  <rect x="56" y="64" width="6" height="5" fill="#4a7c40"/>
-  <rect x="112" y="88" width="5" height="5" fill="#5a8c4a"/>
-  <rect x="24" y="96" width="5" height="4" fill="#3d6b35"/>
-  <circle cx="32" cy="28" r="3" fill="#5a8c4a"/>
-  <circle cx="88" cy="52" r="2" fill="#4a7c40"/>
-  <circle cx="16" cy="84" r="2" fill="#3d6b35"/>
-  <circle cx="72" cy="16" r="3" fill="#4a7c40"/>
-  <circle cx="104" cy="72" r="2" fill="#5a8c4a"/>
-  <circle cx="48" cy="104" r="3" fill="#3d6b35"/>
+  <!-- Naboo Meadowlands ground texture -->
+  <rect width="128" height="128" fill="#4a8c3a" opacity="0.45"/>
+
+  <!-- Sunlit meadow patches -->
+  <ellipse cx="30" cy="34" rx="22" ry="16" fill="#68aa52" opacity="0.35"/>
+  <ellipse cx="96" cy="82" rx="20" ry="14" fill="#68aa52" opacity="0.3"/>
+  <ellipse cx="70" cy="14" rx="16" ry="10" fill="#386e2e" opacity="0.25"/>
+  <ellipse cx="22" cy="104" rx="18" ry="12" fill="#386e2e" opacity="0.22"/>
+  <ellipse cx="62" cy="56" rx="14" ry="16" fill="#68aa52" opacity="0.2"/>
+  <ellipse cx="110" cy="48" rx="12" ry="10" fill="#386e2e" opacity="0.2"/>
+
+  <!-- Grass blade clusters -->
+  <line x1="20" y1="44" x2="18" y2="26" stroke="#1e5518" stroke-width="1.6" stroke-linecap="round" opacity="0.8"/>
+  <line x1="26" y1="46" x2="28" y2="28" stroke="#1e5518" stroke-width="1.3" stroke-linecap="round" opacity="0.75"/>
+  <line x1="32" y1="42" x2="31" y2="24" stroke="#1e5518" stroke-width="1.5" stroke-linecap="round" opacity="0.78"/>
+
+  <line x1="80" y1="28" x2="78" y2="12" stroke="#1e5518" stroke-width="1.5" stroke-linecap="round" opacity="0.75"/>
+  <line x1="86" y1="30" x2="88" y2="14" stroke="#1e5518" stroke-width="1.3" stroke-linecap="round" opacity="0.78"/>
+
+  <line x1="100" y1="92" x2="98" y2="74" stroke="#1e5518" stroke-width="1.6" stroke-linecap="round" opacity="0.8"/>
+  <line x1="106" y1="94" x2="108" y2="76" stroke="#1e5518" stroke-width="1.3" stroke-linecap="round" opacity="0.75"/>
+  <line x1="112" y1="90" x2="111" y2="72" stroke="#1e5518" stroke-width="1.5" stroke-linecap="round" opacity="0.78"/>
+
+  <line x1="48" y1="72" x2="46" y2="54" stroke="#1e5518" stroke-width="1.3" stroke-linecap="round" opacity="0.75"/>
+  <line x1="54" y1="74" x2="56" y2="56" stroke="#1e5518" stroke-width="1.5" stroke-linecap="round" opacity="0.78"/>
+
+  <line x1="12" y1="112" x2="10" y2="94" stroke="#1e5518" stroke-width="1.5" stroke-linecap="round" opacity="0.78"/>
+  <line x1="18" y1="114" x2="20" y2="96" stroke="#1e5518" stroke-width="1.3" stroke-linecap="round" opacity="0.75"/>
+
+  <line x1="66" y1="12" x2="64" y2="4" stroke="#1e5518" stroke-width="1.3" stroke-linecap="round" opacity="0.7"/>
+
+  <!-- Soft curved grass wisps -->
+  <path d="M38 88 Q40 80 42 88" stroke="#2a6825" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <path d="M114 36 Q116 28 118 36" stroke="#2a6825" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <path d="M8 64 Q10 56 12 64" stroke="#2a6825" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <path d="M76 106 Q78 98 80 106" stroke="#2a6825" stroke-width="1.2" fill="none" opacity="0.6"/>
+
+  <!-- Wildflower dots (yellow and pink accents) -->
+  <circle cx="16" cy="38" r="2" fill="#e8c840" opacity="0.75"/>
+  <circle cx="50" cy="20" r="1.5" fill="#c87ab0" opacity="0.65"/>
+  <circle cx="92" cy="58" r="1.8" fill="#e8c840" opacity="0.7"/>
+  <circle cx="36" cy="100" r="1.5" fill="#c87ab0" opacity="0.65"/>
+  <circle cx="116" cy="40" r="1.8" fill="#e8c840" opacity="0.7"/>
+  <circle cx="74" cy="82" r="2" fill="#c87ab0" opacity="0.65"/>
+  <circle cx="104" cy="116" r="1.5" fill="#e8c840" opacity="0.7"/>
+  <circle cx="8" cy="74" r="1.5" fill="#e8d050" opacity="0.65"/>
+  <circle cx="58" cy="48" r="1.2" fill="#c87ab0" opacity="0.6"/>
+  <circle cx="42" cy="118" r="1.2" fill="#e8c840" opacity="0.65"/>
 </svg>

--- a/public/assets/raptor/terrain/ground_sand.svg
+++ b/public/assets/raptor/terrain/ground_sand.svg
@@ -1,16 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" fill="#c8a060"/>
-  <path d="M0 24 Q32 20 64 24 Q96 28 128 24" stroke="#b8884f" stroke-width="1" fill="none"/>
-  <path d="M0 48 Q32 44 64 48 Q96 52 128 48" stroke="#c2956a" stroke-width="1" fill="none"/>
-  <path d="M0 72 Q32 68 64 72 Q96 76 128 72" stroke="#d4a76a" stroke-width="1" fill="none"/>
-  <path d="M0 96 Q32 92 64 96 Q96 100 128 96" stroke="#b8884f" stroke-width="1" fill="none"/>
-  <path d="M0 12 Q64 8 128 12" stroke="#c2956a" stroke-width="0.5" fill="none"/>
-  <path d="M0 36 Q64 32 128 36" stroke="#d4a76a" stroke-width="0.5" fill="none"/>
-  <path d="M0 60 Q64 56 128 60" stroke="#b8884f" stroke-width="0.5" fill="none"/>
-  <path d="M0 84 Q64 80 128 84" stroke="#c2956a" stroke-width="0.5" fill="none"/>
-  <circle cx="20" cy="16" r="1" fill="#d4a76a"/>
-  <circle cx="56" cy="40" r="1" fill="#c2956a"/>
-  <circle cx="92" cy="64" r="1" fill="#b8884f"/>
-  <circle cx="36" cy="88" r="1" fill="#d4a76a"/>
-  <circle cx="108" cy="112" r="1" fill="#c2956a"/>
+  <!-- Abydos/Tatooine Desert Sand texture -->
+  <rect width="128" height="128" fill="#cca465" opacity="0.35"/>
+
+  <!-- Heat shimmer / sun-baked patches -->
+  <ellipse cx="40" cy="40" rx="28" ry="20" fill="#d4b070" opacity="0.25"/>
+  <ellipse cx="100" cy="96" rx="22" ry="16" fill="#b08848" opacity="0.2"/>
+  <ellipse cx="20" cy="88" rx="18" ry="12" fill="#d4b070" opacity="0.18"/>
+
+  <!-- Primary wind ripple lines (16px spacing for seamless vertical tiling) -->
+  <path d="M0 0 Q32 3 64 0 Q96 3 128 0" stroke="#906830" stroke-width="1.4" fill="none" opacity="0.65"/>
+  <path d="M0 32 Q32 28 64 32 Q96 36 128 32" stroke="#906830" stroke-width="1.4" fill="none" opacity="0.6"/>
+  <path d="M0 64 Q32 60 64 64 Q96 68 128 64" stroke="#906830" stroke-width="1.4" fill="none" opacity="0.65"/>
+  <path d="M0 96 Q32 92 64 96 Q96 100 128 96" stroke="#906830" stroke-width="1.4" fill="none" opacity="0.6"/>
+
+  <!-- Secondary wind ripples (thinner, between primaries) -->
+  <path d="M0 16 Q64 12 128 16" stroke="#a88050" stroke-width="0.8" fill="none" opacity="0.45"/>
+  <path d="M0 48 Q64 44 128 48" stroke="#a88050" stroke-width="0.8" fill="none" opacity="0.4"/>
+  <path d="M0 80 Q64 76 128 80" stroke="#a88050" stroke-width="0.8" fill="none" opacity="0.45"/>
+  <path d="M0 112 Q64 108 128 112" stroke="#a88050" stroke-width="0.8" fill="none" opacity="0.4"/>
+
+  <!-- Sun-baked cracked earth -->
+  <path d="M20 28 L26 32 L32 30" stroke="#705020" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M76 58 L82 62 L88 60 L92 64" stroke="#705020" stroke-width="0.8" fill="none" opacity="0.45"/>
+  <path d="M44 90 L50 94 L56 92" stroke="#705020" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M102 20 L106 24 L112 22" stroke="#705020" stroke-width="0.8" fill="none" opacity="0.45"/>
+
+  <!-- Scattered pebbles -->
+  <circle cx="16" cy="44" r="2.2" fill="#785828" opacity="0.65"/>
+  <circle cx="60" cy="24" r="1.8" fill="#604820" opacity="0.6"/>
+  <circle cx="96" cy="74" r="2" fill="#785828" opacity="0.55"/>
+  <circle cx="36" cy="106" r="2.2" fill="#604820" opacity="0.65"/>
+  <circle cx="108" cy="48" r="1.5" fill="#785828" opacity="0.6"/>
+  <circle cx="52" cy="78" r="1.3" fill="#604820" opacity="0.5"/>
+  <circle cx="80" cy="108" r="1.8" fill="#785828" opacity="0.6"/>
+  <circle cx="118" cy="14" r="1.2" fill="#604820" opacity="0.55"/>
 </svg>

--- a/public/assets/raptor/terrain/ground_snow.svg
+++ b/public/assets/raptor/terrain/ground_snow.svg
@@ -1,12 +1,38 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" fill="#e8edf2"/>
-  <rect x="16" y="20" width="24" height="24" fill="#eef2f5" opacity="0.9"/>
-  <rect x="72" y="48" width="20" height="20" fill="#dde5ea"/>
-  <rect x="8" y="80" width="28" height="28" fill="#b5d4e8" opacity="0.4"/>
-  <rect x="88" y="16" width="24" height="24" fill="#dde5ea"/>
-  <rect x="48" y="72" width="22" height="22" fill="#eef2f5" opacity="0.9"/>
-  <rect x="100" y="88" width="20" height="20" fill="#b5d4e8" opacity="0.35"/>
-  <circle cx="40" cy="56" r="8" fill="#b5d4e8" opacity="0.3"/>
-  <circle cx="96" cy="104" r="6" fill="#dde5ea"/>
-  <circle cx="64" cy="24" r="5" fill="#eef2f5" opacity="0.8"/>
+  <!-- Hoth Ice Surface texture -->
+  <rect width="128" height="128" fill="#d0dce6" opacity="0.3"/>
+
+  <!-- Wind-swept snow drift shapes -->
+  <ellipse cx="36" cy="28" rx="28" ry="10" fill="#f0f4f8" opacity="0.4"/>
+  <ellipse cx="100" cy="72" rx="24" ry="8" fill="#f0f4f8" opacity="0.35"/>
+  <ellipse cx="20" cy="96" rx="20" ry="12" fill="#c8d8e4" opacity="0.25"/>
+  <ellipse cx="80" cy="112" rx="26" ry="10" fill="#f0f4f8" opacity="0.3"/>
+  <ellipse cx="64" cy="52" rx="18" ry="8" fill="#c8d8e4" opacity="0.2"/>
+
+  <!-- Ice surface cracks -->
+  <path d="M16 16 L24 22 L28 18 L36 24" stroke="#8aa8c0" stroke-width="0.8" fill="none" opacity="0.55"/>
+  <path d="M72 36 L80 42 L88 38" stroke="#8aa8c0" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M44 64 L52 70 L48 76 L56 80" stroke="#8aa8c0" stroke-width="0.8" fill="none" opacity="0.55"/>
+  <path d="M96 88 L104 94 L108 90 L116 96" stroke="#8aa8c0" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M8 48 L14 54 L10 58" stroke="#8aa8c0" stroke-width="0.7" fill="none" opacity="0.45"/>
+  <path d="M100 8 L106 14 L112 10" stroke="#8aa8c0" stroke-width="0.7" fill="none" opacity="0.45"/>
+
+  <!-- Crystalline frost patterns (branching) -->
+  <path d="M28 78 L32 74 L36 78" stroke="#a0c0d8" stroke-width="1" fill="none" opacity="0.5"/>
+  <path d="M32 74 L32 68" stroke="#a0c0d8" stroke-width="0.8" fill="none" opacity="0.45"/>
+
+  <path d="M88 24 L92 20 L96 24" stroke="#a0c0d8" stroke-width="1" fill="none" opacity="0.5"/>
+  <path d="M92 20 L92 14" stroke="#a0c0d8" stroke-width="0.8" fill="none" opacity="0.45"/>
+
+  <path d="M60 104 L64 100 L68 104" stroke="#a0c0d8" stroke-width="1" fill="none" opacity="0.5"/>
+  <path d="M64 100 L64 94" stroke="#a0c0d8" stroke-width="0.8" fill="none" opacity="0.45"/>
+
+  <!-- Frost crystal dots -->
+  <circle cx="20" cy="40" r="1.5" fill="#b8d0e0" opacity="0.5"/>
+  <circle cx="72" cy="52" r="1.2" fill="#b8d0e0" opacity="0.45"/>
+  <circle cx="48" cy="88" r="1.5" fill="#b8d0e0" opacity="0.5"/>
+  <circle cx="108" cy="44" r="1.2" fill="#b8d0e0" opacity="0.45"/>
+  <circle cx="84" cy="100" r="1.5" fill="#b8d0e0" opacity="0.5"/>
+  <circle cx="16" cy="118" r="1.2" fill="#b8d0e0" opacity="0.45"/>
+  <circle cx="116" cy="68" r="1" fill="#b8d0e0" opacity="0.4"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace natural ground textures with Star Wars/Stargate themed art (Issue #387, part of #378)

### Summary (what & why)
This PR replaces the three existing **natural** ground texture SVGs used by the Raptor game with **high-quality, sci‑fi themed** (Star Wars/Stargate-inspired) tileable artwork. The goal is to better align early/mid-game biomes with the epic’s new art direction while keeping the rendering pipeline unchanged.

This is an **asset-only** update: filenames, paths, and SVG dimensions remain the same, so no code/config/manifest changes are required.

### What changed
- Replaced in-place the following 128×128, seamlessly tileable SVG textures:
  - **Naboo meadowlands** grass texture (lush grass clusters + subtle wildflower accents)
  - **Abydos/Tatooine** desert sand texture (wind ripples + light cracks + scattered pebbles)
  - **Hoth** ice/snow texture (frost patterns + subtle cracks + wind-swept drifts)

All assets:
- Keep `viewBox="0 0 128 128"`
- Use only basic SVG primitives (no external refs / raster images)
- Are intended to look natural at **40% opacity** over each level’s `groundColor` (per `TerrainRenderer.renderGround()`)

### Key files modified
- `public/assets/raptor/terrain/ground_grass.svg`
- `public/assets/raptor/terrain/ground_sand.svg`
- `public/assets/raptor/terrain/ground_snow.svg`

_No changes to:_
- `src/games/raptor/rendering/TerrainRenderer.ts` (still tiles at 128×128, `globalAlpha = 0.4`, parallax `scrollOffset * 0.6`)
- `src/games/raptor/rendering/assets.ts` (keys/paths unchanged)
- `src/games/raptor/levels.ts` (same texture keys)

### Testing notes
Manual/visual verification recommended (asset-only change):
- **Levels 1 & 3 (grass):** confirm grass texture blends well over `#4d8c3f` and `#3d5a3d`, remains subtle at 40% opacity.
- **Level 2 (sand):** confirm wind-ripple pattern tiles cleanly and doesn’t create visible grid seams.
- **Level 4 (snow):** confirm frost/crack details are visible but not distracting at 40% opacity over `#e0e8ee`.
- **Seamless tiling:** verify no seams by viewing a tiled ground area (or a quick 3×3 tile preview).
- **Console check:** load the game and confirm **no AssetLoader warnings/errors** for these SVGs.
- **Regression:** start Level 5 to confirm `ground_concrete.svg` remains unchanged.
- **Performance sanity check:** ensure no noticeable FPS drop (SVG complexity kept intentionally low).

### Related
- Issue: #387  
- Epic: #378

Ref: https://github.com/asgardtech/archer/issues/387