### PR TITLE
Raptor: Replace military base structure images (barracks, AA gun, hangar) with Star Wars/Stargate themed art

### DIFF
--- a/public/assets/raptor/terrain/struct_aa_gun.svg
+++ b/public/assets/raptor/terrain/struct_aa_gun.svg
@@ -1,9 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Octagon base -->
-  <polygon points="52,28 46,42 32,48 18,42 12,28 18,14 32,8 46,14" fill="#444444"/>
-  <!-- Turret center -->
-  <circle cx="32" cy="28" r="6" fill="#333333"/>
-  <!-- Gun barrels -->
-  <line x1="24" y1="20" x2="20" y2="4" stroke="#333333" stroke-width="3" stroke-linecap="round"/>
-  <line x1="40" y1="20" x2="44" y2="4" stroke="#333333" stroke-width="3" stroke-linecap="round"/>
+  <!-- Octagonal reinforced platform -->
+  <polygon points="20,6 44,6 58,20 58,44 44,58 20,58 6,44 6,20" fill="#505050" stroke="#3a3a3a" stroke-width="1.5"/>
+  <!-- Inner platform ring -->
+  <polygon points="24,12 40,12 50,24 50,40 40,52 24,52 14,40 14,24" fill="#585858" stroke="#4a4a4a" stroke-width="1"/>
+  <!-- Platform panel lines -->
+  <line x1="32" y1="6" x2="32" y2="58" stroke="#666666" stroke-width="0.6"/>
+  <line x1="6" y1="32" x2="58" y2="32" stroke="#666666" stroke-width="0.6"/>
+  <!-- Power conduits from platform corners to turret (symmetric) -->
+  <line x1="20" y1="6" x2="28" y2="26" stroke="#707070" stroke-width="1.5"/>
+  <line x1="44" y1="6" x2="36" y2="26" stroke="#707070" stroke-width="1.5"/>
+  <line x1="20" y1="58" x2="28" y2="38" stroke="#707070" stroke-width="1.5"/>
+  <line x1="44" y1="58" x2="36" y2="38" stroke="#707070" stroke-width="1.5"/>
+  <!-- Turret mount base -->
+  <circle cx="32" cy="32" r="10" fill="#606060" stroke="#4a4a4a" stroke-width="1.5"/>
+  <!-- Inner turret ring -->
+  <circle cx="32" cy="32" r="6" fill="#555555" stroke="#444444" stroke-width="1"/>
+  <!-- Twin gun barrels pointing upward (symmetric) -->
+  <rect x="26" y="2" width="4" height="24" rx="1" fill="#4a4a4a" stroke="#333333" stroke-width="0.5"/>
+  <rect x="34" y="2" width="4" height="24" rx="1" fill="#4a4a4a" stroke="#333333" stroke-width="0.5"/>
+  <!-- Barrel muzzle tips -->
+  <rect x="25" y="1" width="6" height="3" rx="1" fill="#3a3a3a" stroke="#555555" stroke-width="0.5"/>
+  <rect x="33" y="1" width="6" height="3" rx="1" fill="#3a3a3a" stroke="#555555" stroke-width="0.5"/>
+  <!-- Red targeting sensors at octagon vertices -->
+  <circle cx="20" cy="6" r="1.5" fill="#cc0000"/>
+  <circle cx="44" cy="6" r="1.5" fill="#cc0000"/>
+  <circle cx="6" cy="20" r="1.5" fill="#cc0000"/>
+  <circle cx="58" cy="20" r="1.5" fill="#cc0000"/>
+  <circle cx="6" cy="44" r="1.5" fill="#cc0000"/>
+  <circle cx="58" cy="44" r="1.5" fill="#cc0000"/>
+  <circle cx="20" cy="58" r="1.5" fill="#cc0000"/>
+  <circle cx="44" cy="58" r="1.5" fill="#cc0000"/>
+  <!-- Sensor glow at top vertices -->
+  <circle cx="20" cy="6" r="2.5" fill="#cc0000" opacity="0.2"/>
+  <circle cx="44" cy="6" r="2.5" fill="#cc0000" opacity="0.2"/>
+  <!-- Central turret core -->
+  <circle cx="32" cy="32" r="3" fill="#444444"/>
+  <circle cx="32" cy="32" r="1.5" fill="#cc0000" opacity="0.8"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_barracks.svg
+++ b/public/assets/raptor/terrain/struct_barracks.svg
@@ -1,8 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Building body (long rectangle) -->
-  <rect x="8" y="20" width="48" height="36" fill="#5a6b50"/>
-  <!-- Roof -->
-  <rect x="6" y="14" width="52" height="10" fill="#4a5a40"/>
-  <!-- Door on short side -->
-  <rect x="26" y="40" width="12" height="16" fill="#3a4a30"/>
+  <!-- Main prefab building body -->
+  <rect x="6" y="14" width="52" height="36" rx="2" ry="2" fill="#6b7a56" stroke="#4a5a3a" stroke-width="1.5"/>
+  <!-- Reinforced wall panels (4 quadrants) -->
+  <rect x="8" y="16" width="23" height="15" fill="#5e6d48" stroke="#4a5a3a" stroke-width="0.5"/>
+  <rect x="33" y="16" width="23" height="15" fill="#5e6d48" stroke="#4a5a3a" stroke-width="0.5"/>
+  <rect x="8" y="33" width="23" height="15" fill="#5e6d48" stroke="#4a5a3a" stroke-width="0.5"/>
+  <rect x="33" y="33" width="23" height="15" fill="#5e6d48" stroke="#4a5a3a" stroke-width="0.5"/>
+  <!-- Camo netting patches (symmetric pairs) -->
+  <polygon points="10,18 20,22 14,28" fill="#7a8a66" opacity="0.35"/>
+  <polygon points="54,18 44,22 50,28" fill="#7a8a66" opacity="0.35"/>
+  <polygon points="18,38 28,42 22,48" fill="#7a8a66" opacity="0.35"/>
+  <polygon points="46,38 36,42 42,48" fill="#7a8a66" opacity="0.35"/>
+  <!-- Roof structural lines -->
+  <line x1="32" y1="14" x2="32" y2="50" stroke="#4a5a3a" stroke-width="1"/>
+  <line x1="6" y1="32" x2="58" y2="32" stroke="#4a5a3a" stroke-width="0.6"/>
+  <!-- Entry door (bottom center) -->
+  <rect x="26" y="44" width="12" height="6" fill="#3a4a2a" stroke="#2a3a1a" stroke-width="0.5"/>
+  <!-- Rebel Alliance starbird insignia on roof -->
+  <polygon points="32,20 35,26 39,28 35,29 32,34 29,29 25,28 29,26" fill="#c45a2a" opacity="0.65"/>
+  <!-- Supply crates beside building (symmetric) -->
+  <rect x="2" y="20" width="4" height="4" fill="#8a7a5a" stroke="#6a5a3a" stroke-width="0.5"/>
+  <rect x="58" y="20" width="4" height="4" fill="#8a7a5a" stroke="#6a5a3a" stroke-width="0.5"/>
+  <rect x="1" y="26" width="4" height="3" fill="#7a6a4a" stroke="#6a5a3a" stroke-width="0.5"/>
+  <rect x="59" y="26" width="4" height="3" fill="#7a6a4a" stroke="#6a5a3a" stroke-width="0.5"/>
+  <!-- Ventilation units on roof (symmetric) -->
+  <rect x="14" y="22" width="4" height="3" fill="#556b44" stroke="#4a5a3a" stroke-width="0.4"/>
+  <rect x="46" y="22" width="4" height="3" fill="#556b44" stroke="#4a5a3a" stroke-width="0.4"/>
+  <!-- Communication antenna mast -->
+  <circle cx="32" cy="17" r="1.5" fill="#555555" stroke="#444444" stroke-width="0.5"/>
+  <!-- Roof edge highlight -->
+  <line x1="6" y1="14" x2="58" y2="14" stroke="#8a9a76" stroke-width="0.6" opacity="0.5"/>
 </svg>

