### PR TITLE
raptor: the horizon should not be there, all we should see are terrain and from above, no horizon line

### DIFF
--- a/src/games/raptor/rendering/TerrainRenderer.ts
+++ b/src/games/raptor/rendering/TerrainRenderer.ts
@@ -7,7 +7,6 @@ const MAX_STRUCTURES_PER_SEGMENT = 4;
 const MAX_PROPS_PER_SEGMENT = 8;
 const MAX_AMBIENT_PARTICLES = 100;
 const GROUND_SCROLL_SPEED = 60;
-const HORIZON_SCROLL_SPEED = 0.15;
 
 interface PlacedObject {
   asset: string;
@@ -53,7 +52,6 @@ export class TerrainRenderer {
   private config: TerrainLayerConfig | null = null;
   private segments: TerrainSegment[] = [];
   private ambientParticles: AmbientParticle[] = [];
-  private horizonY = 0;
   private scrollOffset = 0;
 
   constructor(width: number, height: number, assets: AssetLoader) {
@@ -82,7 +80,6 @@ export class TerrainRenderer {
   reset(): void {
     this.segments = [];
     this.ambientParticles = [];
-    this.horizonY = 0;
     this.scrollOffset = 0;
   }
 
@@ -225,7 +222,6 @@ export class TerrainRenderer {
     if (!this.config) return;
 
     this.scrollOffset += GROUND_SCROLL_SPEED * dt;
-    this.horizonY += GROUND_SCROLL_SPEED * HORIZON_SCROLL_SPEED * dt;
 
     for (const seg of this.segments) {
       seg.y += GROUND_SCROLL_SPEED * 0.6 * dt;
@@ -269,32 +265,15 @@ export class TerrainRenderer {
 
   render(ctx: CanvasRenderingContext2D): void {
     if (!this.config) return;
-    this.renderHorizon(ctx);
     this.renderGround(ctx);
     this.renderStructures(ctx);
     this.renderAmbientParticles(ctx);
   }
 
-  renderHorizon(ctx: CanvasRenderingContext2D): void {
-    if (!this.config) return;
-
-    const horizonHeight = 200;
-    const horizonScreenY = this.height * 0.15 + (this.horizonY % 20);
-
-    for (const assetKey of this.config.horizonAssets) {
-      const img = this.assets.getOptional(assetKey);
-      if (!img) continue;
-      ctx.save();
-      ctx.globalAlpha = 0.6;
-      ctx.drawImage(img, 0, horizonScreenY - horizonHeight * 0.5, this.width, horizonHeight);
-      ctx.restore();
-    }
-  }
-
   renderGround(ctx: CanvasRenderingContext2D): void {
     if (!this.config) return;
 
-    const groundStartY = this.height * 0.25;
+    const groundStartY = 0;
     ctx.save();
     ctx.fillStyle = this.config.groundColor;
     ctx.fillRect(0, groundStartY, this.width, this.height - groundStartY);

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -153,7 +153,7 @@ export interface AmbientParticleConfig {
 
 export interface TerrainLayerConfig {
   theme: LevelTheme;
-  horizonAssets: string[];
+  horizonAssets?: string[];
   groundColor: string;
   groundTexture?: string;
   structurePool: string[];


### PR DESCRIPTION
## PR: Remove horizon rendering for pure top-down terrain view (raptor)

### Summary
This change removes the horizon layer from raptor’s terrain-based levels to enforce a strict top-down aerial perspective. Previously, the renderer drew a horizon/sky band with distant landscape imagery near the top of the screen, which implied a forward-facing view. Now, the entire viewport is filled with terrain from `y = 0` to the bottom of the canvas—no horizon line, no visible sky band.

### Why
Issue requirement: **“the horizon should not be there, all we should see are terrain and from above, no horizon line.”**  
This aligns the visual presentation with the intended bird’s-eye camera style across all terrain levels.

---

### Key changes
- **Removed horizon rendering entirely**
  - Deleted `renderHorizon()` and removed its call from `TerrainRenderer.render()`.
  - Removed horizon scrolling state and related constants (`horizonY`, `HORIZON_SCROLL_SPEED`) and the update/reset logic tied to them.
- **Extended ground rendering to cover the full canvas**
  - Ground fill now starts at `y = 0` (previously started at `height * 0.25`), ensuring the sky gradient/background is fully occluded during terrain levels.
- **Type cleanup (backwards-compatible)**
  - Made `horizonAssets` optional in `TerrainLayerConfig` so future terrain configs aren’t required to define unused horizon assets.

---

### Files modified
- `src/games/raptor/rendering/TerrainRenderer.ts`
  - Removed horizon rendering + horizon scroll state
  - Ground starts at `y=0` to fill the entire viewport
- `src/games/raptor/types.ts`
  - `TerrainLayerConfig.horizonAssets` changed to optional

---

### Testing notes
- Manually verify on all **5 terrain levels** (e.g., Coastal Patrol, Desert Strike, Mountain Assault, Arctic Thunder, Final Fortress):
  - No horizon imagery appears (no distant hills/water/buildings band)
  - No visible sky band at the top; terrain begins at the top edge (`y=0`)
  - Ground texture tiling covers the full height
  - Structures/props/water/roads and ambient particles render normally across the full viewport
- Verify **non-terrain levels** remain unchanged (TerrainRenderer not invoked; background layers behave as before).

Ref: https://github.com/asgardtech/archer/issues/412