### PR TITLE
raptor: I should be able to save/load progress

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,10 +1,11 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, RaptorSaveData } from "./types";
 import { InputManager } from "./systems/InputManager";
 import { CollisionSystem } from "./systems/CollisionSystem";
 import { EnemySpawner } from "./systems/EnemySpawner";
 import { PowerUpManager } from "./systems/PowerUpManager";
 import { SoundSystem } from "./systems/SoundSystem";
 import { WeaponSystem } from "./systems/WeaponSystem";
+import { SaveSystem } from "./systems/SaveSystem";
 import { Player } from "./entities/Player";
 import { Bullet } from "./entities/Bullet";
 import { Missile } from "./entities/Missile";
@@ -313,6 +314,12 @@ export class RaptorGame implements IGame {
       return true;
     }
 
+    if (this.hud.isClearSaveButtonHit(mx, my, this.width, this.height)) {
+      SaveSystem.clear();
+      this.input.consume();
+      return true;
+    }
+
     if (!this.hud.isSettingsPanelHit(mx, my, this.width, this.height)) {
       this.settingsOpen = false;
       this.input.consume();
@@ -337,11 +344,29 @@ export class RaptorGame implements IGame {
       case "menu":
         this.updateBackground(dt);
         if (this.input.wasClicked) {
-          this.audio.ensureContext();
-          this.sound.play("menu_start");
-          this.resetGame();
-          this.state = "playing";
-          this.sound.startMusic("playing", 0);
+          const hasSave = this.hasSaveData;
+          if (hasSave) {
+            if (this.hud.isContinueButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+              this.audio.ensureContext();
+              this.sound.play("menu_start");
+              this.continueGame();
+              this.state = "playing";
+              this.sound.startMusic("playing", this.currentLevel);
+            } else if (this.hud.isNewGameButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+              this.audio.ensureContext();
+              this.sound.play("menu_start");
+              SaveSystem.clear();
+              this.resetGame();
+              this.state = "playing";
+              this.sound.startMusic("playing", 0);
+            }
+          } else {
+            this.audio.ensureContext();
+            this.sound.play("menu_start");
+            this.resetGame();
+            this.state = "playing";
+            this.sound.startMusic("playing", 0);
+          }
         }
         break;
 
@@ -603,9 +628,18 @@ export class RaptorGame implements IGame {
       if (this.currentLevel >= LEVELS.length - 1) {
         this.state = "victory";
         this.sound.play("victory");
+        SaveSystem.clear();
       } else {
         this.state = "level_complete";
         this.sound.play("level_complete");
+        SaveSystem.save({
+          version: 1,
+          levelReached: this.currentLevel + 1,
+          totalScore: this.totalScore,
+          lives: this.player.lives,
+          weapon: this.powerUpManager.currentWeapon,
+          savedAt: new Date().toISOString(),
+        });
       }
     }
   }
@@ -668,10 +702,27 @@ export class RaptorGame implements IGame {
     }
   }
 
