### PR TITLE
raptor: missile flight path makes it so that missiles sometimes fly ass backwards, or on the side

### DIFF
--- a/src/games/raptor/entities/Bullet.ts
+++ b/src/games/raptor/entities/Bullet.ts
@@ -51,7 +51,7 @@ export class Bullet implements Projectile {
     ctx.save();
     if (this.angle !== 0) {
       ctx.translate(this.pos.x, this.pos.y);
-      ctx.rotate(-this.angle);
+      ctx.rotate(this.angle);
       ctx.drawImage(this.sprite!, -this.width / 2, -this.height / 2, this.width, this.height);
     } else {
       ctx.drawImage(

--- a/src/games/raptor/entities/Missile.ts
+++ b/src/games/raptor/entities/Missile.ts
@@ -93,7 +93,7 @@ export class Missile implements Projectile {
   private renderSprite(ctx: CanvasRenderingContext2D): void {
     ctx.save();
     ctx.translate(this.pos.x, this.pos.y);
-    ctx.rotate(-this.angle);
+    ctx.rotate(this.angle);
     ctx.drawImage(this.sprite!, -this.width / 2, -this.height / 2, this.width, this.height);
     ctx.restore();
   }
@@ -101,7 +101,7 @@ export class Missile implements Projectile {
   private renderFallback(ctx: CanvasRenderingContext2D): void {
     ctx.save();
     ctx.translate(this.pos.x, this.pos.y);
-    ctx.rotate(-this.angle);
+    ctx.rotate(this.angle);
 
     ctx.fillStyle = "#ff6644";
     ctx.beginPath();


### PR DESCRIPTION
## PR: raptor — Fix missile (and bullet) sprite rotation to match flight direction

### Summary / Why
Missiles in **Raptor Skies** sometimes appeared to fly backwards or sideways even though their physics/homing behavior was correct. The issue was purely visual: the canvas rotation applied during rendering used the **negated heading angle** (`-this.angle`), mirroring the sprite relative to the actual velocity vector.

This PR updates rendering so the missile (SVG sprite and fallback procedural shape) rotates using the **correct sign** (`this.angle`). It also applies the same correction to bullets for consistency (the visual impact for bullets is subtle due to small spread angles, but the logic should match across projectiles).

### What changed
- Fixed inverted rotation sign in missile rendering:
  - `Missile.renderSprite()`: `ctx.rotate(-this.angle)` → `ctx.rotate(this.angle)`
  - `Missile.renderFallback()`: `ctx.rotate(-this.angle)` → `ctx.rotate(this.angle)`
- Fixed the same rotation sign issue in bullet sprite rendering for consistency:
  - `Bullet.renderSprite()`: `ctx.rotate(-this.angle)` → `ctx.rotate(this.angle)`

### Key files modified
- `src/games/raptor/entities/Missile.ts`
  - Corrected rotation direction in both sprite and fallback render paths.
- `src/games/raptor/entities/Bullet.ts`
  - Corrected rotation direction in sprite render path.

### Testing notes
Manual/visual verification recommended:
- Fire missiles at enemies positioned to the **left** and **right** of the player:
  - Warhead should always point in the direction of travel / toward the homing target.
- Verify both rendering modes:
  - With sprite loaded (SVG) and with fallback procedural rendering.
- Fire spread shots:
  - Missiles (e.g., `-0.25, 0, +0.25` rad) and bullets (e.g., `-0.2, 0, +0.2` rad) should “lean” in the correct direction and never appear mirrored.

No gameplay/physics changes expected—only visual orientation during rendering.

Ref: https://github.com/asgardtech/archer/issues/414