### PR TITLE
raptor: features of the terrain should not be stretched, it looks very weird

### DIFF
--- a/src/games/raptor/rendering/TerrainRenderer.ts
+++ b/src/games/raptor/rendering/TerrainRenderer.ts
@@ -129,8 +129,13 @@ export class TerrainRenderer {
       const asset = this.config.structurePool[
         Math.floor(Math.random() * this.config.structurePool.length)
       ];
-      const w = 32 + Math.random() * 32;
-      const h = 32 + Math.random() * 32;
+      const size = 32 + Math.random() * 32;
+      const img = this.assets.getOptional(asset);
+      const aspectRatio = img && img.naturalWidth && img.naturalHeight
+        ? img.naturalWidth / img.naturalHeight
+        : 1;
+      const w = size * aspectRatio;
+      const h = size;
       const placed = this.tryPlace(w, h, occupiedRects);
       if (placed) {
         segment.structures.push({
@@ -153,8 +158,13 @@ export class TerrainRenderer {
       const asset = this.config.propPool[
         Math.floor(Math.random() * this.config.propPool.length)
       ];
-      const w = 12 + Math.random() * 16;
-      const h = 12 + Math.random() * 16;
+      const size = 12 + Math.random() * 16;
+      const img = this.assets.getOptional(asset);
+      const aspectRatio = img && img.naturalWidth && img.naturalHeight
+        ? img.naturalWidth / img.naturalHeight
+        : 1;
+      const w = size * aspectRatio;
+      const h = size;
       segment.props.push({
         asset,
         x: Math.random() * (this.width - w),


### PR DESCRIPTION
## PR: raptor — Preserve aspect ratio for terrain structures and props (fix stretched terrain features)

### Summary / Why
Terrain features in Raptor (structures + props) were sometimes appearing stretched or squished because their render `width` and `height` were generated using **independent random values**, breaking the original artwork proportions. All current terrain SVG assets are authored with a square `64×64` viewBox, so non-uniform scaling looked especially weird (e.g., lighthouses/palms/cacti appearing tall-and-thin or short-and-wide).

This change fixes the distortion by using a **single randomized size scalar per object** and computing dimensions using the source image’s **natural aspect ratio**, preserving intended proportions while keeping the existing size variation.

### What changed
- **Structures:** replaced independent `w/h` randomness with one randomized `size`, then derived `w` and `h` from the asset’s intrinsic aspect ratio.
- **Props:** same approach as structures.
- **Safety fallback:** if the image is missing/not loaded (`getOptional()` returns null) or has `naturalWidth/naturalHeight` of `0`, we fall back to a `1:1` aspect ratio to avoid errors and preserve prior behavior.

### Key files modified
- `src/games/raptor/rendering/TerrainRenderer.ts`
  - Updated `createSegment()` sizing logic for both **structures** and **props** to preserve aspect ratio based on `img.naturalWidth / img.naturalHeight`.

### Testing notes
Manual verification recommended:
- Run Raptor on terrain-enabled levels and visually confirm **no stretching/squishing** of structures/props (levels 1–5 if applicable).
- Confirm **size variation still exists** (same asset appears at different overall sizes, but always proportionally).
- Resize the window to force terrain regeneration and confirm aspect ratio is still preserved after `resize()`/segment re-init.
- Spot-check mirrored objects still look correct (only horizontal flip changes).
- Optional: simulate a missing/unloaded asset and verify it renders with a safe `1:1` fallback and no runtime error.

Fixes: **raptor: features of the terrain should not be stretched, it looks very weird**

Ref: https://github.com/asgardtech/archer/issues/413