### PR TITLE
Raptor: Replace fortress terrain images (debris, command center, wall segment) with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/prop_debris.svg
+++ b/public/assets/raptor/terrain/prop_debris.svg
@@ -1,10 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Scattered irregular fragments -->
-  <polygon points="12,20 22,18 24,28 14,30" fill="#4a4a4a"/>
-  <polygon points="40,8 52,12 50,22 38,20" fill="#5a5a5a"/>
-  <polygon points="8,44 18,42 20,52 10,54" fill="#3a3a3a"/>
-  <polygon points="36,36 46,34 48,44 38,46" fill="#4a4a4a"/>
-  <polygon points="50,40 60,38 62,48 52,50" fill="#3a3a3a"/>
-  <ellipse cx="28" cy="50" rx="6" ry="4" fill="#5a5a5a"/>
-  <polygon points="16,8 24,6 26,14 18,16" fill="#3a3a3a"/>
+  <!-- TIE wing hex panel fragment -->
+  <polygon points="6,14 24,8 30,24 22,36 6,30" fill="#333333" stroke="#252525" stroke-width="1.5"/>
+  <line x1="10" y1="18" x2="26" y2="14" stroke="#4a4a4a" stroke-width="1.2"/>
+  <line x1="12" y1="26" x2="28" y2="22" stroke="#4a4a4a" stroke-width="1.2"/>
+  <!-- Hull plate shard -->
+  <polygon points="36,6 56,12 52,26 34,20" fill="#3c3c3c" stroke="#2a2a2a" stroke-width="1"/>
+  <!-- Twisted beam section -->
+  <polygon points="34,38 58,32 60,42 36,48" fill="#404040" stroke="#2e2e2e" stroke-width="0.8"/>
+  <!-- Small hull fragment -->
+  <polygon points="8,44 20,42 24,54 10,56" fill="#363636"/>
+  <!-- Sparking electronics -->
+  <circle cx="30" cy="28" r="2.5" fill="#00aaff" opacity="0.7"/>
+  <circle cx="50" cy="24" r="1.5" fill="#00aaff" opacity="0.5"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_command_center.svg
+++ b/public/assets/raptor/terrain/struct_command_center.svg
@@ -1,13 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Main square base -->
-  <rect x="8" y="24" width="48" height="40" fill="#4a4a4a"/>
-  <!-- Raised center section -->
-  <rect x="18" y="14" width="28" height="22" fill="#555555"/>
-  <!-- Antenna arrays (lines from corners) -->
-  <line x1="8" y1="24" x2="2" y2="8" stroke="#666666" stroke-width="1"/>
-  <line x1="56" y1="24" x2="62" y2="8" stroke="#666666" stroke-width="1"/>
-  <line x1="8" y1="64" x2="2" y2="56" stroke="#666666" stroke-width="1"/>
-  <line x1="56" y1="64" x2="62" y2="56" stroke="#666666" stroke-width="1"/>
-  <!-- Satellite dish -->
-  <circle cx="32" cy="22" r="5" fill="#444444"/>
+  <!-- Hexagonal base footprint -->
+  <polygon points="32,4 56,16 56,48 32,60 8,48 8,16" fill="#3a3a3a" stroke="#2a2a2a" stroke-width="1.5"/>
+  <!-- Inner armored section -->
+  <polygon points="32,14 46,22 46,42 32,50 18,42 18,22" fill="#444444" stroke="#383838" stroke-width="1"/>
+  <!-- Armored panel lines -->
+  <line x1="18" y1="22" x2="46" y2="22" stroke="#505050" stroke-width="0.5"/>
+  <line x1="18" y1="42" x2="46" y2="42" stroke="#505050" stroke-width="0.5"/>
+  <line x1="32" y1="14" x2="32" y2="50" stroke="#505050" stroke-width="0.5"/>
+  <!-- Central command module -->
+  <circle cx="32" cy="32" r="8" fill="#4a4a4a" stroke="#555555" stroke-width="1"/>
+  <!-- Imperial insignia accent -->
+  <circle cx="32" cy="32" r="4" fill="#333333" stroke="#cc0000" stroke-width="1.5"/>
+  <!-- Radar/sensor arrays at top and bottom -->
+  <circle cx="32" cy="6" r="3" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <circle cx="32" cy="58" r="3" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <!-- Sensor nodes at side vertices -->
+  <circle cx="8" cy="16" r="2" fill="#505050"/>
+  <circle cx="56" cy="16" r="2" fill="#505050"/>
+  <circle cx="8" cy="48" r="2" fill="#505050"/>
+  <circle cx="56" cy="48" r="2" fill="#505050"/>
+  <!-- Blast door entries -->
+  <rect x="28" y="2" width="8" height="6" fill="#2a2a2a" rx="1"/>
+  <rect x="28" y="56" width="8" height="6" fill="#2a2a2a" rx="1"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_wall_segment.svg
+++ b/public/assets/raptor/terrain/struct_wall_segment.svg
@@ -1,10 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <!-- Main wall body -->
-  <rect x="4" y="20" width="56" height="24" fill="#555555"/>
-  <!-- Battlements/teeth along top -->
-  <rect x="4" y="12" width="8" height="12" fill="#444444"/>
-  <rect x="16" y="12" width="8" height="12" fill="#444444"/>
-  <rect x="28" y="12" width="8" height="12" fill="#444444"/>
-  <rect x="40" y="12" width="8" height="12" fill="#444444"/>
-  <rect x="52" y="12" width="8" height="12" fill="#444444"/>
+  <rect x="2" y="14" width="60" height="36" fill="#3e3e3e" stroke="#2a2a2a" stroke-width="1.5"/>
+  <!-- Top conduit channel -->
+  <rect x="4" y="16" width="56" height="4" fill="#333333"/>
+  <!-- Bottom conduit channel -->
+  <rect x="4" y="44" width="56" height="4" fill="#333333"/>
+  <!-- Central trench detail -->
+  <rect x="4" y="28" width="56" height="8" fill="#484848"/>
+  <!-- Access panels - top row -->
+  <rect x="8" y="22" width="8" height="5" fill="#2e2e2e" stroke="#252525" stroke-width="0.5"/>
+  <rect x="28" y="22" width="8" height="5" fill="#2e2e2e" stroke="#252525" stroke-width="0.5"/>
+  <rect x="48" y="22" width="8" height="5" fill="#2e2e2e" stroke="#252525" stroke-width="0.5"/>
+  <!-- Access panels - bottom row -->
+  <rect x="8" y="37" width="8" height="5" fill="#2e2e2e" stroke="#252525" stroke-width="0.5"/>
+  <rect x="28" y="37" width="8" height="5" fill="#2e2e2e" stroke="#252525" stroke-width="0.5"/>
+  <rect x="48" y="37" width="8" height="5" fill="#2e2e2e" stroke="#252525" stroke-width="0.5"/>
+  <!-- Defensive turret emplacements -->
+  <circle cx="12" cy="32" r="3" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <circle cx="32" cy="32" r="3" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <circle cx="52" cy="32" r="3" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <!-- Vertical structural ribs -->
+  <line x1="20" y1="16" x2="20" y2="48" stroke="#4a4a4a" stroke-width="0.5"/>
+  <line x1="44" y1="16" x2="44" y2="48" stroke="#4a4a4a" stroke-width="0.5"/>
+  <!-- Horizontal conduit line -->
+  <line x1="4" y1="32" x2="60" y2="32" stroke="#525252" stroke-width="0.5"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace fortress terrain images with Star Wars/Imperial themed art

