### PR TITLE
Raptor: Replace coastal structure images (beach hut, lighthouse, palm tree) with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/struct_beach_hut.svg
+++ b/public/assets/raptor/terrain/struct_beach_hut.svg
@@ -1,8 +1,52 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <rect x="18" y="22" width="28" height="24" fill="#c2956a" rx="2"/>
-  <rect x="16" y="20" width="32" height="2" fill="#8b6b3d"/>
-  <polygon points="32,10 14,22 50,22" fill="#8b6b3d"/>
-  <rect x="28" y="34" width="8" height="12" fill="#6b4a2a"/>
-  <rect x="20" y="26" width="6" height="6" fill="#a5d6e8" opacity="0.6"/>
-  <rect x="38" y="26" width="6" height="6" fill="#a5d6e8" opacity="0.6"/>
+  <defs>
+    <radialGradient id="dome" cx="40%" cy="40%" r="55%">
+      <stop offset="0%" stop-color="#fff8ef"/>
+      <stop offset="100%" stop-color="#e0d4b8"/>
+    </radialGradient>
+    <radialGradient id="pool" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#7dd8c0"/>
+      <stop offset="100%" stop-color="#4da890"/>
+    </radialGradient>
+  </defs>
+  <!-- Outer garden terrace -->
+  <circle cx="32" cy="32" r="30" fill="#b8a878" opacity="0.3"/>
+  <!-- Stone base platform -->
+  <circle cx="32" cy="32" r="26" fill="#c8b890"/>
+  <!-- Courtyard floor -->
+  <circle cx="32" cy="32" r="22" fill="#d8ccaa"/>
+  <!-- Inner wall ring -->
+  <circle cx="32" cy="32" r="18" fill="#c0b090"/>
+  <!-- Interior floor -->
+  <circle cx="32" cy="32" r="16" fill="#ddd0b8"/>
+  <!-- Dome shadow -->
+  <circle cx="33" cy="33" r="12" fill="#b0a080" opacity="0.35"/>
+  <!-- Main dome -->
+  <circle cx="32" cy="32" r="12" fill="url(#dome)"/>
+  <!-- Dome highlight -->
+  <circle cx="29" cy="29" r="5" fill="#ffffff" opacity="0.2"/>
+  <!-- Four symmetrical arched walkways -->
+  <rect x="30" y="2" width="4" height="12" fill="#c8b890" rx="2"/>
+  <rect x="30" y="50" width="4" height="12" fill="#c8b890" rx="2"/>
+  <rect x="2" y="30" width="12" height="4" fill="#c8b890" rx="2"/>
+  <rect x="50" y="30" width="12" height="4" fill="#c8b890" rx="2"/>
+  <!-- Walkway inner caps -->
+  <circle cx="32" cy="14" r="3" fill="#d8ccaa"/>
+  <circle cx="32" cy="50" r="3" fill="#d8ccaa"/>
+  <circle cx="14" cy="32" r="3" fill="#d8ccaa"/>
+  <circle cx="50" cy="32" r="3" fill="#d8ccaa"/>
+  <!-- Ornamental teal pools at corners -->
+  <circle cx="14" cy="14" r="4" fill="url(#pool)" opacity="0.6"/>
+  <circle cx="50" cy="14" r="4" fill="url(#pool)" opacity="0.6"/>
+  <circle cx="14" cy="50" r="4" fill="url(#pool)" opacity="0.6"/>
+  <circle cx="50" cy="50" r="4" fill="url(#pool)" opacity="0.6"/>
+  <!-- Pool highlights -->
+  <circle cx="13" cy="13" r="1.5" fill="#ffffff" opacity="0.25"/>
+  <circle cx="49" cy="13" r="1.5" fill="#ffffff" opacity="0.25"/>
+  <circle cx="13" cy="49" r="1.5" fill="#ffffff" opacity="0.25"/>
+  <circle cx="49" cy="49" r="1.5" fill="#ffffff" opacity="0.25"/>
+  <!-- Dome pinnacle -->
+  <circle cx="32" cy="32" r="3.5" fill="#f0e8d8"/>
+  <circle cx="32" cy="32" r="2" fill="#5fb8a0" opacity="0.7"/>
+  <circle cx="32" cy="32" r="0.8" fill="#ffffff" opacity="0.5"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_lighthouse.svg
+++ b/public/assets/raptor/terrain/struct_lighthouse.svg
@@ -1,12 +1,48 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- White base -->
-  <circle cx="32" cy="32" r="22" fill="#f0f0f0"/>
-  <!-- Red stripe ring -->
-  <circle cx="32" cy="32" r="20" fill="#cc3333"/>
-  <circle cx="32" cy="32" r="16" fill="#f0f0f0"/>
-  <!-- Red stripe ring -->
-  <circle cx="32" cy="32" r="14" fill="#cc3333"/>
-  <circle cx="32" cy="32" r="10" fill="#f0f0f0"/>
-  <!-- Yellow glow center -->
-  <circle cx="32" cy="32" r="6" fill="#ffdd44"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <radialGradient id="beacon" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="35%" stop-color="#aaddff"/>
+      <stop offset="70%" stop-color="#4488ff"/>
+      <stop offset="100%" stop-color="#2266cc" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4488ff" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#4488ff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- Outer beacon glow -->
+  <circle cx="32" cy="32" r="31" fill="url(#glow)"/>
+  <!-- Base tier - weathered ancient stone -->
+  <circle cx="32" cy="32" r="28" fill="#7a7a6a"/>
+  <circle cx="32" cy="32" r="26" fill="#8a8a7a"/>
+  <!-- Carved channel details (4 symmetrical buttresses) -->
+  <rect x="30.5" y="3" width="3" height="8" fill="#6a6a5a" rx="1.5"/>
+  <rect x="30.5" y="53" width="3" height="8" fill="#6a6a5a" rx="1.5"/>
+  <rect x="3" y="30.5" width="8" height="3" fill="#6a6a5a" rx="1.5"/>
+  <rect x="53" y="30.5" width="8" height="3" fill="#6a6a5a" rx="1.5"/>
+  <!-- Diagonal buttresses -->
+  <rect x="30.5" y="3" width="3" height="7" fill="#6a6a5a" rx="1.5" transform="rotate(45 32 32)"/>
+  <rect x="30.5" y="3" width="3" height="7" fill="#6a6a5a" rx="1.5" transform="rotate(135 32 32)"/>
+  <rect x="30.5" y="3" width="3" height="7" fill="#6a6a5a" rx="1.5" transform="rotate(225 32 32)"/>
+  <rect x="30.5" y="3" width="3" height="7" fill="#6a6a5a" rx="1.5" transform="rotate(315 32 32)"/>
+  <!-- Second tier -->
+  <circle cx="32" cy="32" r="22" fill="#6a6a5a"/>
+  <circle cx="32" cy="32" r="20" fill="#8a8a7a"/>
+  <!-- Third tier -->
+  <circle cx="32" cy="32" r="17" fill="#5a5a50"/>
+  <circle cx="32" cy="32" r="15" fill="#7a7a6a"/>
+  <!-- Upper platform -->
+  <circle cx="32" cy="32" r="12" fill="#5a5a50"/>
+  <circle cx="32" cy="32" r="10" fill="#6a6a5a"/>
+  <!-- Force-imbued rune marks (subtle) -->
+  <circle cx="32" cy="20" r="1" fill="#6688aa" opacity="0.5"/>
+  <circle cx="32" cy="44" r="1" fill="#6688aa" opacity="0.5"/>
+  <circle cx="20" cy="32" r="1" fill="#6688aa" opacity="0.5"/>
+  <circle cx="44" cy="32" r="1" fill="#6688aa" opacity="0.5"/>
+  <!-- Beacon chamber -->
+  <circle cx="32" cy="32" r="8" fill="url(#beacon)"/>
+  <!-- Beacon core -->
+  <circle cx="32" cy="32" r="3" fill="#aaddff"/>
+  <circle cx="32" cy="32" r="1.5" fill="#ffffff"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_palm_tree.svg
+++ b/public/assets/raptor/terrain/struct_palm_tree.svg
@@ -1,13 +1,55 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Brown trunk center -->
-  <circle cx="32" cy="32" r="6" fill="#8b6b3d"/>
-  <!-- Green leaf fronds - elongated ellipses radiating outward -->
-  <ellipse cx="32" cy="12" rx="8" ry="14" fill="#3d8b3d" transform="rotate(0 32 32)"/>
-  <ellipse cx="48" cy="24" rx="8" ry="14" fill="#2d7a2d" transform="rotate(45 32 32)"/>
-  <ellipse cx="52" cy="32" rx="8" ry="14" fill="#3d8b3d" transform="rotate(90 32 32)"/>
-  <ellipse cx="48" cy="40" rx="8" ry="14" fill="#2d7a2d" transform="rotate(135 32 32)"/>
-  <ellipse cx="32" cy="52" rx="8" ry="14" fill="#3d8b3d" transform="rotate(180 32 32)"/>
-  <ellipse cx="16" cy="40" rx="8" ry="14" fill="#2d7a2d" transform="rotate(225 32 32)"/>
-  <ellipse cx="12" cy="32" rx="8" ry="14" fill="#3d8b3d" transform="rotate(270 32 32)"/>
-  <ellipse cx="16" cy="24" rx="8" ry="14" fill="#2d7a2d" transform="rotate(315 32 32)"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <radialGradient id="trunk" cx="45%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#6b5040"/>
+      <stop offset="100%" stop-color="#4a3525"/>
+    </radialGradient>
+    <radialGradient id="moss" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#aaffcc"/>
+      <stop offset="100%" stop-color="#88ffaa" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- Broad iridescent fronds radiating outward (8 directions, alternating teal/purple) -->
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#2d8b6b" opacity="0.85" transform="rotate(0 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#3da87a" opacity="0.5" transform="rotate(0 32 32)"/>
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#5b4d8b" opacity="0.8" transform="rotate(45 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#7a6aaa" opacity="0.4" transform="rotate(45 32 32)"/>
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#2d8b6b" opacity="0.85" transform="rotate(90 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#3da87a" opacity="0.5" transform="rotate(90 32 32)"/>
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#5b4d8b" opacity="0.8" transform="rotate(135 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#7a6aaa" opacity="0.4" transform="rotate(135 32 32)"/>
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#2d8b6b" opacity="0.85" transform="rotate(180 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#3da87a" opacity="0.5" transform="rotate(180 32 32)"/>
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#5b4d8b" opacity="0.8" transform="rotate(225 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#7a6aaa" opacity="0.4" transform="rotate(225 32 32)"/>
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#2d8b6b" opacity="0.85" transform="rotate(270 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#3da87a" opacity="0.5" transform="rotate(270 32 32)"/>
+  <ellipse cx="32" cy="10" rx="10" ry="17" fill="#5b4d8b" opacity="0.8" transform="rotate(315 32 32)"/>
+  <ellipse cx="32" cy="11" rx="8" ry="15" fill="#7a6aaa" opacity="0.4" transform="rotate(315 32 32)"/>
+  <!-- Central twisted trunk -->
+  <circle cx="32" cy="32" r="8" fill="url(#trunk)"/>
+  <circle cx="32" cy="32" r="6" fill="#5a4030"/>
+  <!-- Trunk ring texture -->
+  <circle cx="32" cy="32" r="7" fill="none" stroke="#3d2a1a" stroke-width="0.6" opacity="0.5"/>
+  <circle cx="32" cy="32" r="5" fill="none" stroke="#3d2a1a" stroke-width="0.5" opacity="0.4"/>
+  <circle cx="32" cy="32" r="3" fill="none" stroke="#3d2a1a" stroke-width="0.4" opacity="0.3"/>
+  <!-- Trunk knot details -->
+  <circle cx="30" cy="30" r="1.5" fill="#4a3525" opacity="0.6"/>
+  <circle cx="34" cy="34" r="1.2" fill="#4a3525" opacity="0.5"/>
+  <!-- Bioluminescent moss dots scattered on fronds -->
+  <circle cx="22" cy="14" r="1.3" fill="#88ffaa" opacity="0.8"/>
+  <circle cx="42" cy="14" r="1.1" fill="#88ffaa" opacity="0.7"/>
+  <circle cx="50" cy="22" r="1.3" fill="#88ffaa" opacity="0.8"/>
+  <circle cx="50" cy="42" r="1.1" fill="#88ffaa" opacity="0.7"/>
+  <circle cx="42" cy="50" r="1.3" fill="#88ffaa" opacity="0.8"/>
+  <circle cx="22" cy="50" r="1.1" fill="#88ffaa" opacity="0.7"/>
+  <circle cx="14" cy="42" r="1.3" fill="#88ffaa" opacity="0.8"/>
+  <circle cx="14" cy="22" r="1.1" fill="#88ffaa" opacity="0.7"/>
+  <!-- Additional subtle glow dots -->
+  <circle cx="26" cy="20" r="0.7" fill="#aaffcc" opacity="0.5"/>
+  <circle cx="38" cy="20" r="0.7" fill="#aaffcc" opacity="0.5"/>
+  <circle cx="44" cy="32" r="0.7" fill="#aaffcc" opacity="0.5"/>
+  <circle cx="20" cy="32" r="0.7" fill="#aaffcc" opacity="0.5"/>
+  <circle cx="38" cy="44" r="0.7" fill="#aaffcc" opacity="0.5"/>
+  <circle cx="26" cy="44" r="0.7" fill="#aaffcc" opacity="0.5"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace coastal structure images with Star Wars/Naboo themed art (Issue #390, Epic #378)

### Summary (what & why)
This PR updates **Level 1 (“Coastal Patrol”) coastal structure art** by replacing three existing terrain structure SVG assets with **high-quality Star Wars/Naboo-inspired** equivalents. The goal is to align the coastal level’s visuals with the broader Star Wars/Stargate themed art direction in the Raptor game, without changing any rendering or level logic.

This is an **asset-only** change: file paths, asset keys, and renderer behavior remain unchanged.

### What changed
Replaced the contents of these SVGs (drop-in replacements, same filenames/paths):

- **Beach hut → Naboo lakeside villa**
  - Domed roof, curved stone walls, ornamental teal pools, symmetrical walkways
- **Lighthouse → Jedi beacon tower**
  - Concentric stone tiers, radial blue beacon glow, buttress details, rune-like markings
- **Palm tree → Alien Naboo swamp tree**
  - Twisted trunk, iridescent teal/purple fronds, bioluminescent moss dots

All new SVGs:
- Use `viewBox="0 0 64 64"`
- Have **transparent backgrounds**
- Are **radially/symmetrically composed** to look natural when horizontally mirrored (renderer behavior)
- Are **< 5KB** each and contain **no external references**

### Key files modified
- `public/assets/raptor/terrain/struct_beach_hut.svg`
- `public/assets/raptor/terrain/struct_lighthouse.svg`
- `public/assets/raptor/terrain/struct_palm_tree.svg`

### Notes / compatibility considerations
- Structures are rendered at randomized sizes (**32–64px**) and may be **horizontally mirrored**; the new art is designed to remain readable at 32px and mirror-safe.
- No changes to:
  - `src/games/raptor/rendering/assets.ts` (same keys/paths)
  - `src/games/raptor/levels.ts` (Level 1 structurePool unchanged)
  - `src/games/raptor/rendering/TerrainRenderer.ts` (rendering pipeline unchanged)

### Testing notes
Manual verification recommended (asset-only change):

- Launch Raptor and start **Level 1: “Coastal Patrol”**
- Confirm all three structures appear across multiple segments and:
  - Render with **transparent** backgrounds (no opaque boxes)
  - Look correct at both **~32px** and **~64px**
  - Look natural when **mirrored**
- Check browser DevTools console for any **asset loading errors**
- Optional spot-check in **Chrome + Firefox** for consistent SVG rendering

Ref: https://github.com/asgardtech/archer/issues/390