### PR TITLE
raptor: developer console commands for level navigation

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -7,6 +7,7 @@ import { PowerUpManager } from "./systems/PowerUpManager";
 import { SoundSystem } from "./systems/SoundSystem";
 import { WeaponSystem } from "./systems/WeaponSystem";
 import { SaveSystem } from "./systems/SaveSystem";
+import { CommandRegistry, CommandContext, registerLevelCommands } from "./systems/CommandRegistry";
 import { Player } from "./entities/Player";
 import { Bullet } from "./entities/Bullet";
 import { Missile } from "./entities/Missile";
@@ -82,6 +83,7 @@ export class RaptorGame implements IGame {
   private hud: HUD;
   private audio: AudioManager;
   private sound: SoundSystem;
+  private commandRegistry: CommandRegistry;
 
   private assets: AssetLoader;
   private vfx: VFXManager;
@@ -110,8 +112,14 @@ export class RaptorGame implements IGame {
 
     this.input = new InputManager(this.canvas, width, height);
     this.devConsole = new DevConsole();
+    this.commandRegistry = new CommandRegistry();
+    registerLevelCommands(this.commandRegistry);
     this.devConsole.onSubmit = (cmd) => {
       this.devConsole.log(`> ${cmd}`);
+      const output = this.commandRegistry.dispatch(cmd, this.buildCommandContext());
+      for (const line of output) {
+        this.devConsole.log(line);
+      }
     };
     this.collisions = new CollisionSystem();
     this.spawner = new EnemySpawner();
@@ -759,6 +767,26 @@ export class RaptorGame implements IGame {
     this.startLevel(data.levelReached, false);
     this.player.lives = data.lives;
     this.powerUpManager.setWeapon(data.weapon);
+  }
+
+  private buildCommandContext(): CommandContext {
+    return {
+      currentLevel: this.currentLevel,
+      levelCount: LEVELS.length,
+      levels: LEVELS,
+      startLevel: (idx: number) => {
+        this.startLevel(idx);
+      },
+      setState: (state: "playing") => {
+        this.state = state;
+      },
+      startMusic: (levelIndex: number) => {
+        this.sound.startMusic("playing", levelIndex);
+      },
+      stopMusic: () => {
+        this.sound.stopMusic();
+      },
+    };
   }
 
   private startLevel(levelIndex: number, fullReset = false): void {

--- a/src/games/raptor/systems/CommandRegistry.ts
+++ b/src/games/raptor/systems/CommandRegistry.ts
@@ -1,0 +1,76 @@
+export interface CommandContext {
+  currentLevel: number;
+  levelCount: number;
+  levels: readonly { level: number; name: string }[];
+  startLevel(levelIndex: number): void;
+  setState(state: "playing"): void;
+  startMusic(levelIndex: number): void;
+  stopMusic(): void;
+}
+
+export type CommandHandler = (args: string[], ctx: CommandContext) => string | string[];
+
+export class CommandRegistry {
+  private commands = new Map<string, CommandHandler>();
+
+  register(name: string, handler: CommandHandler): void {
+    this.commands.set(name.toLowerCase(), handler);
+  }
+
+  dispatch(rawInput: string, ctx: CommandContext): string[] {
+    const tokens = rawInput.trim().split(/\s+/);
+    if (tokens.length === 0 || tokens[0] === "") return ["Unknown command"];
+
+    const name = tokens[0].toLowerCase();
+    const args = tokens.slice(1);
+
+    const handler = this.commands.get(name);
+    if (!handler) return [`Unknown command: ${name}`];
+
+    const result = handler(args, ctx);
+    return Array.isArray(result) ? result : [result];
+  }
+}
+
+export function registerLevelCommands(registry: CommandRegistry): void {
+  registry.register("level", (args, ctx) => {
+    if (args.length === 0) {
+      return `Current: Level ${ctx.currentLevel + 1} - ${ctx.levels[ctx.currentLevel].name}`;
+    }
+
+    const sub = args[0].toLowerCase();
+
+    if (sub === "list") {
+      const lines = ["Available levels:"];
+      for (const lvl of ctx.levels) {
+        lines.push(`  ${lvl.level}. ${lvl.name}`);
+      }
+      return lines;
+    }
+
+    if (sub === "current") {
+      return `Current: Level ${ctx.currentLevel + 1} - ${ctx.levels[ctx.currentLevel].name}`;
+    }
+
+    if (sub === "restart") {
+      ctx.stopMusic();
+      ctx.startLevel(ctx.currentLevel);
+      ctx.setState("playing");
+      ctx.startMusic(ctx.currentLevel);
+      const lvl = ctx.levels[ctx.currentLevel];
+      return `Restarted Level ${lvl.level} - ${lvl.name}`;
+    }
+
+    const num = parseInt(sub, 10);
+    if (isNaN(num) || num < 1 || num > ctx.levelCount) {
+      return `Invalid level. Available levels: 1-${ctx.levelCount}`;
+    }
+
+    const levelIndex = num - 1;
+    ctx.stopMusic();
+    ctx.startLevel(levelIndex);
+    ctx.setState("playing");
+    ctx.startMusic(levelIndex);
+    return `Jumped to Level ${num} - ${ctx.levels[levelIndex].name}`;
+  });
+}


### PR DESCRIPTION
## PR: Raptor — Developer console commands for level navigation (Issue: raptor: developer console commands for level navigation)

### Summary (What changed + Why)
This PR adds a lightweight **developer console command system** for Raptor and introduces **level navigation commands** so developers/QA can jump directly to any level without playing through prior levels.

Key behaviors:
- `level <n>` jumps to a specific level (1-indexed input, converted to 0-indexed internally)
- `level list` prints all available levels and names
- `level restart` restarts the current level
- `level current` (and bare `level`) prints the current level
- Commands validate input, **force state to `playing`** from menu/gameover/victory, and **stop/restart music** for the target level

This leverages the existing `startLevel(levelIndex)` transition logic in `RaptorGame` to ensure entity cleanup, spawner reset, terrain/background setup, and player reset are consistent with normal gameplay transitions.

Part of epic #417.

---

### Key files modified
- **`src/games/raptor/systems/CommandRegistry.ts`** (new)
  - Adds `CommandRegistry` with `register()` and `dispatch()`
  - Defines a narrow `CommandContext` interface to safely expose only what commands need
  - Registers the `level` command suite (`level <n>`, `list`, `restart`, `current`, and default-to-current)

- **`src/games/raptor/RaptorGame.ts`**
  - Instantiates the registry and registers level commands
  - Wires `DevConsole.onSubmit` to dispatch commands and print returned output lines
  - Adds a `buildCommandContext()` bridge to call `startLevel`, set game state, and manage music without changing private visibility

---

### Testing notes
**Manual QA (primary):**
1. Open dev console and run:
   - `level list` → prints all 5 levels with names
   - `level current` (and `level`) → prints `Current: Level <n> - <name>`
   - `level 3` → transitions immediately to Level 3, state becomes `playing`, music restarts for that level, console logs `Jumped to Level 3 - Mountain Assault`
   - `level restart` → restarts current level, clears enemies/projectiles, resets player shield, music restarts
2. Validation checks:
   - `level 0`, `level 6`, `level abc`, `level -1` → prints `Invalid level. Available levels: 1-5` and does not jump
3. State transition checks:
   - From `menu`, `gameover`, or `victory`, running `level <n>` moves to `playing` and properly resets the level.

**Unit-testability note:**
`CommandRegistry` is pure logic and can be unit tested with a stubbed `CommandContext` to assert calls to `startLevel`, `setState`, `stopMusic`, and `startMusic`. (No tests added in this PR.)

Ref: https://github.com/asgardtech/archer/issues/431