--- a/public/assets/raptor/terrain/struct_hangar.svg
+++ b/public/assets/raptor/terrain/struct_hangar.svg
@@ -1,11 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Main building (rounded rectangle) -->
-  <rect x="4" y="16" width="56" height="44" rx="6" ry="6" fill="#666666"/>
-  <!-- Roof ribs -->
-  <rect x="4" y="12" width="56" height="8" rx="4" ry="4" fill="#555555"/>
-  <rect x="12" y="14" width="8" height="4" fill="#555555"/>
-  <rect x="28" y="14" width="8" height="4" fill="#555555"/>
-  <rect x="44" y="14" width="8" height="4" fill="#555555"/>
-  <!-- Large door opening -->
-  <rect x="4" y="28" width="16" height="28" rx="2" ry="2" fill="#333333"/>
+  <!-- Outer hangar structure - curved Goa'uld architecture -->
+  <ellipse cx="32" cy="34" rx="28" ry="24" fill="#b8860b" stroke="#8b6508" stroke-width="1.5"/>
+  <!-- Inner wall layer -->
+  <ellipse cx="32" cy="34" rx="24" ry="20" fill="#cd9b1d" stroke="#a07808" stroke-width="1"/>
+  <!-- Bronze panel rings (organic curves) -->
+  <ellipse cx="32" cy="34" rx="20" ry="16" fill="none" stroke="#8b6508" stroke-width="0.6"/>
+  <ellipse cx="32" cy="34" rx="14" ry="11" fill="none" stroke="#8b6508" stroke-width="0.5"/>
+  <!-- Translucent roof showing interior -->
+  <ellipse cx="32" cy="34" rx="16" ry="13" fill="#a08510" opacity="0.6"/>
+  <!-- Death Glider silhouette visible through roof -->
+  <polygon points="32,26 42,40 44,44 32,38 20,44 22,40" fill="#5a4a0a" opacity="0.45"/>
+  <!-- Death Glider swept wing tips -->
+  <line x1="42" y1="40" x2="46" y2="46" stroke="#4a3a08" stroke-width="1.5" opacity="0.35"/>
+  <line x1="22" y1="40" x2="18" y2="46" stroke="#4a3a08" stroke-width="1.5" opacity="0.35"/>
+  <!-- Energy field entrance (top, cyan barrier) -->
+  <ellipse cx="32" cy="10" rx="12" ry="3" fill="#00ccee" opacity="0.5"/>
+  <ellipse cx="32" cy="10" rx="10" ry="2" fill="#66eeff" opacity="0.4"/>
+  <!-- Goa'uld golden accent ridges (symmetric) -->
+  <line x1="8" y1="20" x2="8" y2="48" stroke="#daa520" stroke-width="1.5" opacity="0.6"/>
+  <line x1="56" y1="20" x2="56" y2="48" stroke="#daa520" stroke-width="1.5" opacity="0.6"/>
+  <!-- Goa'uld eye motifs on flanks (symmetric) -->
+  <ellipse cx="12" cy="34" rx="3" ry="4" fill="#daa520" opacity="0.4"/>
+  <ellipse cx="52" cy="34" rx="3" ry="4" fill="#daa520" opacity="0.4"/>
+  <circle cx="12" cy="34" r="1.5" fill="#ffcc00" opacity="0.6"/>
+  <circle cx="52" cy="34" r="1.5" fill="#ffcc00" opacity="0.6"/>
+  <!-- Central Goa'uld emblem -->
+  <circle cx="32" cy="34" r="3" fill="#daa520" stroke="#8b6508" stroke-width="0.8"/>
+  <circle cx="32" cy="34" r="1.5" fill="#ffcc00"/>
+  <!-- Structural ribs -->
+  <line x1="32" y1="10" x2="32" y2="58" stroke="#8b6508" stroke-width="0.8" opacity="0.5"/>
+  <line x1="4" y1="34" x2="60" y2="34" stroke="#8b6508" stroke-width="0.6" opacity="0.4"/>
 </svg>


