### PR TITLE
Raptor: Replace mountain and surveillance structure images (pine tree, watchtower, radar dish) with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/struct_pine_tree.svg
+++ b/public/assets/raptor/terrain/struct_pine_tree.svg
@@ -1,12 +1,48 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Brown trunk center dot -->
-  <circle cx="32" cy="32" r="4" fill="#8b6b3d"/>
-  <!-- Dark green outer circle -->
-  <circle cx="32" cy="32" r="24" fill="#2d5a2d"/>
-  <!-- Lighter concentric circle - middle layer -->
-  <circle cx="32" cy="32" r="18" fill="#3d6b3d"/>
-  <!-- Inner lighter circle -->
-  <circle cx="32" cy="32" r="10" fill="#3d6b3d"/>
-  <!-- Brown trunk center (on top) -->
-  <circle cx="32" cy="32" r="4" fill="#8b6b3d"/>
+  <defs>
+    <radialGradient id="canopy-outer" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#3d6b3d"/>
+      <stop offset="70%" stop-color="#2a5a2a"/>
+      <stop offset="100%" stop-color="#1a3a1a"/>
+    </radialGradient>
+    <radialGradient id="canopy-inner" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4d7a4d"/>
+      <stop offset="100%" stop-color="#3a6a3a"/>
+    </radialGradient>
+    <radialGradient id="trunk-center" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#6b4a28"/>
+      <stop offset="100%" stop-color="#5a3a20"/>
+    </radialGradient>
+  </defs>
+  <!-- Outer canopy — irregular ancient redwood shape -->
+  <path d="M32 3 C40 4 50 8 55 16 C59 22 60 30 58 36 C56 42 52 50 46 55 C40 59 36 60 32 61 C28 60 24 59 18 55 C12 50 8 42 6 36 C4 30 5 22 9 16 C14 8 24 4 32 3Z" fill="url(#canopy-outer)"/>
+  <!-- Shadow crevices in canopy -->
+  <path d="M18 18 C22 22 20 28 16 26 C12 24 14 14 18 18Z" fill="#1a3a1a" opacity="0.6"/>
+  <path d="M46 20 C50 24 48 30 44 28 C40 26 42 16 46 20Z" fill="#1a3a1a" opacity="0.6"/>
+  <path d="M24 44 C28 48 26 52 22 50 C18 48 20 40 24 44Z" fill="#1a3a1a" opacity="0.5"/>
+  <path d="M42 42 C46 46 44 52 40 50 C36 48 38 38 42 42Z" fill="#1a3a1a" opacity="0.5"/>
+  <!-- Mid-layer canopy clusters -->
+  <ellipse cx="22" cy="22" rx="10" ry="9" fill="#3a6a3a" opacity="0.8"/>
+  <ellipse cx="42" cy="22" rx="10" ry="9" fill="#3a6a3a" opacity="0.8"/>
+  <ellipse cx="22" cy="42" rx="9" ry="10" fill="#356535" opacity="0.7"/>
+  <ellipse cx="42" cy="42" rx="9" ry="10" fill="#356535" opacity="0.7"/>
+  <!-- Inner canopy highlight clusters -->
+  <ellipse cx="26" cy="26" rx="6" ry="5" fill="url(#canopy-inner)" opacity="0.7"/>
+  <ellipse cx="38" cy="26" rx="6" ry="5" fill="url(#canopy-inner)" opacity="0.7"/>
+  <ellipse cx="26" cy="38" rx="5" ry="6" fill="#4a7a4a" opacity="0.6"/>
+  <ellipse cx="38" cy="38" rx="5" ry="6" fill="#4a7a4a" opacity="0.6"/>
+  <!-- Moss/lichen highlights on canopy top -->
+  <ellipse cx="20" cy="16" rx="3" ry="2" fill="#6b8b4b" opacity="0.5"/>
+  <ellipse cx="44" cy="16" rx="3" ry="2" fill="#6b8b4b" opacity="0.5"/>
+  <ellipse cx="32" cy="12" rx="4" ry="2" fill="#6b8b4b" opacity="0.4"/>
+  <ellipse cx="16" cy="32" rx="2" ry="3" fill="#5a7b4a" opacity="0.4"/>
+  <ellipse cx="48" cy="32" rx="2" ry="3" fill="#5a7b4a" opacity="0.4"/>
+  <!-- Trunk visible through canopy gap -->
+  <circle cx="32" cy="32" r="5" fill="url(#trunk-center)"/>
+  <circle cx="32" cy="32" r="3" fill="#7a5a30"/>
+  <!-- Bark ring detail -->
+  <circle cx="32" cy="32" r="4" fill="none" stroke="#5a3a20" stroke-width="0.8" opacity="0.6"/>
+  <!-- Fine canopy edge texture -->
+  <path d="M32 5 C34 7 36 6 38 8" fill="none" stroke="#2a5a2a" stroke-width="1.5" opacity="0.4"/>
+  <path d="M26 5 C28 7 30 6 32 5" fill="none" stroke="#2a5a2a" stroke-width="1.5" opacity="0.4"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_radar_dish.svg
+++ b/public/assets/raptor/terrain/struct_radar_dish.svg
@@ -1,13 +1,56 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Square base -->
-  <rect x="22" y="44" width="20" height="12" fill="#444444"/>
-  <!-- Dish circle -->
-  <circle cx="32" cy="32" r="18" fill="#d0d0d0"/>
-  <!-- Cross-hair lines -->
-  <line x1="32" y1="14" x2="32" y2="50" stroke="#999999" stroke-width="1"/>
-  <line x1="14" y1="32" x2="50" y2="32" stroke="#999999" stroke-width="1"/>
-  <line x1="20" y1="20" x2="44" y2="44" stroke="#999999" stroke-width="0.5"/>
-  <line x1="44" y1="20" x2="20" y2="44" stroke="#999999" stroke-width="0.5"/>
-  <!-- Center hub -->
-  <circle cx="32" cy="32" r="4" fill="#444444"/>
+  <defs>
+    <radialGradient id="dish-surface" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#d0d0d0"/>
+      <stop offset="60%" stop-color="#b8b8b8"/>
+      <stop offset="100%" stop-color="#909090"/>
+    </radialGradient>
+    <radialGradient id="dish-inner" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#c8c8c8"/>
+      <stop offset="100%" stop-color="#aaaaaa"/>
+    </radialGradient>
+    <linearGradient id="yoke-metal" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#666666"/>
+      <stop offset="50%" stop-color="#777777"/>
+      <stop offset="100%" stop-color="#666666"/>
+    </linearGradient>
+  </defs>
+  <!-- Equipment base panels -->
+  <rect x="24" y="52" width="16" height="8" rx="1" fill="#555555" stroke="#444444" stroke-width="0.8"/>
+  <rect x="20" y="54" width="6" height="6" rx="0.5" fill="#4a5a3a" stroke="#3a4a2a" stroke-width="0.6"/>
+  <rect x="38" y="54" width="6" height="6" rx="0.5" fill="#4a5a3a" stroke="#3a4a2a" stroke-width="0.6"/>
+  <!-- Rotating mount base -->
+  <circle cx="32" cy="32" r="4" fill="#555555" stroke="#444444" stroke-width="1"/>
+  <!-- Yoke / support cross bars -->
+  <line x1="10" y1="32" x2="54" y2="32" stroke="url(#yoke-metal)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="32" y1="10" x2="32" y2="54" stroke="url(#yoke-metal)" stroke-width="3" stroke-linecap="round"/>
+  <!-- Outer dish rim -->
+  <circle cx="32" cy="32" r="24" fill="url(#dish-surface)" stroke="#777777" stroke-width="1.5"/>
+  <!-- Concentric depth rings -->
+  <circle cx="32" cy="32" r="20" fill="none" stroke="#a0a0a0" stroke-width="0.8" opacity="0.6"/>
+  <circle cx="32" cy="32" r="15" fill="none" stroke="#a0a0a0" stroke-width="0.7" opacity="0.5"/>
+  <circle cx="32" cy="32" r="10" fill="url(#dish-inner)" stroke="#999999" stroke-width="0.6"/>
+  <!-- Dish surface panel lines (radial) -->
+  <line x1="32" y1="8" x2="32" y2="56" stroke="#a8a8a8" stroke-width="0.6" opacity="0.4"/>
+  <line x1="8" y1="32" x2="56" y2="32" stroke="#a8a8a8" stroke-width="0.6" opacity="0.4"/>
+  <line x1="14" y1="14" x2="50" y2="50" stroke="#a8a8a8" stroke-width="0.5" opacity="0.3"/>
+  <line x1="50" y1="14" x2="14" y2="50" stroke="#a8a8a8" stroke-width="0.5" opacity="0.3"/>
+  <!-- Yoke arms over dish -->
+  <line x1="12" y1="32" x2="52" y2="32" stroke="#666666" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="32" y1="12" x2="32" y2="52" stroke="#666666" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Central feed horn / receiver -->
+  <circle cx="32" cy="32" r="5" fill="#606060" stroke="#444444" stroke-width="1.2"/>
+  <circle cx="32" cy="32" r="2.5" fill="#777777"/>
+  <circle cx="32" cy="32" r="1" fill="#999999"/>
+  <!-- Bolts / attachment points on yoke ends -->
+  <circle cx="12" cy="32" r="1.5" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <circle cx="52" cy="32" r="1.5" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <circle cx="32" cy="12" r="1.5" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <circle cx="32" cy="52" r="1.5" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <!-- Equipment panel details on base -->
+  <rect x="26" y="53" width="3" height="2" rx="0.3" fill="#3a5a3a" opacity="0.7"/>
+  <rect x="35" y="53" width="3" height="2" rx="0.3" fill="#3a5a3a" opacity="0.7"/>
+  <!-- Subtle dish surface reflection highlight -->
+  <ellipse cx="26" cy="24" rx="6" ry="4" fill="#ffffff" opacity="0.08"/>
+  <ellipse cx="38" cy="24" rx="6" ry="4" fill="#ffffff" opacity="0.08"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_watchtower.svg
+++ b/public/assets/raptor/terrain/struct_watchtower.svg
@@ -1,13 +1,60 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Shadow -->
-  <rect x="14" y="48" width="36" height="8" fill="#333333" opacity="0.6"/>
-  <!-- Base platform -->
-  <rect x="8" y="40" width="48" height="16" fill="#555555"/>
-  <!-- Elevated platform -->
-  <rect x="14" y="28" width="36" height="14" fill="#666666"/>
-  <!-- Railing outline -->
-  <rect x="12" y="26" width="40" height="2" fill="none" stroke="#555555" stroke-width="1"/>
-  <rect x="12" y="26" width="2" height="16" fill="none" stroke="#555555" stroke-width="1"/>
-  <rect x="50" y="26" width="2" height="16" fill="none" stroke="#555555" stroke-width="1"/>
-  <rect x="12" y="40" width="40" height="2" fill="none" stroke="#555555" stroke-width="1"/>
+  <defs>
+    <linearGradient id="tower-body" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5a5a5a"/>
+      <stop offset="50%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </linearGradient>
+    <radialGradient id="platform-top" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#606060"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </radialGradient>
+    <radialGradient id="searchlight-glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- Support struts visible below platform -->
+  <line x1="16" y1="16" x2="32" y2="32" stroke="#3a3a3a" stroke-width="3"/>
+  <line x1="48" y1="16" x2="32" y2="32" stroke="#3a3a3a" stroke-width="3"/>
+  <line x1="16" y1="48" x2="32" y2="32" stroke="#3a3a3a" stroke-width="3"/>
+  <line x1="48" y1="48" x2="32" y2="32" stroke="#3a3a3a" stroke-width="3"/>
+  <!-- Diagonal cross-bracing struts -->
+  <line x1="20" y1="32" x2="44" y2="32" stroke="#333333" stroke-width="2"/>
+  <line x1="32" y1="20" x2="32" y2="44" stroke="#333333" stroke-width="2"/>
+  <!-- Octagonal observation platform (top-down) -->
+  <polygon points="24,10 40,10 52,24 52,40 40,54 24,54 12,40 12,24" fill="url(#tower-body)" stroke="#2a2a2a" stroke-width="1.5"/>
+  <!-- Platform panel lines -->
+  <polygon points="24,10 40,10 52,24 52,40 40,54 24,54 12,40 12,24" fill="none" stroke="#555555" stroke-width="0.8"/>
+  <line x1="24" y1="10" x2="40" y2="54" stroke="#4a4a4a" stroke-width="0.6" opacity="0.5"/>
+  <line x1="40" y1="10" x2="24" y2="54" stroke="#4a4a4a" stroke-width="0.6" opacity="0.5"/>
+  <!-- Inner platform deck -->
+  <polygon points="28,16 36,16 44,28 44,36 36,48 28,48 20,36 20,28" fill="url(#platform-top)"/>
+  <!-- Central hub / searchlight housing -->
+  <circle cx="32" cy="32" r="6" fill="#505050" stroke="#2a2a2a" stroke-width="1"/>
+  <circle cx="32" cy="32" r="3" fill="#606060"/>
+  <!-- Searchlight glow (symmetric) -->
+  <circle cx="32" cy="32" r="8" fill="url(#searchlight-glow)"/>
+  <!-- Red accent lights at octagon corners -->
+  <circle cx="24" cy="10" r="1.5" fill="#cc3333"/>
+  <circle cx="40" cy="10" r="1.5" fill="#cc3333"/>
+  <circle cx="52" cy="24" r="1.5" fill="#cc3333"/>
+  <circle cx="52" cy="40" r="1.5" fill="#cc3333"/>
+  <circle cx="40" cy="54" r="1.5" fill="#cc3333"/>
+  <circle cx="24" cy="54" r="1.5" fill="#cc3333"/>
+  <circle cx="12" cy="40" r="1.5" fill="#cc3333"/>
+  <circle cx="12" cy="24" r="1.5" fill="#cc3333"/>
+  <!-- Red accent glow -->
+  <circle cx="24" cy="10" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <circle cx="40" cy="10" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <circle cx="52" cy="24" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <circle cx="52" cy="40" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <circle cx="40" cy="54" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <circle cx="24" cy="54" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <circle cx="12" cy="40" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <circle cx="12" cy="24" r="2.5" fill="#cc3333" opacity="0.25"/>
+  <!-- Metallic edge highlights -->
+  <line x1="24" y1="10" x2="40" y2="10" stroke="#7a7a7a" stroke-width="0.8" opacity="0.6"/>
+  <line x1="12" y1="24" x2="24" y2="10" stroke="#7a7a7a" stroke-width="0.6" opacity="0.4"/>
+  <line x1="40" y1="10" x2="52" y2="24" stroke="#7a7a7a" stroke-width="0.6" opacity="0.4"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace mountain/surveillance structure images with Star Wars/Stargate themed art (Issue #392)

### Summary (what changed + why)
This PR updates the Raptor game’s mountain/surveillance structure artwork by replacing three existing terrain SVG assets with higher-quality, sci‑fi themed replacements:
- **Pine tree** → redesigned as an **Endor-style forest canopy** (Star Wars)
- **Watchtower** → redesigned as an **Imperial scout tower** (Star Wars)
- **Radar dish** → redesigned as an **SGC deep-space telemetry antenna** (Stargate)

**Why:** The previous SVGs were simple geometric placeholders and didn’t match the desired Star Wars/Stargate art direction. These replacements improve visual fidelity while keeping the existing rendering/asset pipeline unchanged.

### Key files modified
Asset replacements only (no TypeScript changes):
- `public/assets/raptor/terrain/struct_pine_tree.svg`  
  - Endor forest tree canopy (top-down), layered foliage, moss highlights, visible trunk center
- `public/assets/raptor/terrain/struct_watchtower.svg`  
  - Imperial scout tower with octagonal platform, panel lines, red accent lights, support struts
- `public/assets/raptor/terrain/struct_radar_dish.svg`  
  - SGC telemetry antenna with parabolic dish depth rings, symmetric yoke, equipment/base panels

### Implementation notes / constraints met
- Maintains **`viewBox="0 0 64 64"`** for compatibility with existing terrain structure assets
- **Transparent backgrounds** (no filled background rects)
- Designed to remain readable at **32–64px** render sizes
- **Mirror-safe** (bilateral/radial symmetry; no text or directional elements)
- `struct_watchtower` and `struct_radar_dish` tuned for contrast on both:
  - Mountain ground `#3d5a3d`
  - Arctic ground `#e0e8ee`
- SVGs are self-contained (no external refs) and lightweight (reported **< 4KB**, element counts **< 50**)

### Testing notes
Manual verification recommended (asset-only change):
- Run the Raptor game locally and confirm assets load with **no console warnings** from the `AssetLoader`
- Visually inspect in-game:
  - **Level 3 (“Mountain Assault”)**: pine tree, watchtower, radar dish appear and read well on dark green terrain
  - **Level 4 (“Arctic Thunder”)**: watchtower + radar dish remain readable on arctic terrain
- Confirm random horizontal mirroring looks natural (structures still plausible when flipped)

No automated tests added/updated (pure asset replacement; asset keys and rendering pipeline unchanged).

Ref: https://github.com/asgardtech/archer/issues/392