### Summary (what & why)
This PR replaces three existing fortress-level terrain SVG assets in **Raptor** with **high-quality Star Wars/Imperial-themed** artwork to better match the “Final Fortress” aesthetic (Issue: *Raptor: Replace fortress terrain images (debris, command center, wall segment) with Star Wars/Stargate themed art*, part of epic **#378**).

These are **drop-in, asset-only** replacements (no rendering/logic/config changes). The new SVGs are designed to remain readable at the game’s small render sizes, work with transparency, and look correct when horizontally mirrored.

### Key changes / files modified
Replaced contents of the following files:

- `public/assets/raptor/terrain/prop_debris.svg`  
  - Now depicts **starfighter wreckage debris** (TIE-style wing/hex panel fragments, hull shards, twisted beam, sparking electronics) with bold shapes for legibility at **12–28px** and **50% opacity**.
- `public/assets/raptor/terrain/struct_command_center.svg`  
  - Now depicts an **Imperial command bunker** (hex footprint, radar/sensor arrays, blast doors, red Imperial insignia accent) for **32–64px** structure rendering.
- `public/assets/raptor/terrain/struct_wall_segment.svg`  
  - Now depicts a **Death Star trench wall** segment (conduits, repeating access panels, turret emplacements, ribs) for **32–64px** structure rendering.

Implementation notes (asset constraints adhered to):
- `viewBox="0 0 64 64"`, transparent backgrounds
- SVG 1.1 basic shapes, **< 50 elements** each
- **Mirror-tolerant** (no text/directional details that break when flipped)

### Gameplay/level impact
- `struct_command_center` and `struct_wall_segment` are used in **Level 5: “Final Fortress”** (higher structure density, so they appear frequently).
- `prop_debris` appears across multiple levels (1/3/4/5); the new debris is intended to still read as **generic metallic wreckage** at small size/opacity to minimize thematic clash.

### Testing notes
Manual/visual verification recommended (asset-only change):

- Launch the game and confirm **no AssetLoader warnings** (e.g., “Failed to load asset”) in the browser console.
- Play/preview:
  - **Level 5 (“Final Fortress”)**: verify command center + wall segment render correctly at varying sizes, full opacity, and look fine when mirrored.
  - **Levels 1, 3, 4, 5**: verify `prop_debris` remains readable at the low end (~12px) with **50% opacity** and doesn’t show a bounding box/background.
- Spot-check in **Chrome and Firefox** for SVG rasterization consistency.

### Related
- Issue / epic: part of **#378**
- Commit: `b091f96` “Replace fortress terrain images with Star Wars/Imperial themed art”

Ref: https://github.com/asgardtech/archer/issues/389