### PR DESCRIPTION
## PR: Raptor — Replace base structure SVGs with Star Wars/Stargate themed art (Issue #393)

### Summary (what changed & why)
This PR replaces three **military base structure** terrain assets in the Raptor game with **high-quality Star Wars/Stargate themed SVG artwork** to align the game’s visuals with the broader sci‑fi art direction (part of epic #378).

The asset keys, filenames, and rendering pipeline remain unchanged—this is a **pure asset swap** to avoid any code/config impact while upgrading in-game visuals.

### What’s included
- **`struct_barracks.svg`**: Rebel Alliance / SGC-style field barracks (prefab housing, camo netting, supply crates, insignia)
- **`struct_aa_gun.svg`**: Imperial turbolaser emplacement (octagonal platform, twin barrels, power conduits, red sensors)
- **`struct_hangar.svg`**: Goa’uld hangar bay (curved gold/bronze architecture, cyan energy field entrance, Death Glider silhouette)

All three SVGs:
- Use `viewBox="0 0 64 64"`
- Have **transparent backgrounds**
- Use **basic SVG shapes only** (no filters/clipPaths/styles)
- Are designed to look natural when **horizontally mirrored** (Raptor randomly mirrors structures)

### Key files modified
- `public/assets/raptor/terrain/struct_barracks.svg`
- `public/assets/raptor/terrain/struct_aa_gun.svg`
- `public/assets/raptor/terrain/struct_hangar.svg`

_No TypeScript changes._ (Manifest/loader/renderer/levels remain intact.)

### Where this appears in-game
- Level 4 **“Arctic Thunder”**: `struct_barracks` (icy ground `#e0e8ee` — asset designed for contrast)
- Level 5 **“Final Fortress”**: `struct_aa_gun`, `struct_hangar` (dark ground `#3a3a3a` — assets tuned for readability)

### Testing notes
Manual / visual validation:
- Loaded Raptor and verified structures render without missing-asset errors.
- Confirmed readability at **32–64px** scale range used by `TerrainRenderer`.
- Verified **mirrored** placements look correct (no directional text/markings that break when flipped).
- Checked transparency and that no full-background rect obscures terrain.

Automation:
- Run existing test suite (no expected behavior changes): `npm test` (no Raptor-specific structure tests, but ensures no regressions elsewhere).

Ref: https://github.com/asgardtech/archer/issues/393