+  get hasSaveData(): boolean {
+    return SaveSystem.hasSave();
+  }
+
   private resetGame(): void {
     this.totalScore = 0;
     this.vfx.reset();
     this.startLevel(0, true);
+  }
+
+  private continueGame(): void {
+    const data = SaveSystem.load();
+    if (!data) {
+      this.resetGame();
+      return;
+    }
+    this.totalScore = data.totalScore;
+    this.vfx.reset();
+    this.startLevel(data.levelReached, false);
+    this.player.lives = data.lives;
+    this.powerUpManager.setWeapon(data.weapon);
   }
 
   private startLevel(levelIndex: number, fullReset = false): void {
@@ -876,7 +927,8 @@ export class RaptorGame implements IGame {
       this.width,
       this.height,
       this.powerUpManager.getActive(),
-      this.weaponSystem.currentWeapon
+      this.weaponSystem.currentWeapon,
+      this.hasSaveData
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
     this.hud.renderSettingsButton(this.ctx, this.width);
@@ -884,7 +936,8 @@ export class RaptorGame implements IGame {
     if (this.settingsOpen) {
       this.hud.renderSettingsPanel(
         this.ctx, this.width, this.height,
-        this.audio.musicVolume, this.audio.sfxVolume
+        this.audio.musicVolume, this.audio.sfxVolume,
+        this.hasSaveData
       );
     }
   }

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -163,12 +163,27 @@ export class HUD {
     return { x: px + panelW - btnW - 10, y: py + 10, w: btnW, h: btnH };
   }
 
+  private getClearSaveButtonRect(width: number, height: number) {
+    const { px, py, panelW, panelH } = this.getSettingsPanelRect(width, height);
+    const btnW = 140;
+    const btnH = 28;
+    const btnX = px + (panelW - btnW) / 2;
+    const btnY = py + panelH - btnH - 16;
+    return { x: btnX, y: btnY, w: btnW, h: btnH };
+  }
+
+  isClearSaveButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    const btn = this.getClearSaveButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
   renderSettingsPanel(
     ctx: CanvasRenderingContext2D,
     width: number,
     height: number,
     musicVolume: number,
-    sfxVolume: number
+    sfxVolume: number,
+    hasSave?: boolean
   ): void {
     ctx.save();
 
@@ -210,6 +225,18 @@ export class HUD {
 
     const sfxSlider = this.getSfxSliderLayout(width, height);
     this.renderSlider(ctx, sfxSlider, sfxVolume, "SFX");
+
+    if (hasSave) {
+      const csBtn = this.getClearSaveButtonRect(width, height);
+      ctx.fillStyle = "rgba(231, 76, 60, 0.8)";
+      this.roundedRect(ctx, csBtn.x, csBtn.y, csBtn.w, csBtn.h, 5);
+      ctx.fill();
+      ctx.font = `8px ${RETRO_FONT}`;
+      ctx.fillStyle = "#FFFFFF";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("Clear Save", csBtn.x + csBtn.w / 2, csBtn.y + csBtn.h / 2);
+    }
 
     ctx.restore();
   }
@@ -311,13 +338,14 @@ export class HUD {
     width: number,
     height: number,
     activeEffects?: ReadonlyArray<ActiveEffect>,
-    currentWeapon?: WeaponType
+    currentWeapon?: WeaponType,
+    hasSave?: boolean
   ): void {
     switch (state) {
       case "loading":
         break;
       case "menu":
-        this.renderMenu(ctx, width, height);
+        this.renderMenu(ctx, width, height, hasSave);
         break;
       case "playing":
         this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon);
@@ -391,16 +419,49 @@ export class HUD {
     return this.isTouchDevice ? `Tap ${suffix}` : `Click ${suffix}`;
   }
 
-  private renderMenu(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  private getMenuPanelRect(width: number, height: number) {
+    const panelW = 420;
+    const panelH = 220;
+    const px = (width - panelW) / 2;
+    const py = (height - panelH) / 2 - 10;
+    return { px, py, panelW, panelH };
+  }
+
+  private getContinueButtonRect(width: number, height: number) {
+    const { px, py, panelW } = this.getMenuPanelRect(width, height);
+    const btnW = 180;
+    const btnH = 32;
+    const btnX = px + (panelW / 2 - btnW) / 2;
+    const btnY = py + 125;
+    return { x: btnX, y: btnY, w: btnW, h: btnH };
+  }
+
+  private getNewGameButtonRect(width: number, height: number) {
+    const { px, py, panelW } = this.getMenuPanelRect(width, height);
+    const btnW = 180;
+    const btnH = 32;
+    const btnX = px + panelW / 2 + (panelW / 2 - btnW) / 2;
+    const btnY = py + 125;
+    return { x: btnX, y: btnY, w: btnW, h: btnH };
+  }
+
+  isContinueButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    const btn = this.getContinueButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  isNewGameButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    const btn = this.getNewGameButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  private renderMenu(ctx: CanvasRenderingContext2D, width: number, height: number, hasSave?: boolean): void {
     ctx.save();
 
     ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
     ctx.fillRect(0, 0, width, height);
 
-    const panelW = 420;
-    const panelH = 220;
-    const px = (width - panelW) / 2;
-    const py = (height - panelH) / 2 - 10;
+    const { px, py, panelW, panelH } = this.getMenuPanelRect(width, height);
 
     const panelGrad = ctx.createLinearGradient(px, py, px, py + panelH);
     panelGrad.addColorStop(0, "rgba(20, 30, 60, 0.85)");
@@ -424,13 +485,39 @@ export class HUD {
     ctx.fillStyle = "#B0C4DE";
     ctx.fillText("A Vertical Scrolling Shoot-em-up", width / 2, py + 90);
 
-    ctx.font = `10px ${RETRO_FONT}`;
-    ctx.fillStyle = "#FFD700";
-    ctx.fillText(
-      this.isTouchDevice ? "Tap to Start" : "Click to Start",
-      width / 2,
-      py + 140
-    );
+    if (hasSave) {
+      const contBtn = this.getContinueButtonRect(width, height);
+      ctx.fillStyle = "#2ecc71";
+      this.roundedRect(ctx, contBtn.x, contBtn.y, contBtn.w, contBtn.h, 6);
+      ctx.fill();
+      ctx.font = `10px ${RETRO_FONT}`;
+      ctx.fillStyle = "#FFFFFF";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("Continue", contBtn.x + contBtn.w / 2, contBtn.y + contBtn.h / 2);
+
+      const newBtn = this.getNewGameButtonRect(width, height);
+      ctx.fillStyle = "rgba(255, 255, 255, 0.15)";
+      this.roundedRect(ctx, newBtn.x, newBtn.y, newBtn.w, newBtn.h, 6);
+      ctx.fill();
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.3)";
+      ctx.lineWidth = 1;
+      this.roundedRect(ctx, newBtn.x, newBtn.y, newBtn.w, newBtn.h, 6);
+      ctx.stroke();
+      ctx.font = `10px ${RETRO_FONT}`;
+      ctx.fillStyle = "#B0C4DE";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("New Game", newBtn.x + newBtn.w / 2, newBtn.y + newBtn.h / 2);
+    } else {
+      ctx.font = `10px ${RETRO_FONT}`;
+      ctx.fillStyle = "#FFD700";
+      ctx.fillText(
+        this.isTouchDevice ? "Tap to Start" : "Click to Start",
+        width / 2,
+        py + 140
+      );
+    }
 
     ctx.font = `7px ${RETRO_FONT}`;
     ctx.fillStyle = "#8899AA";

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -1,0 +1,77 @@
+import { RaptorSaveData, WeaponType } from "../types";
+import { LEVELS } from "../levels";
+import { tryGetStorage, trySetStorage, tryRemoveStorage } from "../../../shared/storage";
+
+const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser"];
+
+export class SaveSystem {
+  private static readonly STORAGE_KEY = "raptor_save";
+
+  static save(data: RaptorSaveData): void {
+    trySetStorage(this.STORAGE_KEY, JSON.stringify(data));
+  }
+
+  static load(): RaptorSaveData | null {
+    const raw = tryGetStorage(this.STORAGE_KEY, "");
+    if (!raw) return null;
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (!this.validate(parsed)) return null;
+      return parsed as RaptorSaveData;
+    } catch {
+      return null;
+    }
+  }
+
+  static clear(): void {
+    tryRemoveStorage(this.STORAGE_KEY);
+  }
+
+  static hasSave(): boolean {
+    const raw = tryGetStorage(this.STORAGE_KEY, "");
+    if (!raw) return false;
+
+    try {
+      const parsed = JSON.parse(raw);
+      return this.validate(parsed);
+    } catch {
+      return false;
+    }
+  }
+
+  private static validate(data: unknown): data is RaptorSaveData {
+    if (typeof data !== "object" || data === null) return false;
+
+    const d = data as Record<string, unknown>;
+
+    if (d.version !== 1) return false;
+
+    if (
+      typeof d.levelReached !== "number" ||
+      !Number.isInteger(d.levelReached) ||
+      d.levelReached < 0 ||
+      d.levelReached >= LEVELS.length
+    ) {
+      return false;
+    }
+
+    if (typeof d.totalScore !== "number" || d.totalScore < 0) return false;
+
+    if (
+      typeof d.lives !== "number" ||
+      !Number.isInteger(d.lives) ||
+      d.lives <= 0
+    ) {
+      return false;
+    }
+
+    if (typeof d.weapon !== "string" || !VALID_WEAPONS.includes(d.weapon as WeaponType)) {
+      return false;
+    }
+
+    if (typeof d.savedAt !== "string" || d.savedAt.length === 0) return false;
+
+    return true;
+  }
+}

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -53,6 +53,20 @@ export type RaptorSoundEvent =
 
 export type WeaponType = "machine-gun" | "missile" | "laser";
 
+export interface RaptorSaveData {
+  version: 1;
+  /** The highest level index the player has unlocked (0-based). */
+  levelReached: number;
+  /** Cumulative score at the time of save. */
+  totalScore: number;
+  /** Player lives remaining at save point. */
+  lives: number;
+  /** Active weapon type at save point. */
+  weapon: WeaponType;
+  /** ISO-8601 timestamp of when the save was created. */
+  savedAt: string;
+}
+
 export interface WeaponConfig {
   type: WeaponType;
   damage: number;

--- a/src/shared/AudioManager.ts
+++ b/src/shared/AudioManager.ts
@@ -1,3 +1,5 @@
+import { tryGetStorage, trySetStorage } from "./storage";
+
 export interface EnvelopeParams {
   attack: number;
   decay: number;
@@ -17,22 +19,6 @@ const DEFAULT_ENVELOPE: EnvelopeParams = {
   sustain: 0.6,
   release: 0.1,
 };
-
-function tryGetStorage(key: string, fallback: string): string {
-  try {
-    return localStorage.getItem(key) ?? fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function trySetStorage(key: string, value: string): void {
-  try {
-    localStorage.setItem(key, value);
-  } catch {
-    // localStorage unavailable — silently ignore
-  }
-}
 
 export type AudioCategory = "music" | "sfx";
 

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,0 +1,23 @@
+export function tryGetStorage(key: string, fallback: string): string {
+  try {
+    return localStorage.getItem(key) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function trySetStorage(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // localStorage unavailable — silently ignore
+  }
+}
+
+export function tryRemoveStorage(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // localStorage unavailable — silently ignore
+  }
+}

--- a/tests/raptor-save.test.ts
+++ b/tests/raptor-save.test.ts
@@ -1,0 +1,644 @@
+import { SaveSystem } from "../src/games/raptor/systems/SaveSystem";
+import { RaptorSaveData, WeaponType } from "../src/games/raptor/types";
+import { LEVELS } from "../src/games/raptor/levels";
+import { raptorDescriptor } from "../src/games/raptor";
+
+// ─── Test Helpers ───────────────────────────────────────────────
+
+let mockStorage: Record<string, string> = {};
+
+beforeEach(() => {
+  mockStorage = {};
+  (global as any).localStorage = {
+    getItem: jest.fn((key: string) => mockStorage[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => { mockStorage[key] = value; }),
+    removeItem: jest.fn((key: string) => { delete mockStorage[key]; }),
+  };
+});
+
+afterEach(() => {
+  delete (global as any).localStorage;
+});
+
+function createMockCanvas(): HTMLCanvasElement {
+  const fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
+  const ctx = {
+    fillText: jest.fn((text: string, x: number, y: number) => {
+      fillTextCalls.push({ text, x, y });
+    }),
+    fillRect: jest.fn(),
+    strokeRect: jest.fn(),
+    fillStyle: "",
+    font: "",
+    textAlign: "",
+    textBaseline: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    globalAlpha: 1,
+    shadowColor: "",
+    shadowBlur: 0,
+    save: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    closePath: jest.fn(),
+    fill: jest.fn(),
+    stroke: jest.fn(),
+    arc: jest.fn(),
+    arcTo: jest.fn(),
+    ellipse: jest.fn(),
+    quadraticCurveTo: jest.fn(),
+    translate: jest.fn(),
+    rotate: jest.fn(),
+    roundRect: jest.fn(),
+    drawImage: jest.fn(),
+    setTransform: jest.fn(),
+    createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
+    measureText: jest.fn(() => ({ width: 50 })),
+  };
+
+  const canvas = {
+    getContext: jest.fn(() => ctx),
+    width: 800,
+    height: 600,
+    style: {} as CSSStyleDeclaration,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    getBoundingClientRect: jest.fn(() => ({
+      left: 0, top: 0, right: 800, bottom: 600, width: 800, height: 600,
+    })),
+  } as unknown as HTMLCanvasElement;
+
+  (canvas as any).__ctx = ctx;
+  (canvas as any).__fillTextCalls = fillTextCalls;
+  return canvas;
+}
+
+function setupDom(canvas: HTMLCanvasElement): void {
+  (global as any).document = {
+    getElementById: jest.fn(() => canvas),
+  };
+  (global as any).HTMLCanvasElement = class HTMLCanvasElement {};
+  Object.setPrototypeOf(canvas, (global as any).HTMLCanvasElement.prototype);
+  (global as any).window = {
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    innerWidth: 800,
+    innerHeight: 600,
+    devicePixelRatio: 1,
+  };
+  (global as any).navigator = { maxTouchPoints: 0 };
+  (global as any).performance = { now: jest.fn(() => 0) };
+  (global as any).requestAnimationFrame = jest.fn((_cb: Function) => 1);
+  (global as any).cancelAnimationFrame = jest.fn();
+  (global as any).setTimeout = setTimeout;
+  (global as any).clearTimeout = clearTimeout;
+  (global as any).setInterval = setInterval;
+  (global as any).clearInterval = clearInterval;
+}
+
+function createPlayingGame(): { game: any; canvas: HTMLCanvasElement } {
+  const canvas = createMockCanvas();
+  setupDom(canvas);
+  const game = raptorDescriptor.createGame(canvas) as any;
+  game.state = "playing";
+  game.score = 0;
+  game.player.lives = 3;
+  game.player.shield = 100;
+  game.player.alive = true;
+  return { game, canvas };
+}
+
+function validSaveData(overrides?: Partial<RaptorSaveData>): RaptorSaveData {
+  return {
+    version: 1,
+    levelReached: 2,
+    totalScore: 500,
+    lives: 2,
+    weapon: "machine-gun",
+    savedAt: "2026-03-10T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ════════════════════════════════════════════════════════════════
+// SAVE SYSTEM UNIT TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: SaveSystem.save() and load() round-trip correctly", () => {
+  test("save then load returns matching data", () => {
+    const data = validSaveData();
+    SaveSystem.save(data);
+    const loaded = SaveSystem.load();
+    expect(loaded).toEqual(data);
+  });
+
+  test("save stores data under 'raptor_save' key", () => {
+    const data = validSaveData();
+    SaveSystem.save(data);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "raptor_save",
+      JSON.stringify(data)
+    );
+  });
+});
+
+describe("Scenario: SaveSystem.clear() removes saved data", () => {
+  test("hasSave returns false after clear", () => {
+    SaveSystem.save(validSaveData());
+    expect(SaveSystem.hasSave()).toBe(true);
+    SaveSystem.clear();
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+
+  test("load returns null after clear", () => {
+    SaveSystem.save(validSaveData());
+    SaveSystem.clear();
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: SaveSystem.hasSave() returns false when no save exists", () => {
+  test("hasSave returns false with empty storage", () => {
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+});
+
+describe("Scenario: Save data includes a version number for forward compatibility", () => {
+  test("saved data has version field set to 1", () => {
+    const data = validSaveData();
+    SaveSystem.save(data);
+    const loaded = SaveSystem.load();
+    expect(loaded!.version).toBe(1);
+  });
+});
+
+describe("Scenario: Save data includes a timestamp", () => {
+  test("saved data has a valid ISO-8601 savedAt field", () => {
+    const data = validSaveData();
+    SaveSystem.save(data);
+    const loaded = SaveSystem.load();
+    expect(loaded!.savedAt).toBeDefined();
+    const parsed = new Date(loaded!.savedAt);
+    expect(parsed.getTime()).not.toBeNaN();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// VALIDATION TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Corrupt save data is handled gracefully", () => {
+  test("invalid JSON returns null from load", () => {
+    mockStorage["raptor_save"] = "not-json{{{";
+    expect(SaveSystem.load()).toBeNull();
+  });
+
+  test("invalid JSON causes hasSave to return false", () => {
+    mockStorage["raptor_save"] = "not-json{{{";
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+
+  test("no error is thrown for corrupt data", () => {
+    mockStorage["raptor_save"] = "not-json{{{";
+    expect(() => SaveSystem.load()).not.toThrow();
+    expect(() => SaveSystem.hasSave()).not.toThrow();
+  });
+});
+
+describe("Scenario: Save data with out-of-range level is rejected", () => {
+  test("levelReached of 99 is invalid", () => {
+    const data = validSaveData({ levelReached: 99 } as any);
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+
+  test("negative levelReached is invalid", () => {
+    const data = validSaveData({ levelReached: -1 } as any);
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: Save data with zero or negative lives is rejected", () => {
+  test("lives of 0 is invalid", () => {
+    const data = validSaveData({ lives: 0 } as any);
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+
+  test("negative lives is invalid", () => {
+    const data = validSaveData({ lives: -1 } as any);
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: Save data with unknown weapon type is rejected", () => {
+  test("weapon 'plasma-cannon' is invalid", () => {
+    const data = { ...validSaveData(), weapon: "plasma-cannon" };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+});
+
+describe("Scenario: Save data with missing version field is rejected", () => {
+  test("missing version returns null", () => {
+    const data = { ...validSaveData() } as any;
+    delete data.version;
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+
+  test("wrong version number returns null", () => {
+    const data = { ...validSaveData(), version: 2 } as any;
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: localStorage is unavailable", () => {
+  test("save does not throw when localStorage is unavailable", () => {
+    delete (global as any).localStorage;
+    expect(() => SaveSystem.save(validSaveData())).not.toThrow();
+  });
+
+  test("load returns null when localStorage is unavailable", () => {
+    delete (global as any).localStorage;
+    expect(SaveSystem.load()).toBeNull();
+  });
+
+  test("hasSave returns false when localStorage is unavailable", () => {
+    delete (global as any).localStorage;
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+
+  test("clear does not throw when localStorage is unavailable", () => {
+    delete (global as any).localStorage;
+    expect(() => SaveSystem.clear()).not.toThrow();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// VALIDATION EDGE CASES
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Additional validation edge cases", () => {
+  test("valid data for each weapon type loads correctly", () => {
+    const weapons: WeaponType[] = ["machine-gun", "missile", "laser"];
+    for (const weapon of weapons) {
+      const data = validSaveData({ weapon });
+      SaveSystem.save(data);
+      const loaded = SaveSystem.load();
+      expect(loaded!.weapon).toBe(weapon);
+    }
+  });
+
+  test("levelReached at max valid index (LEVELS.length - 1) is valid", () => {
+    const data = validSaveData({ levelReached: LEVELS.length - 1 });
+    SaveSystem.save(data);
+    expect(SaveSystem.load()).not.toBeNull();
+  });
+
+  test("levelReached at 0 is valid", () => {
+    const data = validSaveData({ levelReached: 0 });
+    SaveSystem.save(data);
+    expect(SaveSystem.load()).not.toBeNull();
+  });
+
+  test("non-integer levelReached is rejected", () => {
+    const data = { ...validSaveData(), levelReached: 1.5 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+
+  test("non-integer lives is rejected", () => {
+    const data = { ...validSaveData(), lives: 2.5 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+
+  test("negative totalScore is rejected", () => {
+    const data = { ...validSaveData(), totalScore: -100 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+
+  test("empty savedAt string is rejected", () => {
+    const data = { ...validSaveData(), savedAt: "" };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+
+  test("null data in storage returns null", () => {
+    mockStorage["raptor_save"] = "null";
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// AUTO-SAVE INTEGRATION
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Progress is saved automatically when a level is completed", () => {
+  test("completing a non-final level saves progress", () => {
+    const { game } = createPlayingGame();
+    game.currentLevel = 1;
+    game.totalScore = 200;
+    game.score = 100;
+    game.player.lives = 2;
+    game.powerUpManager.setWeapon("missile");
+    game.spawner.configure(LEVELS[1]);
+
+    for (let t = 0; t < 100; t += 0.1) {
+      game.spawner.update(0.1, 800);
+    }
+    game.enemies = [];
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("level_complete");
+    const saved = SaveSystem.load();
+    expect(saved).not.toBeNull();
+    expect(saved!.levelReached).toBe(2);
+    expect(saved!.totalScore).toBe(300);
+    expect(saved!.lives).toBe(2);
+    expect(saved!.weapon).toBe("missile");
+    expect(saved!.version).toBe(1);
+    expect(saved!.savedAt).toBeDefined();
+  });
+});
+
+describe("Scenario: Save data is cleared on victory", () => {
+  test("completing the final level clears save data", () => {
+    SaveSystem.save(validSaveData());
+    expect(SaveSystem.hasSave()).toBe(true);
+
+    const { game } = createPlayingGame();
+    game.currentLevel = 4;
+    game.spawner.configure(LEVELS[4]);
+
+    for (let t = 0; t < 200; t += 0.1) {
+      game.spawner.update(0.1, 800);
+    }
+    game.spawner.spawnBoss(800);
+    game.spawner.markBossDefeated();
+    game.enemies = [];
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("victory");
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+});
+
+describe("Scenario: Save data is preserved on game over", () => {
+  test("save data survives when player dies", () => {
+    SaveSystem.save(validSaveData({ levelReached: 2 }));
+
+    const { game } = createPlayingGame();
+    game.player.alive = false;
+    game.state = "playing";
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("gameover");
+    expect(SaveSystem.hasSave()).toBe(true);
+    expect(SaveSystem.load()!.levelReached).toBe(2);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CONTINUE & NEW GAME
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Clicking Continue resumes from the saved level", () => {
+  test("continueGame restores saved state", () => {
+    const { game } = createPlayingGame();
+    SaveSystem.save(validSaveData({
+      levelReached: 3,
+      totalScore: 500,
+      lives: 2,
+      weapon: "missile",
+    }));
+
+    (game as any).continueGame();
+
+    expect(game.currentLevel).toBe(3);
+    expect(game.totalScore).toBe(500);
+    expect(game.player.lives).toBe(2);
+    expect(game.powerUpManager.currentWeapon).toBe("missile");
+    expect(game.player.alive).toBe(true);
+  });
+
+  test("continueGame falls back to resetGame when no save exists", () => {
+    const { game } = createPlayingGame();
+
+    (game as any).continueGame();
+
+    expect(game.currentLevel).toBe(0);
+    expect(game.totalScore).toBe(0);
+    expect(game.player.lives).toBe(3);
+  });
+});
+
+describe("Scenario: Starting a New Game clears existing save data", () => {
+  test("new game from menu clears save and starts at level 0", () => {
+    const { game } = createPlayingGame();
+    SaveSystem.save(validSaveData({ levelReached: 3 }));
+    game.state = "menu";
+
+    const newBtn = game.hud.isNewGameButtonHit;
+    expect(typeof newBtn).toBe("function");
+
+    SaveSystem.clear();
+    (game as any).resetGame();
+
+    expect(game.currentLevel).toBe(0);
+    expect(game.totalScore).toBe(0);
+    expect(game.player.lives).toBe(3);
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+});
+
+describe("Scenario: Saved weapon type is restored on continue", () => {
+  test("laser weapon is restored", () => {
+    const { game } = createPlayingGame();
+    SaveSystem.save(validSaveData({ weapon: "laser" }));
+    (game as any).continueGame();
+    expect(game.powerUpManager.currentWeapon).toBe("laser");
+  });
+
+  test("missile weapon is restored", () => {
+    const { game } = createPlayingGame();
+    SaveSystem.save(validSaveData({ weapon: "missile" }));
+    (game as any).continueGame();
+    expect(game.powerUpManager.currentWeapon).toBe("missile");
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// MENU HUD RENDERING
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Menu shows a Continue option when a save exists", () => {
+  test("menu renders Continue and New Game buttons when save exists", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    hud.render(ctx, "menu", 0, 3, 100, 1, "Coastal Patrol", 800, 600, undefined, undefined, true);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    const hasContinue = fillTextCalls.some((c: any) => c.text === "Continue");
+    const hasNewGame = fillTextCalls.some((c: any) => c.text === "New Game");
+    expect(hasContinue).toBe(true);
+    expect(hasNewGame).toBe(true);
+  });
+});
+
+describe("Scenario: Menu shows only Start when no save exists", () => {
+  test("menu renders Click to Start when no save exists", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    hud.render(ctx, "menu", 0, 3, 100, 1, "Coastal Patrol", 800, 600, undefined, undefined, false);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    const hasClick = fillTextCalls.some((c: any) => c.text.includes("Click to Start"));
+    const hasContinue = fillTextCalls.some((c: any) => c.text === "Continue");
+    expect(hasClick).toBe(true);
+    expect(hasContinue).toBe(false);
+  });
+
+  test("menu renders Tap to Start on touch devices when no save exists", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(true);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    hud.render(ctx, "menu", 0, 3, 100, 1, "Coastal Patrol", 800, 600, undefined, undefined, false);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    const hasTap = fillTextCalls.some((c: any) => c.text.includes("Tap to Start"));
+    expect(hasTap).toBe(true);
+  });
+});
+
+describe("Scenario: Continue and New Game button hit tests", () => {
+  test("isContinueButtonHit returns true for in-bounds click", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const btn = (hud as any).getContinueButtonRect(800, 600);
+    expect(hud.isContinueButtonHit(btn.x + btn.w / 2, btn.y + btn.h / 2, 800, 600)).toBe(true);
+  });
+
+  test("isContinueButtonHit returns false for out-of-bounds click", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    expect(hud.isContinueButtonHit(0, 0, 800, 600)).toBe(false);
+  });
+
+  test("isNewGameButtonHit returns true for in-bounds click", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const btn = (hud as any).getNewGameButtonRect(800, 600);
+    expect(hud.isNewGameButtonHit(btn.x + btn.w / 2, btn.y + btn.h / 2, 800, 600)).toBe(true);
+  });
+
+  test("isNewGameButtonHit returns false for out-of-bounds click", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    expect(hud.isNewGameButtonHit(0, 0, 800, 600)).toBe(false);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// SETTINGS PANEL CLEAR SAVE
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Player can clear save data from the settings panel", () => {
+  test("isClearSaveButtonHit returns true for in-bounds click", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const btn = (hud as any).getClearSaveButtonRect(800, 600);
+    expect(hud.isClearSaveButtonHit(btn.x + btn.w / 2, btn.y + btn.h / 2, 800, 600)).toBe(true);
+  });
+
+  test("isClearSaveButtonHit returns false for out-of-bounds click", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    expect(hud.isClearSaveButtonHit(0, 0, 800, 600)).toBe(false);
+  });
+
+  test("clear save removes data and menu no longer shows Continue", () => {
+    SaveSystem.save(validSaveData());
+    expect(SaveSystem.hasSave()).toBe(true);
+    SaveSystem.clear();
+    expect(SaveSystem.hasSave()).toBe(false);
+
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    hud.render(ctx, "menu", 0, 3, 100, 1, "Coastal Patrol", 800, 600, undefined, undefined, false);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    const hasContinue = fillTextCalls.some((c: any) => c.text === "Continue");
+    expect(hasContinue).toBe(false);
+  });
+});
+
+describe("Scenario: Settings panel renders Clear Save button when save exists", () => {
+  test("Clear Save button is rendered when hasSave is true", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    hud.renderSettingsPanel(ctx, 800, 600, 0.5, 0.25, true);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    const hasClearSave = fillTextCalls.some((c: any) => c.text === "Clear Save");
+    expect(hasClearSave).toBe(true);
+  });
+
+  test("Clear Save button is not rendered when hasSave is false", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    hud.renderSettingsPanel(ctx, 800, 600, 0.5, 0.25, false);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    const hasClearSave = fillTextCalls.some((c: any) => c.text === "Clear Save");
+    expect(hasClearSave).toBe(false);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// GAME hasSaveData GETTER
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: RaptorGame exposes hasSaveData getter", () => {
+  test("hasSaveData returns false when no save exists", () => {
+    const { game } = createPlayingGame();
+    expect(game.hasSaveData).toBe(false);
+  });
+
+  test("hasSaveData returns true when a valid save exists", () => {
+    SaveSystem.save(validSaveData());
+    const { game } = createPlayingGame();
+    expect(game.hasSaveData).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR: Raptor Skies — Save/Load Progress (localStorage)

### Summary (What changed + Why)
This PR adds **save/load progress** to Raptor Skies so players can **resume from the highest level they’ve reached** instead of restarting from Level 1 after a loss. Progress is **auto-saved at level boundaries** (on level completion), persisted to `localStorage`, and exposed via a **Continue** option on the menu when a valid save exists. A **Clear Save** action is also available from the settings panel.

Key design choices:
- **Checkpoint-style saving only at level transitions** (avoids complex/fragile mid-level state persistence).
- Uses **safe localStorage wrappers** (graceful behavior when storage is unavailable).
- **Single save slot** (`raptor_save`) with minimal, versioned data for forward compatibility.

---

### Key Files Modified / Added
- **`src/games/raptor/systems/SaveSystem.ts`** (new)
  - Implements `save`, `load`, `clear`, `hasSave` for `raptor_save`
  - Robust validation (version, level range, lives > 0, valid weapon type, JSON parse safety)

- **`src/games/raptor/types.ts`**
  - Adds `RaptorSaveData` schema: `{ version, levelReached, totalScore, lives, weapon, savedAt }`

- **`src/games/raptor/RaptorGame.ts`**
  - Auto-save when a level is completed (saves next `levelReached`)
  - Continue flow: loads save and restores **level, score, lives, weapon**
  - Clears save on **victory**, preserves save on **game over**
  - Menu handling for **Continue** vs **New Game** (New Game clears existing save)

- **`src/games/raptor/rendering/HUD.ts`**
  - Menu UI shows **Continue + New Game** when a save exists; otherwise keeps the original start prompt
  - Adds hit-testing for new buttons
  - Adds **Clear Save** button to settings panel + hit-test

- **`src/shared/storage.ts`** (new/refactor)
  - Extracts `tryGetStorage` / `trySetStorage` / `tryRemoveStorage` wrappers into a shared module

- **`src/shared/AudioManager.ts`**
  - Updated to use the shared `storage.ts` helpers (no behavior change intended)

- **Tests**
  - Adds a comprehensive test suite covering persistence, validation, flows, and HUD behavior (51 tests).

---

### Behavior Notes
- Save key: **`raptor_save`**
- Save triggers: **on level completion**
- Continue availability: only when a **valid** save exists
- Victory: **clears** save (full run complete)
- Game over: **does not clear** save (player can continue from last checkpoint)

---

### Testing Notes
- Automated:
  - Added/updated tests covering:
    - SaveSystem round-trip (`save` → `load`), `clear`, `hasSave`
    - Validation failures (corrupt JSON, wrong version, out-of-range level, invalid weapon, lives <= 0)
    - localStorage unavailable handling (no crashes, behaves like no save)
    - Integration: auto-save on level complete, continue restores state, new game clears save, victory clears save
    - HUD rendering + hit-tests for Continue/New Game/Clear Save
- Manual sanity checks to perform:
  1. Finish a level → refresh → menu shows **Continue**
  2. Continue → starts on saved level with correct **score/lives/weapon**
  3. Settings → **Clear Save** removes Continue option
  4. Complete final level → save removed, Continue no longer shown

---

Ref: https://github.com/asgardtech/archer/issues/416