### PR TITLE
raptor: developer console commands for weapons and power-ups

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -7,7 +7,7 @@ import { PowerUpManager } from "./systems/PowerUpManager";
 import { SoundSystem } from "./systems/SoundSystem";
 import { WeaponSystem } from "./systems/WeaponSystem";
 import { SaveSystem } from "./systems/SaveSystem";
-import { CommandRegistry, CommandContext, registerLevelCommands } from "./systems/CommandRegistry";
+import { CommandRegistry, CommandContext, registerLevelCommands, registerWeaponCommands, registerPowerUpCommands } from "./systems/CommandRegistry";
 import { Player } from "./entities/Player";
 import { Bullet } from "./entities/Bullet";
 import { Missile } from "./entities/Missile";
@@ -114,6 +114,8 @@ export class RaptorGame implements IGame {
     this.devConsole = new DevConsole();
     this.commandRegistry = new CommandRegistry();
     registerLevelCommands(this.commandRegistry);
+    registerWeaponCommands(this.commandRegistry);
+    registerPowerUpCommands(this.commandRegistry);
     this.devConsole.onSubmit = (cmd) => {
       this.devConsole.log(`> ${cmd}`);
       const output = this.commandRegistry.dispatch(cmd, this.buildCommandContext());
@@ -786,6 +788,10 @@ export class RaptorGame implements IGame {
       stopMusic: () => {
         this.sound.stopMusic();
       },
+      gameState: this.state,
+      player: this.player,
+      powerUpManager: this.powerUpManager,
+      weaponSystem: this.weaponSystem,
     };
   }
 

--- a/src/games/raptor/systems/CommandRegistry.ts
+++ b/src/games/raptor/systems/CommandRegistry.ts
@@ -1,3 +1,7 @@
+import { RaptorGameState, RaptorPowerUpType, WeaponType, WEAPON_CONFIGS } from "../types";
+import { PowerUpManager } from "./PowerUpManager";
+import { WeaponSystem } from "./WeaponSystem";
+
 export interface CommandContext {
   currentLevel: number;
   levelCount: number;
@@ -6,6 +10,10 @@ export interface CommandContext {
   setState(state: "playing"): void;
   startMusic(levelIndex: number): void;
   stopMusic(): void;
+  gameState: RaptorGameState;
+  player: { shield: number; lives: number };
+  powerUpManager: PowerUpManager;
+  weaponSystem: WeaponSystem;
 }
 
 export type CommandHandler = (args: string[], ctx: CommandContext) => string | string[];
@@ -72,5 +80,108 @@ export function registerLevelCommands(registry: CommandRegistry): void {
     ctx.setState("playing");
     ctx.startMusic(levelIndex);
     return `Jumped to Level ${num} - ${ctx.levels[levelIndex].name}`;
+  });
+}
+
+const WEAPON_ALIASES: Record<string, WeaponType> = {
+  "machine-gun": "machine-gun",
+  mg: "machine-gun",
+  gun: "machine-gun",
+  missile: "missile",
+  msl: "missile",
+  laser: "laser",
+  lsr: "laser",
+};
+
+const POWERUP_ALIASES: Record<string, RaptorPowerUpType> = {
+  spread: "spread-shot",
+  rapid: "rapid-fire",
+  shield: "shield-restore",
+  life: "bonus-life",
+};
+
+export function registerWeaponCommands(registry: CommandRegistry): void {
+  registry.register("weapon", (args, ctx) => {
+    if (ctx.gameState !== "playing") {
+      return "Command only available while playing";
+    }
+
+    if (args.length === 0) {
+      return "Usage: weapon <type|list>";
+    }
+
+    const sub = args[0].toLowerCase();
+
+    if (sub === "list") {
+      const lines = ["Available weapons:"];
+      const names = Object.keys(WEAPON_CONFIGS) as WeaponType[];
+      const maxLen = Math.max(...names.map((n) => n.length));
+
+      for (const name of names) {
+        const cfg = WEAPON_CONFIGS[name];
+        const paddedName = name.padEnd(maxLen);
+        const parts: string[] = [`DMG:${cfg.damage}`];
+
+        if (cfg.fireRateMultiplier > 0) {
+          parts.push(`RATE:${cfg.fireRateMultiplier.toFixed(1)}x`);
+        } else {
+          parts.push("BEAM");
+        }
+
+        if (cfg.homing) parts.push("HOMING");
+        if (cfg.piercing) parts.push("PIERCING");
+
+        lines.push(`  ${paddedName} \u2014 ${parts.join(" ")}`);
+      }
+      return lines;
+    }
+
+    const resolved = WEAPON_ALIASES[sub];
+    if (!resolved) {
+      return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr)`;
+    }
+
+    ctx.powerUpManager.setWeapon(resolved);
+    ctx.weaponSystem.setWeapon(resolved);
+    return `Weapon switched to ${resolved}`;
+  });
+}
+
+export function registerPowerUpCommands(registry: CommandRegistry): void {
+  registry.register("powerup", (args, ctx) => {
+    if (ctx.gameState !== "playing") {
+      return "Command only available while playing";
+    }
+
+    if (args.length === 0) {
+      return "Usage: powerup <type|clear>";
+    }
+
+    const sub = args[0].toLowerCase();
+
+    if (sub === "clear") {
+      ctx.powerUpManager.clearEffects();
+      return "All power-up effects cleared";
+    }
+
+    const resolved = POWERUP_ALIASES[sub];
+    if (!resolved) {
+      return `Unknown power-up '${sub}'. Available: spread, rapid, shield, life`;
+    }
+
+    switch (resolved) {
+      case "spread-shot":
+      case "rapid-fire":
+        ctx.powerUpManager.activate(resolved);
+        break;
+      case "shield-restore":
+        ctx.player.shield = 100;
+        break;
+      case "bonus-life":
+        ctx.player.lives++;
+        break;
+    }
+
+    return `Activated power-up: ${resolved}`;
   });
 }

--- a/src/games/raptor/systems/PowerUpManager.ts
+++ b/src/games/raptor/systems/PowerUpManager.ts
@@ -51,6 +51,10 @@ export class PowerUpManager {
     return this.effects;
   }
 
+  clearEffects(): void {
+    this.effects = [];
+  }
+
   reset(): void {
     this.effects = [];
     this._currentWeapon = "machine-gun";


### PR DESCRIPTION
## PR: Raptor — Developer console commands for weapons & power-ups (Issue: raptor: developer console commands for weapons and power-ups, part of epic #417)

### Summary (what changed + why)
This PR adds two new developer console command families to **Raptor**—`weapon` and `powerup`—so developers can instantly switch weapons and trigger power-ups for rapid gameplay testing without waiting for in-game drops.

Key capabilities:
- **Weapon switching** via `weapon <type>` (with shorthand aliases) and a **config-driven** `weapon list` output.
- **Power-up activation** via `powerup <type>` for common test cases and `powerup clear` to remove active timed effects.
- Commands are **restricted to the `"playing"` game state** to prevent unintended mutations during menus/gameover.

### Behavior / Commands added
#### `weapon <type|list>`
- `weapon machine-gun|missile|laser` (aliases: `mg|gun`, `msl`, `lsr`)
- `weapon list` prints available weapons and key stats derived from `WEAPON_CONFIGS`
- Helpful errors for unknown inputs
- Outputs success message: `Weapon switched to <type>`

#### `powerup <type|clear>`
- `powerup spread|rapid|shield|life`
  - Timed: `spread-shot`, `rapid-fire` use `powerUpManager.activate(...)` (resets timer on re-activate)
  - Instant: `shield` sets `player.shield = 100`, `life` increments `player.lives`
- `powerup clear` removes **timed** effects without resetting the current weapon
- Outputs success message: `Activated power-up: <type>` / `All power-up effects cleared`

### Key files modified
- `src/games/raptor/systems/CommandRegistry.ts`
  - Extends `CommandContext` with `gameState`, `player`, `powerUpManager`, `weaponSystem`
  - Adds `registerWeaponCommands()` + `registerPowerUpCommands()`
  - Implements alias resolution, `weapon list` formatting, and `"playing"` state guard
- `src/games/raptor/systems/PowerUpManager.ts`
  - Adds `clearEffects()` to clear timed effects **without** resetting weapon (keeps existing `reset()` behavior intact)
- `src/games/raptor/RaptorGame.ts`
  - Registers the new command families
  - Populates the expanded `CommandContext` with the required runtime references
- `src/games/raptor/systems/WeaponSystem.ts`
  - No changes (already supports `setWeapon()`)

### Testing notes
Manual verification via developer console while in `"playing"` state:
- `weapon missile`, `weapon mg`, `weapon lsr` switch weapons immediately and print confirmation
- `weapon list` shows all weapons with expected stats (HOMING for missiles, BEAM/PIERCING for laser)
- `powerup spread` / `powerup rapid` activates timed effects and re-running resets duration
- `powerup shield` restores shield to 100; `powerup life` increments lives
- `powerup clear` clears timed effects and **does not** revert weapon
- Non-playing state: `weapon ...` / `powerup ...` returns `Command only available while playing`

No automated tests added in this PR (handlers are structured to be unit-testable via `CommandRegistry.dispatch()` with a mocked `CommandContext`).

Ref: https://github.com/asgardtech/archer/issues/432