### PR TITLE
Raptor: Replace desert and wilderness structure images (oil rig, bunker, cactus) with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/struct_bunker.svg
+++ b/public/assets/raptor/terrain/struct_bunker.svg
@@ -1,8 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Dark olive base rectangle -->
-  <rect x="10" y="20" width="44" height="32" fill="#4a5540" rx="2"/>
-  <!-- Lighter roof slit -->
-  <rect x="14" y="16" width="36" height="8" fill="#5a6550" rx="1"/>
-  <!-- Small dark entrance on one side -->
-  <rect x="10" y="32" width="8" height="12" fill="#3a4535" rx="1"/>
+  <!-- Partially buried earth mound -->
+  <ellipse cx="32" cy="34" rx="24" ry="20" fill="#a09a80" opacity="0.4"/>
+  <!-- Outer crystal formation (irregular but near-symmetrical) -->
+  <polygon points="32,6 42,12 48,22 50,34 46,46 38,52 26,52 18,46 14,34 16,22 22,12" fill="#7a8a9a" stroke="#5a6a7a" stroke-width="1"/>
+  <!-- Inner crystal layer -->
+  <polygon points="32,12 40,17 44,26 44,38 40,46 32,48 24,46 20,38 20,26 24,17" fill="#6a7a8a" stroke="#5a6a7a" stroke-width="0.75"/>
+  <!-- Crystal shard accents (radiating, near-symmetrical) -->
+  <polygon points="32,4 34,10 30,10" fill="#8ab0c0" opacity="0.7"/>
+  <polygon points="32,54 34,48 30,48" fill="#8ab0c0" opacity="0.7"/>
+  <polygon points="10,32 16,30 16,34" fill="#8ab0c0" opacity="0.6"/>
+  <polygon points="54,32 48,30 48,34" fill="#8ab0c0" opacity="0.6"/>
+  <!-- Diagonal crystal shards -->
+  <polygon points="18,14 22,18 18,18" fill="#8ab0c0" opacity="0.5"/>
+  <polygon points="46,14 42,18 46,18" fill="#8ab0c0" opacity="0.5"/>
+  <polygon points="18,50 22,46 18,46" fill="#8ab0c0" opacity="0.5"/>
+  <polygon points="46,50 42,46 46,46" fill="#8ab0c0" opacity="0.5"/>
+  <!-- Entrance ring (outer) -->
+  <circle cx="32" cy="32" r="12" fill="#5a6a7a" stroke="#4a5a6a" stroke-width="1.5"/>
+  <!-- Entrance ring (inner bevel) -->
+  <circle cx="32" cy="32" r="9" fill="#4a5a6a" stroke="#8ab0c0" stroke-width="1"/>
+  <!-- Deep tunnel opening -->
+  <circle cx="32" cy="32" r="6" fill="#2a3a4a"/>
+  <!-- Tunnel depth glow -->
+  <circle cx="32" cy="32" r="4" fill="#3a4a5a" opacity="0.8"/>
+  <!-- Ring markings (alien tech, symmetrical) -->
+  <circle cx="32" cy="19" r="1.5" fill="#8ab0c0" opacity="0.8"/>
+  <circle cx="32" cy="45" r="1.5" fill="#8ab0c0" opacity="0.8"/>
+  <circle cx="19" cy="32" r="1.5" fill="#8ab0c0" opacity="0.8"/>
+  <circle cx="45" cy="32" r="1.5" fill="#8ab0c0" opacity="0.8"/>
+  <!-- Earth/sand camouflage patches -->
+  <ellipse cx="14" cy="24" rx="4" ry="3" fill="#a09a80" opacity="0.5"/>
+  <ellipse cx="50" cy="24" rx="4" ry="3" fill="#a09a80" opacity="0.5"/>
+  <ellipse cx="14" cy="42" rx="3" ry="3" fill="#a09a80" opacity="0.4"/>
+  <ellipse cx="50" cy="42" rx="3" ry="3" fill="#a09a80" opacity="0.4"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_cactus.svg
+++ b/public/assets/raptor/terrain/struct_cactus.svg
@@ -1,10 +1,45 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Shadow -->
-  <ellipse cx="34" cy="38" rx="14" ry="8" fill="#2a4a2a" opacity="0.5"/>
-  <!-- Main green oval body -->
-  <ellipse cx="32" cy="32" rx="12" ry="16" fill="#3d7a3d"/>
-  <!-- Arm branch 1 -->
-  <ellipse cx="18" cy="28" rx="8" ry="6" fill="#3d7a3d"/>
-  <!-- Arm branch 2 -->
-  <ellipse cx="46" cy="36" rx="8" ry="6" fill="#3d7a3d"/>
+  <!-- Ground shadow -->
+  <ellipse cx="33" cy="38" rx="20" ry="12" fill="#4a6a4a" opacity="0.25"/>
+  <!-- Arm branch left (thick, extending) -->
+  <ellipse cx="14" cy="28" rx="10" ry="6" fill="#4a6a4a"/>
+  <ellipse cx="14" cy="28" rx="8" ry="4.5" fill="#5a7a5a"/>
+  <!-- Arm branch right (thick, extending) -->
+  <ellipse cx="50" cy="36" rx="10" ry="6" fill="#4a6a4a"/>
+  <ellipse cx="50" cy="36" rx="8" ry="4.5" fill="#5a7a5a"/>
+  <!-- Small arm top-right -->
+  <ellipse cx="44" cy="18" rx="6" ry="4" fill="#4a6a4a"/>
+  <ellipse cx="44" cy="18" rx="4.5" ry="3" fill="#5a7a5a"/>
+  <!-- Main bulbous body -->
+  <ellipse cx="32" cy="32" rx="14" ry="16" fill="#4a6a4a"/>
+  <ellipse cx="32" cy="32" rx="12" ry="14" fill="#5a7a5a"/>
+  <!-- Body highlight (alien sheen) -->
+  <ellipse cx="29" cy="28" rx="6" ry="8" fill="#7a9a7a" opacity="0.4"/>
+  <!-- Body ridge lines (vertical growth pattern) -->
+  <line x1="28" y1="18" x2="28" y2="46" stroke="#4a6a4a" stroke-width="0.75" opacity="0.6"/>
+  <line x1="32" y1="16" x2="32" y2="48" stroke="#4a6a4a" stroke-width="0.75" opacity="0.5"/>
+  <line x1="36" y1="18" x2="36" y2="46" stroke="#4a6a4a" stroke-width="0.75" opacity="0.6"/>
+  <!-- Spines on body edge (small dots) -->
+  <circle cx="20" cy="26" r="1" fill="#8a8a6a"/>
+  <circle cx="19" cy="32" r="1" fill="#8a8a6a"/>
+  <circle cx="20" cy="38" r="1" fill="#8a8a6a"/>
+  <circle cx="44" cy="26" r="1" fill="#8a8a6a"/>
+  <circle cx="45" cy="32" r="1" fill="#8a8a6a"/>
+  <circle cx="44" cy="38" r="1" fill="#8a8a6a"/>
+  <circle cx="28" cy="17" r="1" fill="#8a8a6a"/>
+  <circle cx="36" cy="17" r="1" fill="#8a8a6a"/>
+  <circle cx="28" cy="47" r="1" fill="#8a8a6a"/>
+  <circle cx="36" cy="47" r="1" fill="#8a8a6a"/>
+  <!-- Spines on left arm -->
+  <circle cx="6" cy="26" r="0.8" fill="#8a8a6a"/>
+  <circle cx="8" cy="23" r="0.8" fill="#8a8a6a"/>
+  <circle cx="6" cy="30" r="0.8" fill="#8a8a6a"/>
+  <!-- Spines on right arm -->
+  <circle cx="58" cy="34" r="0.8" fill="#8a8a6a"/>
+  <circle cx="56" cy="31" r="0.8" fill="#8a8a6a"/>
+  <circle cx="58" cy="38" r="0.8" fill="#8a8a6a"/>
+  <!-- Alien texture spots (grey-green tint) -->
+  <circle cx="30" cy="25" r="2" fill="#8a8a6a" opacity="0.3"/>
+  <circle cx="35" cy="35" r="2.5" fill="#8a8a6a" opacity="0.25"/>
+  <circle cx="28" cy="40" r="1.5" fill="#8a8a6a" opacity="0.3"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_oil_rig.svg
+++ b/public/assets/raptor/terrain/struct_oil_rig.svg
@@ -1,14 +1,48 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Square platform - dark grey -->
-  <rect x="8" y="24" width="48" height="32" fill="#555555" rx="2"/>
-  <!-- Inner platform detail -->
-  <rect x="14" y="30" width="36" height="20" fill="#444444" rx="1"/>
-  <!-- Crane arm base -->
-  <rect x="28" y="18" width="8" height="8" fill="#555555"/>
-  <!-- Crane arm lines -->
-  <line x1="32" y1="26" x2="20" y2="38" stroke="#333333" stroke-width="2"/>
-  <line x1="32" y1="26" x2="44" y2="38" stroke="#333333" stroke-width="2"/>
-  <!-- Derrick tower -->
-  <rect x="26" y="8" width="12" height="18" fill="#444444"/>
-  <rect x="28" y="10" width="8" height="14" fill="#333333"/>
+  <!-- Base shadow -->
+  <ellipse cx="32" cy="34" rx="18" ry="16" fill="#6b6b5b" opacity="0.3"/>
+  <!-- Outer collection ring / pipe framework -->
+  <circle cx="32" cy="32" r="22" fill="none" stroke="#8a8a7a" stroke-width="2"/>
+  <!-- Collection tanks (4 symmetrical) -->
+  <rect x="8" y="28" width="6" height="8" rx="1" fill="#6b6b5b"/>
+  <rect x="50" y="28" width="6" height="8" rx="1" fill="#6b6b5b"/>
+  <rect x="28" y="8" width="8" height="6" rx="1" fill="#6b6b5b"/>
+  <rect x="28" y="50" width="8" height="6" rx="1" fill="#6b6b5b"/>
+  <!-- Tank highlights -->
+  <rect x="9" y="29" width="4" height="3" rx="1" fill="#a0a090" opacity="0.5"/>
+  <rect x="51" y="29" width="4" height="3" rx="1" fill="#a0a090" opacity="0.5"/>
+  <rect x="29" y="9" width="4" height="3" rx="1" fill="#a0a090" opacity="0.5"/>
+  <rect x="29" y="51" width="4" height="3" rx="1" fill="#a0a090" opacity="0.5"/>
+  <!-- Condensation fins (8 radiating) -->
+  <line x1="32" y1="14" x2="32" y2="20" stroke="#a0a090" stroke-width="2"/>
+  <line x1="32" y1="44" x2="32" y2="50" stroke="#a0a090" stroke-width="2"/>
+  <line x1="14" y1="32" x2="20" y2="32" stroke="#a0a090" stroke-width="2"/>
+  <line x1="44" y1="32" x2="50" y2="32" stroke="#a0a090" stroke-width="2"/>
+  <line x1="19" y1="19" x2="23" y2="23" stroke="#9a9a8a" stroke-width="1.5"/>
+  <line x1="45" y1="19" x2="41" y2="23" stroke="#9a9a8a" stroke-width="1.5"/>
+  <line x1="19" y1="45" x2="23" y2="41" stroke="#9a9a8a" stroke-width="1.5"/>
+  <line x1="45" y1="45" x2="41" y2="41" stroke="#9a9a8a" stroke-width="1.5"/>
+  <!-- Inner machinery ring -->
+  <circle cx="32" cy="32" r="12" fill="#7a7a6a" stroke="#6b6b5b" stroke-width="1.5"/>
+  <!-- Panel lines on inner ring -->
+  <line x1="32" y1="20" x2="32" y2="22" stroke="#5a5a4a" stroke-width="1"/>
+  <line x1="32" y1="42" x2="32" y2="44" stroke="#5a5a4a" stroke-width="1"/>
+  <line x1="20" y1="32" x2="22" y2="32" stroke="#5a5a4a" stroke-width="1"/>
+  <line x1="42" y1="32" x2="44" y2="32" stroke="#5a5a4a" stroke-width="1"/>
+  <!-- Central column (top-down cross-section) -->
+  <circle cx="32" cy="32" r="6" fill="#8a8a7a" stroke="#5a5a4a" stroke-width="1"/>
+  <!-- Column highlight -->
+  <circle cx="30" cy="30" r="2" fill="#b8a880" opacity="0.5"/>
+  <!-- Sand weathering marks -->
+  <circle cx="32" cy="32" r="4" fill="none" stroke="#b8a880" stroke-width="0.5" opacity="0.6"/>
+  <!-- Rivet details (symmetrical) -->
+  <circle cx="26" cy="26" r="1" fill="#5a5a4a"/>
+  <circle cx="38" cy="26" r="1" fill="#5a5a4a"/>
+  <circle cx="26" cy="38" r="1" fill="#5a5a4a"/>
+  <circle cx="38" cy="38" r="1" fill="#5a5a4a"/>
+  <!-- Pipe connections from center to tanks -->
+  <line x1="20" y1="32" x2="14" y2="32" stroke="#7a7a6a" stroke-width="1.5"/>
+  <line x1="44" y1="32" x2="50" y2="32" stroke="#7a7a6a" stroke-width="1.5"/>
+  <line x1="32" y1="20" x2="32" y2="14" stroke="#7a7a6a" stroke-width="1.5"/>
+  <line x1="32" y1="44" x2="32" y2="50" stroke="#7a7a6a" stroke-width="1.5"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace desert/wilderness structure images with Star Wars/Stargate themed art (Issue #391)

### Summary (What / Why)
This PR replaces three existing desert/wilderness structure SVG assets in **Raptor** with new, higher-quality **Star Wars/Stargate-themed** artwork to better match the game’s sci‑fi aesthetic (part of epic #378).  
This is an **in-place asset swap** only: filenames/paths/asset keys remain unchanged, so no code or level configuration updates are required.

### What changed
- **`struct_oil_rig.svg`** → replaced with a **Star Wars Tatooine Moisture Vaporator** (top-down), including radial condensation fins, collection tanks, and sand-weathered metallic tones.
- **`struct_bunker.svg`** → replaced with a **Stargate Tok’ra underground tunnel entrance** (top-down), featuring a crystalline formation and centered ringed hatch; uses neutral tones to remain readable across multiple biomes (desert/mountain/arctic/fortress).
- **`struct_cactus.svg`** → replaced with an **alien desert succulent** (top-down) inspired by Tatooine/Abydos flora; bulbous body, thick arms, subtle spine details, muted green-grey palette.

All three SVGs keep project conventions:
- `viewBox="0 0 64 64"`
- transparent background (no full-canvas backdrop)
- inline attributes only (no external CSS / no raster embeds)
- designed to look natural when **horizontally mirrored** (renderer may flip them)
- kept **under 5KB**

### Key files modified
- `public/assets/raptor/terrain/struct_oil_rig.svg`
- `public/assets/raptor/terrain/struct_bunker.svg`
- `public/assets/raptor/terrain/struct_cactus.svg`

### Testing notes
- Manual QA:
  - Load Raptor and play **Level 2 “Desert Strike”** to verify all three structures render cleanly at typical 32–64px sizes, including mirrored variants.
  - Play **Levels 3–5** to confirm `struct_bunker` remains visually distinct and theme-compatible on mountain/arctic/fortress terrain colors.
  - Open each SVG directly in a browser to confirm transparency and correct viewBox.
- Automated:
  - No code paths changed; existing tests should be unaffected. If running QA suite: `npx jest tests/raptor-qa.test.ts` (note: any `starDensity` assertion failures are pre-existing and unrelated to these asset updates).

Closes: #391

Ref: https://github.com/asgardtech/archer/issues/391