### PR TITLE
raptor: Create SVG terrain assets for levels 6–10 (BSG grimy aesthetic)

### DIFF
--- a/public/assets/raptor/terrain/ground_ash.svg
+++ b/public/assets/raptor/terrain/ground_ash.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="ga-base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2e2a1e"/>
+      <stop offset="50%" stop-color="#3a3528"/>
+      <stop offset="100%" stop-color="#4a4a40"/>
+    </linearGradient>
+    <linearGradient id="ga-crack" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1e1a14"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Scorched base -->
+  <rect width="128" height="128" fill="url(#ga-base)"/>
+
+  <!-- Crack pattern (seamless - cracks use 32/64 boundaries) -->
+  <path d="M 0 64 Q 20 60 32 64 Q 44 68 64 64 Q 84 60 96 64 Q 108 68 128 64" stroke="#1e1a14" stroke-width="1.2" fill="none"/>
+  <path d="M 64 0 Q 60 24 64 32 Q 68 44 64 64 Q 60 84 64 96 Q 68 108 64 128" stroke="#1e1a14" stroke-width="1" fill="none"/>
+  <path d="M 0 32 Q 16 28 32 32 Q 48 36 64 32" stroke="#2e2a1e" stroke-width="0.8" fill="none"/>
+  <path d="M 64 32 Q 80 36 96 32 Q 112 28 128 32" stroke="#2e2a1e" stroke-width="0.8" fill="none"/>
+  <path d="M 0 96 Q 16 92 32 96 Q 48 100 64 96" stroke="#2e2a1e" stroke-width="0.8" fill="none"/>
+  <path d="M 64 96 Q 80 100 96 96 Q 112 92 128 96" stroke="#2e2a1e" stroke-width="0.8" fill="none"/>
+  <path d="M 32 0 Q 28 16 32 32 Q 36 48 32 64" stroke="#2e2a1e" stroke-width="0.7" fill="none"/>
+  <path d="M 32 64 Q 36 80 32 96 Q 28 112 32 128" stroke="#2e2a1e" stroke-width="0.7" fill="none"/>
+  <path d="M 96 0 Q 92 16 96 32 Q 100 48 96 64" stroke="#2e2a1e" stroke-width="0.7" fill="none"/>
+  <path d="M 96 64 Q 100 80 96 96 Q 92 112 96 128" stroke="#2e2a1e" stroke-width="0.7" fill="none"/>
+
+  <!-- Diagonal crack branches -->
+  <line x1="16" y1="48" x2="32" y2="56" stroke="#1e1a14" stroke-width="0.6"/>
+  <line x1="48" y1="80" x2="64" y2="72" stroke="#1e1a14" stroke-width="0.6"/>
+  <line x1="80" y1="16" x2="96" y2="24" stroke="#1e1a14" stroke-width="0.6"/>
+  <line x1="112" y1="80" x2="96" y2="88" stroke="#1e1a14" stroke-width="0.6"/>
+  <line x1="48" y1="48" x2="56" y2="64" stroke="#2e2a1e" stroke-width="0.5"/>
+  <line x1="80" y1="96" x2="72" y2="112" stroke="#2e2a1e" stroke-width="0.5"/>
+
+  <!-- Ash texture spots -->
+  <circle cx="24" cy="24" r="4" fill="#4a4a40" opacity="0.4"/>
+  <circle cx="88" cy="40" r="3" fill="#3a3528" opacity="0.5"/>
+  <circle cx="40" cy="88" r="5" fill="#4a4a40" opacity="0.35"/>
+  <circle cx="104" cy="104" r="3.5" fill="#3a3528" opacity="0.45"/>
+  <circle cx="64" cy="64" r="6" fill="#2e2a1e" opacity="0.3"/>
+  <circle cx="16" cy="112" r="3" fill="#4a4a40" opacity="0.4"/>
+  <circle cx="112" cy="16" r="2.5" fill="#3a3528" opacity="0.5"/>
+
+  <!-- Fine ash particles -->
+  <circle cx="8" cy="72" r="1" fill="#4a4a40"/>
+  <circle cx="56" cy="24" r="1" fill="#3a3528"/>
+  <circle cx="120" cy="88" r="1" fill="#4a4a40"/>
+  <circle cx="72" cy="120" r="1" fill="#3a3528"/>
+  <circle cx="32" cy="56" r="0.8" fill="#4a4a40"/>
+  <circle cx="96" cy="72" r="0.8" fill="#3a3528"/>
+</svg>

--- a/public/assets/raptor/terrain/ground_dark_metal.svg
+++ b/public/assets/raptor/terrain/ground_dark_metal.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gd-base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="50%" stop-color="#222222"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="gd-highlight" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Dark steel base -->
+  <rect width="128" height="128" fill="url(#gd-base)"/>
+
+  <!-- Fine grid (16px) -->
+  <line x1="0" y1="0" x2="128" y2="0" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="0" y1="16" x2="128" y2="16" stroke="#222222" stroke-width="0.4"/>
+  <line x1="0" y1="32" x2="128" y2="32" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="0" y1="48" x2="128" y2="48" stroke="#222222" stroke-width="0.4"/>
+  <line x1="0" y1="64" x2="128" y2="64" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="0" y1="80" x2="128" y2="80" stroke="#222222" stroke-width="0.4"/>
+  <line x1="0" y1="96" x2="128" y2="96" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="0" y1="112" x2="128" y2="112" stroke="#222222" stroke-width="0.4"/>
+  <line x1="0" y1="0" x2="0" y2="128" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="16" y1="0" x2="16" y2="128" stroke="#222222" stroke-width="0.4"/>
+  <line x1="32" y1="0" x2="32" y2="128" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="48" y1="0" x2="48" y2="128" stroke="#222222" stroke-width="0.4"/>
+  <line x1="64" y1="0" x2="64" y2="128" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="80" y1="0" x2="80" y2="128" stroke="#222222" stroke-width="0.4"/>
+  <line x1="96" y1="0" x2="96" y2="128" stroke="#1a1a1a" stroke-width="0.5"/>
+  <line x1="112" y1="0" x2="112" y2="128" stroke="#222222" stroke-width="0.4"/>
+
+  <!-- Red accent lines (32px spacing) -->
+  <line x1="0" y1="32" x2="128" y2="32" stroke="#8a0000" stroke-width="0.6"/>
+  <line x1="0" y1="96" x2="128" y2="96" stroke="#8a0000" stroke-width="0.6"/>
+  <line x1="32" y1="0" x2="32" y2="128" stroke="#8a0000" stroke-width="0.6"/>
+  <line x1="96" y1="0" x2="96" y2="128" stroke="#8a0000" stroke-width="0.6"/>
+
+  <!-- Subtle reflection panels -->
+  <rect x="8" y="8" width="12" height="12" fill="url(#gd-highlight)" opacity="0.15"/>
+  <rect x="56" y="40" width="10" height="10" fill="url(#gd-highlight)" opacity="0.12"/>
+  <rect x="104" y="72" width="12" height="12" fill="url(#gd-highlight)" opacity="0.15"/>
+  <rect x="24" y="104" width="10" height="10" fill="url(#gd-highlight)" opacity="0.12"/>
+  <rect x="72" y="8" width="8" height="8" fill="url(#gd-highlight)" opacity="0.1"/>
+  <rect x="8" y="88" width="10" height="10" fill="url(#gd-highlight)" opacity="0.12"/>
+
+  <!-- Red accent corners at major grid -->
+  <rect x="0" y="0" width="2" height="2" fill="#8a0000"/>
+  <rect x="30" y="0" width="2" height="2" fill="#8a0000"/>
+  <rect x="94" y="0" width="2" height="2" fill="#8a0000"/>
+  <rect x="126" y="0" width="2" height="2" fill="#8a0000"/>
+  <rect x="0" y="30" width="2" height="2" fill="#8a0000"/>
+  <rect x="126" y="30" width="2" height="2" fill="#8a0000"/>
+  <rect x="0" y="94" width="2" height="2" fill="#8a0000"/>
+  <rect x="126" y="94" width="2" height="2" fill="#8a0000"/>
+  <rect x="0" y="126" width="2" height="2" fill="#8a0000"/>
+  <rect x="30" y="126" width="2" height="2" fill="#8a0000"/>
+  <rect x="94" y="126" width="2" height="2" fill="#8a0000"/>
+  <rect x="126" y="126" width="2" height="2" fill="#8a0000"/>
+
+  <!-- Fine detail dots at 64px intersections -->
+  <circle cx="64" cy="64" r="0.8" fill="#2a2a2a"/>
+  <circle cx="0" cy="64" r="0.8" fill="#2a2a2a"/>
+  <circle cx="64" cy="0" r="0.8" fill="#2a2a2a"/>
+  <circle cx="127" cy="64" r="0.8" fill="#2a2a2a"/>
+  <circle cx="64" cy="128" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/public/assets/raptor/terrain/ground_hull_plate.svg
+++ b/public/assets/raptor/terrain/ground_hull_plate.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gh-base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c0c14"/>
+      <stop offset="50%" stop-color="#1a1a28"/>
+      <stop offset="100%" stop-color="#2a2a3a"/>
+    </linearGradient>
+    <linearGradient id="gh-panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#3a3a4a"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Hull base -->
+  <rect width="128" height="128" fill="url(#gh-base)"/>
+
+  <!-- Panel lines (32px grid) -->
+  <line x1="0" y1="0" x2="128" y2="0" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="0" y1="32" x2="128" y2="32" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="0" y1="64" x2="128" y2="64" stroke="#3a3a4a" stroke-width="1"/>
+  <line x1="0" y1="96" x2="128" y2="96" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="0" y1="0" x2="0" y2="128" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="32" y1="0" x2="32" y2="128" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="64" y1="0" x2="64" y2="128" stroke="#3a3a4a" stroke-width="1"/>
+  <line x1="96" y1="0" x2="96" y2="128" stroke="#2a2a3a" stroke-width="0.8"/>
+
+  <!-- Sub-panel lines -->
+  <line x1="0" y1="16" x2="32" y2="16" stroke="#1a1a28" stroke-width="0.5"/>
+  <line x1="64" y1="48" x2="96" y2="48" stroke="#1a1a28" stroke-width="0.5"/>
+  <line x1="0" y1="80" x2="32" y2="80" stroke="#1a1a28" stroke-width="0.5"/>
+  <line x1="64" y1="112" x2="96" y2="112" stroke="#1a1a28" stroke-width="0.5"/>
+  <line x1="16" y1="0" x2="16" y2="32" stroke="#1a1a28" stroke-width="0.5"/>
+  <line x1="48" y1="32" x2="48" y2="64" stroke="#1a1a28" stroke-width="0.5"/>
+  <line x1="80" y1="64" x2="80" y2="96" stroke="#1a1a28" stroke-width="0.5"/>
+  <line x1="112" y1="96" x2="112" y2="128" stroke="#1a1a28" stroke-width="0.5"/>
+
+  <!-- Rivet points at intersections -->
+  <circle cx="0" cy="0" r="1.5" fill="#5a5a6a"/>
+  <circle cx="32" cy="0" r="1.5" fill="#5a5a6a"/>
+  <circle cx="64" cy="0" r="1.5" fill="#5a5a6a"/>
+  <circle cx="96" cy="0" r="1.5" fill="#5a5a6a"/>
+  <circle cx="0" cy="32" r="1.5" fill="#5a5a6a"/>
+  <circle cx="32" cy="32" r="1.5" fill="#5a5a6a"/>
+  <circle cx="64" cy="32" r="1.5" fill="#5a5a6a"/>
+  <circle cx="96" cy="32" r="1.5" fill="#5a5a6a"/>
+  <circle cx="0" cy="64" r="1.8" fill="#5a5a6a"/>
+  <circle cx="32" cy="64" r="1.8" fill="#5a5a6a"/>
+  <circle cx="64" cy="64" r="1.8" fill="#5a5a6a"/>
+  <circle cx="96" cy="64" r="1.8" fill="#5a5a6a"/>
+  <circle cx="0" cy="96" r="1.5" fill="#5a5a6a"/>
+  <circle cx="32" cy="96" r="1.5" fill="#5a5a6a"/>
+  <circle cx="64" cy="96" r="1.5" fill="#5a5a6a"/>
+  <circle cx="96" cy="96" r="1.5" fill="#5a5a6a"/>
+
+  <!-- Access hatches -->
+  <rect x="6" y="38" width="10" height="10" fill="#1a1a28" stroke="#3a3a4a" stroke-width="0.5" rx="0.5"/>
+  <rect x="8" y="40" width="6" height="6" fill="#0c0c14" rx="0.3"/>
+  <circle cx="11" cy="43" r="1" fill="#5a5a6a"/>
+  <rect x="70" y="70" width="12" height="8" fill="#1a1a28" stroke="#3a3a4a" stroke-width="0.5" rx="0.5"/>
+  <rect x="38" y="102" width="10" height="10" fill="#1a1a28" stroke="#3a3a4a" stroke-width="0.5" rx="0.5"/>
+  <circle cx="43" cy="107" r="1" fill="#5a5a6a"/>
+
+  <!-- Panel edge highlights -->
+  <line x1="1" y1="33" x2="31" y2="33" stroke="#5a5a6a" stroke-width="0.3"/>
+  <line x1="65" y1="33" x2="65" y2="63" stroke="#5a5a6a" stroke-width="0.3"/>
+  <line x1="1" y1="97" x2="31" y2="97" stroke="#5a5a6a" stroke-width="0.3"/>
+</svg>

--- a/public/assets/raptor/terrain/ground_metal.svg
+++ b/public/assets/raptor/terrain/ground_metal.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gm-base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="50%" stop-color="#3a3a3a"/>
+      <stop offset="100%" stop-color="#4a4a4a"/>
+    </linearGradient>
+    <linearGradient id="gm-diamond" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="50%" stop-color="#3a3a3a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Base metal -->
+  <rect width="128" height="128" fill="url(#gm-base)"/>
+
+  <!-- Diamond plate (32px repeat) -->
+  <path d="M 0 16 L 16 0 L 32 16 L 16 32 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 32 16 L 48 0 L 64 16 L 48 32 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 64 16 L 80 0 L 96 16 L 80 32 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 96 16 L 112 0 L 128 16 L 112 32 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 0 48 L 16 32 L 32 48 L 16 64 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 32 48 L 48 32 L 64 48 L 48 64 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 64 48 L 80 32 L 96 48 L 80 64 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 96 48 L 112 32 L 128 48 L 112 64 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 0 80 L 16 64 L 32 80 L 16 96 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 32 80 L 48 64 L 64 80 L 48 96 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 64 80 L 80 64 L 96 80 L 80 96 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 96 80 L 112 64 L 128 80 L 112 96 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 0 112 L 16 96 L 32 112 L 16 128 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 32 112 L 48 96 L 64 112 L 48 128 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 64 112 L 80 96 L 96 112 L 80 128 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+  <path d="M 96 112 L 112 96 L 128 112 L 112 128 Z" fill="url(#gm-diamond)" stroke="#2a2a2a" stroke-width="0.5"/>
+
+  <!-- Panel grid -->
+  <line x1="0" y1="0" x2="128" y2="0" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="0" y1="32" x2="128" y2="32" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="0" y1="64" x2="128" y2="64" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="0" y1="96" x2="128" y2="96" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="0" y1="0" x2="0" y2="128" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="32" y1="0" x2="32" y2="128" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="64" y1="0" x2="64" y2="128" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="96" y1="0" x2="96" y2="128" stroke="#2a2a2a" stroke-width="0.5"/>
+</svg>

--- a/public/assets/raptor/terrain/ground_rust.svg
+++ b/public/assets/raptor/terrain/ground_rust.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gr-base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6b3a1a"/>
+      <stop offset="50%" stop-color="#7a4a28"/>
+      <stop offset="100%" stop-color="#8b5e3c"/>
+    </linearGradient>
+    <linearGradient id="gr-oxide" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Base rust plating -->
+  <rect width="128" height="128" fill="url(#gr-base)"/>
+
+  <!-- Panel lines (32px grid for seamless tiling) -->
+  <line x1="0" y1="0" x2="128" y2="0" stroke="#5a3520" stroke-width="1"/>
+  <line x1="0" y1="32" x2="128" y2="32" stroke="#5a3520" stroke-width="0.8"/>
+  <line x1="0" y1="64" x2="128" y2="64" stroke="#6b3a1a" stroke-width="1"/>
+  <line x1="0" y1="96" x2="128" y2="96" stroke="#5a3520" stroke-width="0.8"/>
+  <line x1="0" y1="0" x2="0" y2="128" stroke="#5a3520" stroke-width="1"/>
+  <line x1="32" y1="0" x2="32" y2="128" stroke="#5a3520" stroke-width="0.8"/>
+  <line x1="64" y1="0" x2="64" y2="128" stroke="#6b3a1a" stroke-width="1"/>
+  <line x1="96" y1="0" x2="96" y2="128" stroke="#5a3520" stroke-width="0.8"/>
+
+  <!-- Rivet lines along panel edges -->
+  <circle cx="0" cy="0" r="2" fill="#5a3520"/>
+  <circle cx="32" cy="0" r="2" fill="#5a3520"/>
+  <circle cx="64" cy="0" r="2" fill="#5a3520"/>
+  <circle cx="96" cy="0" r="2" fill="#5a3520"/>
+  <circle cx="0" cy="32" r="2" fill="#5a3520"/>
+  <circle cx="32" cy="32" r="2" fill="#5a3520"/>
+  <circle cx="64" cy="32" r="2" fill="#5a3520"/>
+  <circle cx="96" cy="32" r="2" fill="#5a3520"/>
+  <circle cx="0" cy="64" r="2.2" fill="#6b3a1a"/>
+  <circle cx="32" cy="64" r="2.2" fill="#6b3a1a"/>
+  <circle cx="64" cy="64" r="2.2" fill="#6b3a1a"/>
+  <circle cx="96" cy="64" r="2.2" fill="#6b3a1a"/>
+  <circle cx="0" cy="96" r="2" fill="#5a3520"/>
+  <circle cx="32" cy="96" r="2" fill="#5a3520"/>
+  <circle cx="64" cy="96" r="2" fill="#5a3520"/>
+  <circle cx="96" cy="96" r="2" fill="#5a3520"/>
+
+  <!-- Oxide patches (positioned for tiling) -->
+  <ellipse cx="16" cy="16" rx="8" ry="5" fill="url(#gr-oxide)" opacity="0.6"/>
+  <ellipse cx="48" cy="48" rx="10" ry="6" fill="url(#gr-oxide)" opacity="0.5"/>
+  <ellipse cx="80" cy="16" rx="7" ry="4" fill="url(#gr-oxide)" opacity="0.55"/>
+  <ellipse cx="16" cy="80" rx="9" ry="5" fill="url(#gr-oxide)" opacity="0.5"/>
+  <ellipse cx="112" cy="48" rx="6" ry="4" fill="url(#gr-oxide)" opacity="0.45"/>
+  <ellipse cx="80" cy="112" rx="8" ry="5" fill="url(#gr-oxide)" opacity="0.55"/>
+  <ellipse cx="48" cy="80" rx="7" ry="4" fill="url(#gr-oxide)" opacity="0.5"/>
+
+  <!-- Corrosion spots -->
+  <circle cx="24" cy="40" r="3" fill="#5a3520"/>
+  <circle cx="72" cy="88" r="2.5" fill="#5a3520"/>
+  <circle cx="104" cy="24" r="2" fill="#6b3a1a"/>
+  <circle cx="40" cy="104" r="2.5" fill="#5a3520"/>
+  <circle cx="88" cy="56" r="2" fill="#6b3a1a"/>
+  <circle cx="56" cy="72" r="3" fill="#5a3520"/>
+
+  <!-- Sub-panel rivets -->
+  <circle cx="16" cy="16" r="1.2" fill="#4a2a14"/>
+  <circle cx="48" cy="16" r="1.2" fill="#4a2a14"/>
+  <circle cx="80" cy="16" r="1.2" fill="#4a2a14"/>
+  <circle cx="16" cy="48" r="1.2" fill="#4a2a14"/>
+  <circle cx="48" cy="48" r="1.2" fill="#4a2a14"/>
+  <circle cx="80" cy="48" r="1.2" fill="#4a2a14"/>
+  <circle cx="16" cy="80" r="1.2" fill="#4a2a14"/>
+  <circle cx="48" cy="80" r="1.2" fill="#4a2a14"/>
+  <circle cx="80" cy="80" r="1.2" fill="#4a2a14"/>
+</svg>

--- a/public/assets/raptor/terrain/horizon_industrial.svg
+++ b/public/assets/raptor/terrain/horizon_industrial.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
+  <defs>
+    <linearGradient id="in-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="50%" stop-color="#3a3a3a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="in-stack" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#4a4a4a"/>
+    </linearGradient>
+    <linearGradient id="in-pipe" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="50%" stop-color="#6a4a3a"/>
+      <stop offset="100%" stop-color="#4a4a4a"/>
+    </linearGradient>
+    <radialGradient id="in-smog" cx="400" cy="50" r="400" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#4a4a4a" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#2a2a2a" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Smog sky -->
+  <rect width="800" height="200" fill="url(#in-sky)"/>
+  <rect width="800" height="120" fill="url(#in-smog)"/>
+
+  <!-- Factory base -->
+  <rect x="0" y="140" width="800" height="60" fill="#2a2a2a"/>
+  <rect x="0" y="155" width="800" height="45" fill="#1a1a1a"/>
+  <line x1="0" y1="155" x2="800" y2="155" stroke="#3a3a3a" stroke-width="0.5"/>
+
+  <!-- Cooling tower 1 -->
+  <ellipse cx="120" cy="140" rx="35" ry="8" fill="#3a3a3a"/>
+  <rect x="85" y="60" width="70" height="80" fill="url(#in-stack)"/>
+  <ellipse cx="120" cy="60" rx="35" ry="8" fill="#4a4a4a"/>
+  <line x1="85" y1="80" x2="155" y2="80" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="85" y1="100" x2="155" y2="100" stroke="#2a2a2a" stroke-width="0.5"/>
+
+  <!-- Cooling tower 2 -->
+  <ellipse cx="320" cy="145" rx="40" ry="8" fill="#3a3a3a"/>
+  <rect x="280" y="50" width="80" height="95" fill="url(#in-stack)"/>
+  <ellipse cx="320" cy="50" rx="40" ry="8" fill="#4a4a4a"/>
+  <line x1="280" y1="70" x2="360" y2="70" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="280" y1="95" x2="360" y2="95" stroke="#2a2a2a" stroke-width="0.5"/>
+
+  <!-- Smokestack 1 -->
+  <rect x="455" y="40" width="25" height="115" fill="url(#in-stack)"/>
+  <rect x="450" y="35" width="35" height="8" fill="#4a4a4a"/>
+  <line x1="455" y1="70" x2="480" y2="70" stroke="#2a2a2a" stroke-width="0.4"/>
+  <line x1="455" y1="95" x2="480" y2="95" stroke="#2a2a2a" stroke-width="0.4"/>
+
+  <!-- Smokestack 2 -->
+  <rect x="520" y="55" width="20" height="100" fill="url(#in-stack)"/>
+  <rect x="516" y="50" width="28" height="8" fill="#4a4a4a"/>
+  <line x1="520" y1="80" x2="540" y2="80" stroke="#2a2a2a" stroke-width="0.4"/>
+
+  <!-- Factory block with warning stripe -->
+  <rect x="580" y="100" width="120" height="55" fill="#3a3a3a"/>
+  <rect x="580" y="100" width="120" height="12" fill="#8a7a20"/>
+  <rect x="580" y="116" width="120" height="6" fill="#4a4a4a"/>
+  <line x1="580" y1="100" x2="700" y2="100" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="620" y1="100" x2="620" y2="155" stroke="#2a2a2a" stroke-width="0.5"/>
+  <line x1="660" y1="100" x2="660" y2="155" stroke="#2a2a2a" stroke-width="0.5"/>
+
+  <!-- Pipe runs -->
+  <rect x="0" y="165" width="200" height="8" fill="url(#in-pipe)"/>
+  <rect x="250" y="168" width="150" height="6" fill="url(#in-pipe)"/>
+  <rect x="480" y="162" width="100" height="7" fill="url(#in-pipe)"/>
+  <rect x="650" y="170" width="150" height="6" fill="url(#in-pipe)"/>
+
+  <!-- Vertical pipe -->
+  <rect x="195" y="120" width="12" height="55" fill="url(#in-pipe)"/>
+  <rect x="398" y="110" width="10" height="50" fill="url(#in-pipe)"/>
+
+  <!-- Low factory buildings -->
+  <rect x="30" y="125" width="60" height="30" fill="#3a3a3a"/>
+  <rect x="35" y="128" width="50" height="8" fill="#2a2a2a"/>
+  <rect x="220" y="130" width="55" height="25" fill="#3a3a3a"/>
+  <rect x="225" y="133" width="45" height="6" fill="#2a2a2a"/>
+  <rect x="720" y="135" width="70" height="25" fill="#3a3a3a"/>
+  <rect x="725" y="138" width="60" height="6" fill="#2a2a2a"/>
+</svg>

--- a/public/assets/raptor/terrain/horizon_orbital.svg
+++ b/public/assets/raptor/terrain/horizon_orbital.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
+  <defs>
+    <linearGradient id="ob-space" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c0c14"/>
+      <stop offset="70%" stop-color="#0a0a12"/>
+      <stop offset="100%" stop-color="#1a1a30"/>
+    </linearGradient>
+    <linearGradient id="ob-hull" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#2a2a3a"/>
+      <stop offset="50%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#4a4a5a"/>
+    </linearGradient>
+    <linearGradient id="ob-planet" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a1a30"/>
+      <stop offset="100%" stop-color="#0c0c14"/>
+    </linearGradient>
+    <radialGradient id="ob-atmosphere" cx="400" cy="220" r="180" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#1a1a30" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#3a6a8a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#3a6a8a" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Deep space -->
+  <rect width="800" height="200" fill="url(#ob-space)"/>
+
+  <!-- Stars -->
+  <circle cx="45" cy="25" r="0.8" fill="#5a5a6a"/>
+  <circle cx="120" cy="40" r="0.6" fill="#4a4a5a"/>
+  <circle cx="200" cy="15" r="1" fill="#5a5a6a"/>
+  <circle cx="280" cy="55" r="0.5" fill="#4a4a5a"/>
+  <circle cx="350" cy="30" r="0.7" fill="#5a5a6a"/>
+  <circle cx="420" cy="45" r="0.6" fill="#4a4a5a"/>
+  <circle cx="500" cy="20" r="0.9" fill="#5a5a6a"/>
+  <circle cx="580" cy="50" r="0.5" fill="#4a4a5a"/>
+  <circle cx="650" cy="35" r="0.7" fill="#5a5a6a"/>
+  <circle cx="720" cy="25" r="0.6" fill="#5a5a6a"/>
+  <circle cx="780" cy="42" r="0.8" fill="#4a4a5a"/>
+  <circle cx="150" cy="80" r="0.4" fill="#3a6a8a"/>
+  <circle cx="380" cy="75" r="0.5" fill="#3a6a8a"/>
+  <circle cx="600" cy="85" r="0.4" fill="#3a6a8a"/>
+
+  <!-- Planet curvature -->
+  <ellipse cx="400" cy="220" rx="500" ry="120" fill="url(#ob-planet)"/>
+  <ellipse cx="400" cy="218" rx="480" ry="115" fill="url(#ob-atmosphere)"/>
+
+  <!-- Space station silhouette -->
+  <rect x="80" y="95" width="180" height="25" fill="url(#ob-hull)"/>
+  <rect x="85" y="90" width="40" height="35" fill="url(#ob-hull)"/>
+  <rect x="135" y="85" width="60" height="40" fill="url(#ob-hull)"/>
+  <rect x="205" y="90" width="45" height="35" fill="url(#ob-hull)"/>
+  <rect x="135" y="85" width="60" height="8" fill="#3a6a8a"/>
+  <line x1="80" y1="108" x2="260" y2="108" stroke="#3a6a8a" stroke-width="0.5"/>
+  <line x1="135" y1="85" x2="195" y2="85" stroke="#2a2a3a" stroke-width="0.5"/>
+  <line x1="85" y1="90" x2="125" y2="90" stroke="#2a2a3a" stroke-width="0.5"/>
+
+  <!-- Second station module -->
+  <rect x="420" y="105" width="140" height="20" fill="url(#ob-hull)"/>
+  <rect x="440" y="98" width="50" height="32" fill="url(#ob-hull)"/>
+  <rect x="500" y="92" width="70" height="38" fill="url(#ob-hull)"/>
+  <rect x="500" y="92" width="70" height="6" fill="#3a6a8a"/>
+  <line x1="420" y1="115" x2="560" y2="115" stroke="#3a6a8a" stroke-width="0.5"/>
+  <line x1="440" y1="98" x2="490" y2="98" stroke="#2a2a3a" stroke-width="0.5"/>
+
+  <!-- Debris field -->
+  <rect x="300" y="130" width="8" height="15" fill="#5a5a6a" transform="rotate(-25 304 137)"/>
+  <rect x="340" y="125" width="6" height="12" fill="#4a4a5a" transform="rotate(15 343 131)"/>
+  <rect x="380" y="135" width="10" height="8" fill="#5a5a6a" transform="rotate(-10 385 139)"/>
+  <polygon points="620,140 628,145 625,152 617,147" fill="#4a4a5a"/>
+  <polygon points="680,128 686,132 684,138 678,134" fill="#5a5a6a"/>
+  <rect x="720" y="142" width="5" height="10" fill="#4a4a5a" transform="rotate(20 722 147)"/>
+
+  <!-- Docking arm -->
+  <rect x="255" y="100" width="25" height="8" fill="url(#ob-hull)"/>
+  <rect x="278" y="102" width="35" height="5" fill="#5a5a6a"/>
+  <circle cx="295" cy="104" r="4" fill="#3a6a8a"/>
+</svg>

--- a/public/assets/raptor/terrain/horizon_shipyard.svg
+++ b/public/assets/raptor/terrain/horizon_shipyard.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
+  <defs>
+    <linearGradient id="sy-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="60%" stop-color="#6b3a1a"/>
+      <stop offset="100%" stop-color="#4a2a14"/>
+    </linearGradient>
+    <linearGradient id="sy-hull1" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="40%" stop-color="#6b3a1a"/>
+      <stop offset="100%" stop-color="#8b5e3c"/>
+    </linearGradient>
+    <linearGradient id="sy-hull2" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="50%" stop-color="#9a5a30"/>
+      <stop offset="100%" stop-color="#7a4a28"/>
+    </linearGradient>
+    <linearGradient id="sy-crane" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="100%" stop-color="#5a4035"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Murky brown-orange sky -->
+  <rect width="800" height="200" fill="url(#sy-sky)"/>
+
+  <!-- Distant hull silhouettes -->
+  <polygon points="0,200 0,140 80,120 160,135 200,200" fill="url(#sy-hull1)"/>
+  <polygon points="120,200 180,155 260,165 280,200" fill="#3a2f2a"/>
+  <polygon points="220,200 280,145 380,160 420,200" fill="url(#sy-hull2)"/>
+  <polygon points="350,200 400,130 520,150 580,200" fill="#3a2f2a"/>
+  <polygon points="480,200 540,155 640,170 680,200" fill="url(#sy-hull1)"/>
+  <polygon points="580,200 640,125 750,145 800,200" fill="#6b3a1a"/>
+  <polygon points="680,200 720,160 800,175 800,200" fill="#3a2f2a"/>
+
+  <!-- Dry dock structure -->
+  <rect x="0" y="165" width="800" height="35" fill="#3a2f2a"/>
+  <rect x="0" y="175" width="800" height="25" fill="#2a221e"/>
+  <line x1="0" y1="175" x2="800" y2="175" stroke="#6b3a1a" stroke-width="0.5"/>
+  <line x1="0" y1="185" x2="800" y2="185" stroke="#5a3520" stroke-width="0.5"/>
+
+  <!-- Crane 1 -->
+  <rect x="95" y="85" width="6" height="95" fill="url(#sy-crane)"/>
+  <rect x="88" y="78" width="20" height="10" fill="#3a2f2a"/>
+  <line x1="98" y1="78" x2="98" y2="45" stroke="#5a4035" stroke-width="2"/>
+  <polygon points="90,45 106,45 98,35" fill="#6b3a1a"/>
+  <rect x="70" y="140" width="50" height="6" fill="#3a2f2a"/>
+
+  <!-- Crane 2 -->
+  <rect x="420" y="95" width="5" height="85" fill="url(#sy-crane)"/>
+  <rect x="408" y="88" width="28" height="10" fill="#3a2f2a"/>
+  <line x1="422" y1="88" x2="422" y2="55" stroke="#5a4035" stroke-width="1.5"/>
+  <polygon points="412,55 432,55 422,48" fill="#8b5e3c"/>
+  <rect x="395" y="155" width="55" height="5" fill="#3a2f2a"/>
+
+  <!-- Crane 3 (distant) -->
+  <rect x="650" y="110" width="4" height="70" fill="#3a2f2a"/>
+  <rect x="642" y="105" width="20" height="8" fill="#2a221e"/>
+  <line x1="652" y1="105" x2="652" y2="80" stroke="#4a3528" stroke-width="1"/>
+  <polygon points="646,80 658,80 652,75" fill="#6b3a1a"/>
+
+  <!-- Hull ribs / structural detail -->
+  <line x1="45" y1="140" x2="85" y2="125" stroke="#5a3520" stroke-width="0.8"/>
+  <line x1="55" y1="155" x2="95" y2="140" stroke="#4a2a14" stroke-width="0.5"/>
+  <line x1="280" y1="165" x2="320" y2="155" stroke="#5a3520" stroke-width="0.6"/>
+  <line x1="520" y1="155" x2="560" y2="165" stroke="#6b3a1a" stroke-width="0.5"/>
+  <line x1="720" y1="145" x2="760" y2="160" stroke="#5a3520" stroke-width="0.6"/>
+
+  <!-- Oxide patches on hulls -->
+  <ellipse cx="140" cy="170" rx="25" ry="8" fill="#9a5a30" opacity="0.4"/>
+  <ellipse cx="350" cy="175" rx="30" ry="6" fill="#8b5e3c" opacity="0.35"/>
+  <ellipse cx="600" cy="168" rx="20" ry="7" fill="#9a5a30" opacity="0.3"/>
+</svg>

--- a/public/assets/raptor/terrain/horizon_stronghold.svg
+++ b/public/assets/raptor/terrain/horizon_stronghold.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
+  <defs>
+    <linearGradient id="sh-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#0a0a0a"/>
+    </linearGradient>
+    <linearGradient id="sh-wall" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="30%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="sh-red" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#cc0000"/>
+      <stop offset="100%" stop-color="#8a0000"/>
+    </linearGradient>
+    <radialGradient id="sh-glow1" cx="200" cy="120" r="80" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#cc0000" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#8a0000" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="sh-glow2" cx="600" cy="110" r="70" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#cc0000" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#8a0000" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Dark sky -->
+  <rect width="800" height="200" fill="url(#sh-sky)"/>
+
+  <!-- Base platform -->
+  <rect x="0" y="150" width="800" height="50" fill="#0a0a0a"/>
+  <line x1="0" y1="155" x2="800" y2="155" stroke="#1a1a1a" stroke-width="0.5"/>
+
+  <!-- Central fortress tower -->
+  <polygon points="350,200 350,60 450,60 450,200" fill="url(#sh-wall)"/>
+  <rect x="390" y="45" width="20" height="25" fill="#2a2a2a"/>
+  <rect x="392" y="40" width="16" height="8" fill="#1a1a1a"/>
+  <rect x="395" y="35" width="10" height="8" fill="#cc0000"/>
+  <rect x="397" y="32" width="6" height="4" fill="#8a0000"/>
+  <line x1="350" y1="90" x2="450" y2="90" stroke="#0a0a0a" stroke-width="0.5"/>
+  <line x1="350" y1="120" x2="450" y2="120" stroke="#0a0a0a" stroke-width="0.5"/>
+  <line x1="395" y1="60" x2="405" y2="60" stroke="#cc0000" stroke-width="0.8"/>
+
+  <!-- Left angular wall -->
+  <polygon points="0,200 0,100 120,120 180,200" fill="url(#sh-wall)"/>
+  <rect x="40" y="130" width="15" height="25" fill="#2a2a2a"/>
+  <rect x="42" y="125" width="11" height="8" fill="#cc0000"/>
+  <line x1="0" y1="140" x2="115" y2="135" stroke="#0a0a0a" stroke-width="0.5"/>
+  <rect x="20" y="175" width="25" height="8" fill="#8a0000"/>
+  <ellipse cx="100" cy="165" rx="30" ry="15" fill="url(#sh-glow1)"/>
+
+  <!-- Right angular wall -->
+  <polygon points="800,200 800,95 680,115 620,200" fill="url(#sh-wall)"/>
+  <rect x="745" y="128" width="15" height="25" fill="#2a2a2a"/>
+  <rect x="747" y="123" width="11" height="8" fill="#cc0000"/>
+  <line x1="685" y1="120" x2="800" y2="135" stroke="#0a0a0a" stroke-width="0.5"/>
+  <rect x="683" y="178" width="25" height="8" fill="#8a0000"/>
+  <ellipse cx="700" cy="168" rx="30" ry="15" fill="url(#sh-glow2)"/>
+
+  <!-- Secondary angular structures -->
+  <polygon points="200,200 200,140 280,155 320,200" fill="url(#sh-wall)"/>
+  <rect x="230" y="165" width="12" height="18" fill="#2a2a2a"/>
+  <rect x="232" y="161" width="8" height="6" fill="#cc0000"/>
+  <polygon points="600,200 600,142 520,158 480,200" fill="url(#sh-wall)"/>
+  <rect x="558" y="168" width="12" height="18" fill="#2a2a2a"/>
+  <rect x="560" y="164" width="8" height="6" fill="#cc0000"/>
+  <line x1="522" y1="163" x2="600" y2="158" stroke="#0a0a0a" stroke-width="0.4"/>
+
+  <!-- Red accent strips on central tower -->
+  <rect x="350" y="85" width="100" height="4" fill="url(#sh-red)"/>
+  <rect x="350" y="105" width="100" height="4" fill="url(#sh-red)"/>
+  <rect x="350" y="125" width="100" height="4" fill="url(#sh-red)"/>
+
+  <!-- Cylon eye slit -->
+  <rect x="398" y="68" width="4" height="12" fill="#cc0000"/>
+</svg>

--- a/public/assets/raptor/terrain/horizon_wasteland.svg
+++ b/public/assets/raptor/terrain/horizon_wasteland.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
+  <defs>
+    <linearGradient id="wl-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5a5530"/>
+      <stop offset="40%" stop-color="#4a4a40"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="wl-ground" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3a4030"/>
+      <stop offset="60%" stop-color="#2e2a1e"/>
+      <stop offset="100%" stop-color="#1e1a14"/>
+    </linearGradient>
+    <radialGradient id="wl-smoke1" cx="200" cy="80" r="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#4a4a40" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#2e2a1e" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="wl-smoke2" cx="520" cy="70" r="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#4a4a40" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#2e2a1e" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Hazy ash sky -->
+  <rect width="800" height="200" fill="url(#wl-sky)"/>
+
+  <!-- Smoke plumes -->
+  <ellipse cx="200" cy="80" rx="55" ry="40" fill="url(#wl-smoke1)"/>
+  <ellipse cx="520" cy="70" rx="45" ry="35" fill="url(#wl-smoke2)"/>
+  <ellipse cx="680" cy="95" rx="35" ry="25" fill="#4a4a40" opacity="0.25"/>
+
+  <!-- Jagged terrain base -->
+  <polygon points="0,200 0,165 50,155 120,170 200,150 280,165 350,145 420,160 500,140 580,155 650,145 720,165 800,170 800,200" fill="url(#wl-ground)"/>
+  <polygon points="0,200 30,185 100,195 180,175 260,190 340,170 420,188 500,168 580,192 660,178 740,195 800,185 800,200" fill="#2e2a1e"/>
+
+  <!-- Jagged peaks / ridges -->
+  <polygon points="80,170 110,155 140,170" fill="#3a4030"/>
+  <polygon points="240,165 270,148 300,165" fill="#2e2a1e"/>
+  <polygon points="380,160 410,142 440,160" fill="#3a4030"/>
+  <polygon points="520,155 555,138 590,155" fill="#2e2a1e"/>
+  <polygon points="640,165 670,150 700,165" fill="#3a4030"/>
+  <polygon points="750,170 775,158 800,170" fill="#2e2a1e"/>
+
+  <!-- Barren rock outcrops -->
+  <polygon points="25,195 45,182 65,195" fill="#4a4a40"/>
+  <polygon points="155,190 180,175 205,190" fill="#3a4030"/>
+  <polygon points="320,188 345,172 370,188" fill="#4a4a40"/>
+  <polygon points="480,192 505,178 530,192" fill="#3a4030"/>
+  <polygon points="620,190 645,176 670,190" fill="#4a4a40"/>
+  <polygon points="760,195 780,183 800,195" fill="#3a4030"/>
+
+  <!-- Cracked ground lines -->
+  <path d="M 0 198 Q 80 195 160 198 Q 240 192 320 198 Q 400 194 480 198 Q 560 193 640 198 Q 720 195 800 198" stroke="#1e1a14" stroke-width="0.8" fill="none"/>
+  <line x1="120" y1="185" x2="180" y2="178" stroke="#2e2a1e" stroke-width="0.5"/>
+  <line x1="400" y1="182" x2="460" y2="176" stroke="#2e2a1e" stroke-width="0.5"/>
+  <line x1="600" y1="188" x2="660" y2="182" stroke="#2e2a1e" stroke-width="0.5"/>
+
+  <!-- Dead vegetation silhouettes -->
+  <line x1="95" y1="195" x2="95" y2="175" stroke="#3a4030" stroke-width="1.5"/>
+  <line x1="95" y1="175" x2="88" y2="165" stroke="#3a4030" stroke-width="1"/>
+  <line x1="95" y1="175" x2="102" y2="168" stroke="#3a4030" stroke-width="1"/>
+  <line x1="420" y1="192" x2="420" y2="172" stroke="#3a4030" stroke-width="1.2"/>
+  <line x1="420" y1="172" x2="414" y2="162" stroke="#3a4030" stroke-width="0.8"/>
+  <line x1="420" y1="172" x2="426" y2="165" stroke="#3a4030" stroke-width="0.8"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_anchor.svg
+++ b/public/assets/raptor/terrain/prop_anchor.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pa-rust" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+    <linearGradient id="pa-chain" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Chain links at top -->
+  <ellipse cx="32" cy="8" rx="6" ry="4" fill="none" stroke="#3a2f2a" stroke-width="3"/>
+  <ellipse cx="32" cy="16" rx="6" ry="4" fill="none" stroke="url(#pa-chain)" stroke-width="3"/>
+  <ellipse cx="32" cy="24" rx="6" ry="4" fill="none" stroke="#3a2f2a" stroke-width="3"/>
+  <!-- Shank -->
+  <rect x="28" y="24" width="8" height="24" fill="url(#pa-rust)"/>
+  <!-- Ring -->
+  <ellipse cx="32" cy="50" rx="14" ry="6" fill="none" stroke="url(#pa-rust)" stroke-width="4"/>
+  <!-- Arms (flukes) -->
+  <polygon points="18,48 28,44 30,52 20,54" fill="#6b3a1a"/>
+  <polygon points="46,48 36,44 34,52 44,54" fill="#6b3a1a"/>
+  <!-- Corroded spots -->
+  <ellipse cx="32" cy="36" rx="2" ry="3" fill="#3a2f2a"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_blast_mark.svg
+++ b/public/assets/raptor/terrain/prop_blast_mark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="pbm-center" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="40%" stop-color="#1a1a1a"/>
+      <stop offset="70%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </radialGradient>
+    <radialGradient id="pbm-ring" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </radialGradient>
+  </defs>
+  <!-- Scorch mark - radial pattern -->
+  <circle cx="32" cy="32" r="28" fill="url(#pbm-center)"/>
+  <circle cx="32" cy="32" r="22" fill="#0a0a0a"/>
+  <!-- Radial scorch rays -->
+  <polygon points="32,8 36,28 32,32 28,28" fill="#1a1a1a"/>
+  <polygon points="32,56 36,36 32,32 28,36" fill="#1a1a1a"/>
+  <polygon points="8,32 28,28 32,32 28,36" fill="#1a1a1a"/>
+  <polygon points="56,32 36,28 32,32 36,36" fill="#1a1a1a"/>
+  <polygon points="16,16 26,26 32,32 26,38" fill="#2a2a2a"/>
+  <polygon points="48,16 38,26 32,32 38,38" fill="#2a2a2a"/>
+  <polygon points="48,48 38,38 32,32 38,26" fill="#2a2a2a"/>
+  <polygon points="16,48 26,38 32,32 26,26" fill="#2a2a2a"/>
+  <!-- Center burn -->
+  <circle cx="32" cy="32" r="8" fill="#0a0a0a"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_bones.svg
+++ b/public/assets/raptor/terrain/prop_bones.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pb-bone" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4a4a40"/>
+      <stop offset="50%" stop-color="#5a5530"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+  </defs>
+  <!-- Femur - long bone -->
+  <ellipse cx="32" cy="48" rx="4" ry="6" fill="url(#pb-bone)"/>
+  <rect x="26" y="20" width="12" height="32" rx="2" fill="#4a4a40"/>
+  <ellipse cx="32" cy="18" rx="5" ry="4" fill="#5a5530"/>
+  <!-- Rib shapes - curved -->
+  <path d="M12 36 Q20 32 24 38 Q20 42 12 40 Z" fill="#2e2a1e"/>
+  <path d="M52 34 Q44 30 40 36 Q44 40 52 38 Z" fill="#4a4a40"/>
+  <!-- Smaller fragment -->
+  <ellipse cx="48" cy="52" rx="6" ry="3" fill="#5a5530"/>
+  <rect x="44" y="50" width="8" height="4" fill="#4a4a40"/>
+  <!-- Skull fragment (stylized circle) -->
+  <ellipse cx="16" cy="20" rx="6" ry="5" fill="#2e2a1e"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_cable_cluster.svg
+++ b/public/assets/raptor/terrain/prop_cable_cluster.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pcc-cable" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="50%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="pcc-red" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8a0000"/>
+      <stop offset="100%" stop-color="#cc0000"/>
+    </linearGradient>
+  </defs>
+  <!-- Cable bundle -->
+  <ellipse cx="32" cy="20" rx="16" ry="6" fill="#1a1a1a"/>
+  <path d="M16 20 Q20 40 18 56" fill="none" stroke="#2a2a2a" stroke-width="5"/>
+  <path d="M32 18 Q30 42 34 58" fill="none" stroke="#1a1a1a" stroke-width="5"/>
+  <path d="M48 20 Q44 38 46 54" fill="none" stroke="#2a2a2a" stroke-width="5"/>
+  <!-- Connectors at ends -->
+  <rect x="14" y="52" width="8" height="6" fill="#2a2a2a"/>
+  <rect x="28" y="54" width="8" height="6" fill="#2a2a2a"/>
+  <rect x="42" y="50" width="8" height="6" fill="#2a2a2a"/>
+  <!-- Red power cable accent -->
+  <path d="M24 22 Q26 36 22 50" fill="none" stroke="#8a0000" stroke-width="3"/>
+  <rect x="18" y="48" width="6" height="4" fill="url(#pcc-red)"/>
+  <!-- Junction box -->
+  <rect x="26" y="8" width="12" height="8" fill="#1a1a1a"/>
+  <rect x="28" y="10" width="8" height="4" fill="#2a2a2a"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_grate.svg
+++ b/public/assets/raptor/terrain/prop_grate.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pg-metal" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="50%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="pg-hole" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#0a0a0a"/>
+    </linearGradient>
+  </defs>
+  <!-- Outer frame -->
+  <rect x="8" y="8" width="48" height="48" fill="#2a2a2a"/>
+  <rect x="10" y="10" width="44" height="44" fill="url(#pg-metal)"/>
+  <!-- Grid pattern - horizontal bars -->
+  <rect x="10" y="16" width="44" height="4" fill="#3a3a3a"/>
+  <rect x="10" y="26" width="44" height="4" fill="#3a3a3a"/>
+  <rect x="10" y="36" width="44" height="4" fill="#3a3a3a"/>
+  <rect x="10" y="46" width="44" height="4" fill="#3a3a3a"/>
+  <!-- Grid pattern - vertical bars -->
+  <rect x="16" y="10" width="4" height="44" fill="#3a3a3a"/>
+  <rect x="26" y="10" width="4" height="44" fill="#3a3a3a"/>
+  <rect x="36" y="10" width="4" height="44" fill="#3a3a3a"/>
+  <rect x="46" y="10" width="4" height="44" fill="#3a3a3a"/>
+  <!-- Drain openings (dark) -->
+  <rect x="20" y="20" width="6" height="6" fill="url(#pg-hole)"/>
+  <rect x="34" y="20" width="6" height="6" fill="url(#pg-hole)"/>
+  <rect x="20" y="34" width="6" height="6" fill="url(#pg-hole)"/>
+  <rect x="34" y="34" width="6" height="6" fill="url(#pg-hole)"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_hull_fragment.svg
+++ b/public/assets/raptor/terrain/prop_hull_fragment.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="phf-hull" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a1a30"/>
+      <stop offset="50%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#0c0c14"/>
+    </linearGradient>
+    <linearGradient id="phf-inner" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2a2a3a"/>
+      <stop offset="100%" stop-color="#0c0c14"/>
+    </linearGradient>
+  </defs>
+  <!-- Hull plate - ragged torn edge -->
+  <path d="M12 16 L48 12 L56 36 L52 52 L20 56 L8 40 Z" fill="url(#phf-hull)"/>
+  <!-- Exposed internals -->
+  <path d="M20 28 L44 24 L48 44 L24 48 Z" fill="url(#phf-inner)"/>
+  <!-- Ribbing/structural -->
+  <line x1="24" y1="32" x2="42" y2="30" stroke="#3a6a8a" stroke-width="2"/>
+  <line x1="26" y1="38" x2="40" y2="36" stroke="#3a6a8a" stroke-width="2"/>
+  <!-- Ragged edge detail -->
+  <polygon points="8,40 12,44 10,50 6,46" fill="#0c0c14"/>
+  <polygon points="52,52 56,48 58,54 54,58" fill="#1a1a30"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_oil_drum.svg
+++ b/public/assets/raptor/terrain/prop_oil_drum.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pod-body" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="30%" stop-color="#6b3a1a"/>
+      <stop offset="70%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#3a2f2a"/>
+    </linearGradient>
+    <linearGradient id="pod-top" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+    <linearGradient id="pod-stain" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2a2018"/>
+      <stop offset="100%" stop-color="#0a0a0a"/>
+    </linearGradient>
+  </defs>
+  <!-- Cylindrical drum body (ellipse for side view) -->
+  <ellipse cx="32" cy="40" rx="18" ry="14" fill="url(#pod-body)"/>
+  <!-- Top cap -->
+  <ellipse cx="32" cy="26" rx="16" ry="6" fill="url(#pod-top)"/>
+  <!-- Dent -->
+  <ellipse cx="28" cy="36" rx="4" ry="3" fill="#3a2f2a"/>
+  <!-- Oil stain drip -->
+  <path d="M26 52 Q24 58 28 60 Q32 62 30 58 L28 52 Z" fill="url(#pod-stain)"/>
+  <ellipse cx="30" cy="56" rx="4" ry="3" fill="#1a1a1a"/>
+  <!-- Rim detail -->
+  <ellipse cx="32" cy="24" rx="14" ry="4" fill="#3a2f2a"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_panel_shard.svg
+++ b/public/assets/raptor/terrain/prop_panel_shard.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pps-screen" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a30"/>
+      <stop offset="50%" stop-color="#3a6a8a"/>
+      <stop offset="100%" stop-color="#0c0c14"/>
+    </linearGradient>
+    <linearGradient id="pps-frame" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#2a2a3a"/>
+    </linearGradient>
+  </defs>
+  <!-- Broken panel fragment -->
+  <polygon points="16,12 52,8 56,44 24,56 8,36" fill="url(#pps-frame)"/>
+  <!-- Cracked screen surface -->
+  <polygon points="20,18 46,14 50,40 22,48 12,32" fill="url(#pps-screen)"/>
+  <!-- Crack lines -->
+  <line x1="24" y1="28" x2="38" y2="42" stroke="#0c0c14" stroke-width="2"/>
+  <line x1="38" y1="42" x2="32" y2="50" stroke="#0c0c14" stroke-width="2"/>
+  <line x1="32" y1="22" x2="24" y2="28" stroke="#0c0c14" stroke-width="1.5"/>
+  <!-- Exposed edge -->
+  <polygon points="8,36 16,40 14,52 6,48" fill="#0c0c14"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_radiation_sign.svg
+++ b/public/assets/raptor/terrain/prop_radiation_sign.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="prs-post" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2e2a1e"/>
+      <stop offset="100%" stop-color="#4a4a40"/>
+    </linearGradient>
+    <linearGradient id="prs-sign" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5a5530"/>
+      <stop offset="100%" stop-color="#4a4a40"/>
+    </linearGradient>
+  </defs>
+  <!-- Tilted post -->
+  <rect x="28" y="8" width="6" height="52" transform="rotate(-8 31 34)" fill="url(#prs-post)"/>
+  <!-- Sign plate - damaged, tilted -->
+  <rect x="8" y="12" width="36" height="28" rx="2" transform="rotate(-12 26 26)" fill="url(#prs-sign)"/>
+  <!-- Trefoil symbol - 3 blades (radiation warning) -->
+  <path d="M26 14 L30 26 L26 28 L22 26 Z" fill="#2e2a1e"/>
+  <path d="M26 42 L30 30 L26 28 L22 30 Z" fill="#2e2a1e"/>
+  <path d="M14 28 L26 24 L26 32 L14 32 Z" fill="#2e2a1e"/>
+  <path d="M38 28 L26 24 L26 32 L38 32 Z" fill="#2e2a1e"/>
+  <!-- Center circle -->
+  <circle cx="26" cy="28" r="5" fill="#2e2a1e"/>
+  <!-- Damage/dent -->
+  <polygon points="32,16 36,20 34,24 30,22" fill="#4a4a40"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_red_light.svg
+++ b/public/assets/raptor/terrain/prop_red_light.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="prl-glow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#cc0000"/>
+      <stop offset="100%" stop-color="#8a0000"/>
+    </linearGradient>
+    <linearGradient id="prl-halo" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8a0000"/>
+      <stop offset="100%" stop-color="#4a0000"/>
+    </linearGradient>
+    <linearGradient id="prl-housing" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Glow halo -->
+  <circle cx="32" cy="32" r="24" fill="url(#prl-halo)"/>
+  <circle cx="32" cy="32" r="18" fill="#5a2020"/>
+  <!-- Housing -->
+  <circle cx="32" cy="32" r="14" fill="url(#prl-housing)"/>
+  <!-- Red indicator light -->
+  <circle cx="32" cy="32" r="10" fill="url(#prl-glow)"/>
+  <circle cx="32" cy="30" r="5" fill="#cc0000"/>
+  <!-- Mount bracket -->
+  <rect x="26" y="44" width="12" height="6" fill="#1a1a1a"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_scrap_metal.svg
+++ b/public/assets/raptor/terrain/prop_scrap_metal.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="psm-rust1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+    <linearGradient id="psm-rust2" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6b3a1a"/>
+      <stop offset="100%" stop-color="#3a2f2a"/>
+    </linearGradient>
+  </defs>
+  <!-- Irregular scrap pieces - bent plates -->
+  <polygon points="12,44 28,38 32,52 16,54" fill="url(#psm-rust1)"/>
+  <polygon points="36,42 52,36 56,48 40,52" fill="url(#psm-rust2)"/>
+  <polygon points="8,28 24,22 28,34 14,38" fill="#6b3a1a"/>
+  <polygon points="38,24 50,18 54,28 42,32" fill="#8b5e3c"/>
+  <!-- Sharp edge fragment -->
+  <polygon points="20,12 36,8 40,20 24,24" fill="#3a2f2a"/>
+  <!-- Small debris -->
+  <rect x="48" y="44" width="8" height="6" transform="rotate(-15 52 47)" fill="#6b3a1a"/>
+  <polygon points="4,48 10,46 12,52 6,54" fill="#8b5e3c"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_space_debris.svg
+++ b/public/assets/raptor/terrain/prop_space_debris.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="psd-metal1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a30"/>
+      <stop offset="100%" stop-color="#5a5a6a"/>
+    </linearGradient>
+    <linearGradient id="psd-metal2" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3a6a8a"/>
+      <stop offset="100%" stop-color="#0c0c14"/>
+    </linearGradient>
+  </defs>
+  <!-- Mixed fragment 1 -->
+  <polygon points="32,8 48,16 44,28 28,24" fill="url(#psd-metal1)"/>
+  <!-- Fragment 2 -->
+  <polygon points="12,36 28,32 32,44 16,48" fill="#5a5a6a"/>
+  <!-- Fragment 3 -->
+  <rect x="40" y="40" width="14" height="10" transform="rotate(-20 47 45)" fill="#3a6a8a"/>
+  <!-- Fragment 4 -->
+  <polygon points="8,20 20,16 24,28 12,32" fill="#1a1a30"/>
+  <!-- Small metallic pieces -->
+  <rect x="50" y="20" width="6" height="8" transform="rotate(15 53 24)" fill="#5a5a6a"/>
+  <ellipse cx="20" cy="52" rx="6" ry="4" fill="url(#psd-metal2)"/>
+  <polygon points="36,12 42,14 40,20 34,18" fill="#0c0c14"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_steam_vent.svg
+++ b/public/assets/raptor/terrain/prop_steam_vent.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="psv-ring" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="psv-hole" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#0a0a0a"/>
+    </linearGradient>
+    <linearGradient id="psv-steam" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#6a6a6a"/>
+    </linearGradient>
+  </defs>
+  <!-- Circular vent opening -->
+  <circle cx="32" cy="44" r="18" fill="url(#psv-ring)"/>
+  <circle cx="32" cy="44" r="14" fill="#3a3a3a"/>
+  <circle cx="32" cy="44" r="10" fill="url(#psv-hole)"/>
+  <!-- Steam wisps rising -->
+  <ellipse cx="24" cy="28" rx="6" ry="8" fill="url(#psv-steam)"/>
+  <ellipse cx="36" cy="22" rx="5" ry="10" fill="#5a5a5a"/>
+  <ellipse cx="32" cy="14" rx="7" ry="6" fill="#4a4a4a"/>
+  <!-- Bolt details -->
+  <circle cx="14" cy="32" r="3" fill="#6a4a3a"/>
+  <circle cx="50" cy="32" r="3" fill="#6a4a3a"/>
+  <circle cx="32" cy="58" r="3" fill="#6a4a3a"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_vent_grate.svg
+++ b/public/assets/raptor/terrain/prop_vent_grate.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pvg-frame" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="pvg-hole" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Frame -->
+  <rect x="12" y="12" width="40" height="40" fill="url(#pvg-frame)"/>
+  <!-- Slats - horizontal -->
+  <rect x="16" y="18" width="32" height="3" fill="#2a2a2a"/>
+  <rect x="16" y="26" width="32" height="3" fill="#2a2a2a"/>
+  <rect x="16" y="34" width="32" height="3" fill="#2a2a2a"/>
+  <rect x="16" y="42" width="32" height="3" fill="#2a2a2a"/>
+  <!-- Dark opening behind slats -->
+  <rect x="18" y="20" width="28" height="26" fill="url(#pvg-hole)"/>
+  <!-- Slat shadows -->
+  <rect x="16" y="18" width="32" height="1" fill="#1a1a1a"/>
+  <rect x="16" y="26" width="32" height="1" fill="#1a1a1a"/>
+  <rect x="16" y="34" width="32" height="1" fill="#1a1a1a"/>
+  <rect x="16" y="42" width="32" height="1" fill="#1a1a1a"/>
+</svg>

--- a/public/assets/raptor/terrain/prop_wiring.svg
+++ b/public/assets/raptor/terrain/prop_wiring.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pw-red" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5a3a3a"/>
+      <stop offset="100%" stop-color="#3a2a2a"/>
+    </linearGradient>
+    <linearGradient id="pw-blue" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3a4a5a"/>
+      <stop offset="100%" stop-color="#2a3a4a"/>
+    </linearGradient>
+    <linearGradient id="pw-yellow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5a5a3a"/>
+      <stop offset="100%" stop-color="#4a4a2a"/>
+    </linearGradient>
+  </defs>
+  <!-- Dangling wires from top -->
+  <path d="M16 8 Q20 24 14 40 Q18 52 12 60" fill="none" stroke="#5a3a3a" stroke-width="3"/>
+  <path d="M32 8 Q28 28 34 44 Q30 56 36 62" fill="none" stroke="#3a4a5a" stroke-width="3"/>
+  <path d="M48 8 Q52 20 46 36 Q50 48 44 58" fill="none" stroke="#5a5a3a" stroke-width="3"/>
+  <!-- Coiled section -->
+  <ellipse cx="24" cy="48" rx="8" ry="4" fill="none" stroke="#5a3a3a" stroke-width="2.5"/>
+  <ellipse cx="24" cy="48" rx="5" ry="2.5" fill="none" stroke="#5a3a3a" stroke-width="2"/>
+  <!-- Connector at end -->
+  <rect x="10" y="56" width="6" height="4" fill="#2a2a2a"/>
+  <rect x="32" y="58" width="6" height="4" fill="#2a2a2a"/>
+  <rect x="42" y="54" width="6" height="4" fill="#2a2a2a"/>
+  <!-- Junction point -->
+  <circle cx="32" cy="20" r="4" fill="#1a1a30"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_antenna_array.svg
+++ b/public/assets/raptor/terrain/struct_antenna_array.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="saa-mast" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2a2a40"/>
+      <stop offset="50%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#2a2a40"/>
+    </linearGradient>
+    <linearGradient id="saa-dipole" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3a6a8a"/>
+      <stop offset="100%" stop-color="#1a1a30"/>
+    </linearGradient>
+  </defs>
+  <!-- Base platform -->
+  <rect x="24" y="56" width="16" height="8" fill="#0c0c14"/>
+  <!-- Main mast -->
+  <rect x="30" y="8" width="4" height="52" fill="url(#saa-mast)"/>
+  <!-- Crossbars -->
+  <rect x="12" y="14" width="40" height="2" fill="url(#saa-mast)"/>
+  <rect x="16" y="26" width="32" height="2" fill="url(#saa-mast)"/>
+  <rect x="20" y="38" width="24" height="2" fill="url(#saa-mast)"/>
+  <!-- Dipole elements - top row -->
+  <line x1="16" y1="14" x2="16" y2="8" stroke="#3a6a8a" stroke-width="1.5"/>
+  <line x1="16" y1="14" x2="16" y2="20" stroke="#3a6a8a" stroke-width="1.5"/>
+  <line x1="32" y1="14" x2="32" y2="6" stroke="#3a6a8a" stroke-width="1.5"/>
+  <line x1="32" y1="14" x2="32" y2="22" stroke="#3a6a8a" stroke-width="1.5"/>
+  <line x1="48" y1="14" x2="48" y2="8" stroke="#3a6a8a" stroke-width="1.5"/>
+  <line x1="48" y1="14" x2="48" y2="20" stroke="#3a6a8a" stroke-width="1.5"/>
+  <!-- Dipole elements - middle row -->
+  <line x1="22" y1="26" x2="22" y2="20" stroke="#5a5a6a" stroke-width="1"/>
+  <line x1="22" y1="26" x2="22" y2="32" stroke="#5a5a6a" stroke-width="1"/>
+  <line x1="42" y1="26" x2="42" y2="20" stroke="#5a5a6a" stroke-width="1"/>
+  <line x1="42" y1="26" x2="42" y2="32" stroke="#5a5a6a" stroke-width="1"/>
+  <!-- Dipole elements - bottom row -->
+  <line x1="28" y1="38" x2="28" y2="34" stroke="#5a5a6a" stroke-width="1"/>
+  <line x1="28" y1="38" x2="28" y2="42" stroke="#5a5a6a" stroke-width="1"/>
+  <line x1="36" y1="38" x2="36" y2="34" stroke="#5a5a6a" stroke-width="1"/>
+  <line x1="36" y1="38" x2="36" y2="42" stroke="#5a5a6a" stroke-width="1"/>
+  <!-- Mast cap -->
+  <rect x="28" y="4" width="8" height="4" fill="#3a6a8a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_cargo_container.svg
+++ b/public/assets/raptor/terrain/struct_cargo_container.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="scc-box1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+    <linearGradient id="scc-box2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6b3a1a"/>
+      <stop offset="100%" stop-color="#9a5a30"/>
+    </linearGradient>
+    <linearGradient id="scc-rust" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#9a5a30"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Back container (angled) -->
+  <polygon points="8,52 8,28 24,20 24,44" fill="url(#scc-box1)"/>
+  <!-- Corrugation lines back -->
+  <line x1="10" y1="32" x2="22" y2="26" stroke="#3a2f2a" stroke-width="0.8"/>
+  <line x1="10" y1="38" x2="22" y2="32" stroke="#3a2f2a" stroke-width="0.8"/>
+  <line x1="10" y1="44" x2="22" y2="38" stroke="#3a2f2a" stroke-width="0.8"/>
+  <!-- Middle container -->
+  <polygon points="24,44 24,16 44,8 44,36" fill="url(#scc-box2)"/>
+  <line x1="26" y1="22" x2="42" y2="16" stroke="#3a2f2a" stroke-width="0.8"/>
+  <line x1="26" y1="28" x2="42" y2="22" stroke="#3a2f2a" stroke-width="0.8"/>
+  <line x1="26" y1="34" x2="42" y2="28" stroke="#3a2f2a" stroke-width="0.8"/>
+  <!-- Front container (stacked) -->
+  <polygon points="44,36 44,12 60,8 60,32" fill="url(#scc-box1)"/>
+  <line x1="46" y1="18" x2="58" y2="14" stroke="#3a2f2a" stroke-width="0.8"/>
+  <line x1="46" y1="24" x2="58" y2="20" stroke="#3a2f2a" stroke-width="0.8"/>
+  <line x1="46" y1="30" x2="58" y2="26" stroke="#3a2f2a" stroke-width="0.8"/>
+  <!-- Rust streaks -->
+  <path d="M14 30 L18 44" stroke="#6b3a1a" stroke-width="2" fill="none"/>
+  <path d="M30 14 L36 32" stroke="#6b3a1a" stroke-width="1.5" fill="none"/>
+  <path d="M48 14 L52 28" stroke="#6b3a1a" stroke-width="1.5" fill="none"/>
+  <!-- Container edges / depth -->
+  <polygon points="24,20 24,44 28,42 28,18" fill="#3a2f2a"/>
+  <polygon points="44,8 44,36 48,34 48,6" fill="#3a2f2a"/>
+  <!-- Base shadow -->
+  <rect x="8" y="50" width="52" height="6" fill="#3a2f2a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_conveyor.svg
+++ b/public/assets/raptor/terrain/struct_conveyor.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="scv-frame" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="scv-belt" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3a3a3a"/>
+      <stop offset="50%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </linearGradient>
+    <linearGradient id="scv-roller" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="50%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+  </defs>
+  <!-- Frame legs -->
+  <rect x="8" y="44" width="4" height="20" fill="url(#scv-frame)"/>
+  <rect x="28" y="48" width="4" height="16" fill="url(#scv-frame)"/>
+  <rect x="52" y="44" width="4" height="20" fill="url(#scv-frame)"/>
+  <!-- Cross braces -->
+  <rect x="8" y="52" width="48" height="3" fill="#3a3a3a"/>
+  <line x1="12" y1="48" x2="30" y2="52" stroke="#4a4a4a" stroke-width="2"/>
+  <line x1="32" y1="52" x2="52" y2="48" stroke="#4a4a4a" stroke-width="2"/>
+  <!-- Roller supports -->
+  <rect x="10" y="36" width="6" height="4" fill="#2a2a2a"/>
+  <rect x="26" y="38" width="6" height="4" fill="#2a2a2a"/>
+  <rect x="48" y="36" width="6" height="4" fill="#2a2a2a"/>
+  <!-- Rollers -->
+  <rect x="12" y="34" width="2" height="8" fill="url(#scv-roller)"/>
+  <rect x="28" y="36" width="2" height="8" fill="url(#scv-roller)"/>
+  <rect x="50" y="34" width="2" height="8" fill="url(#scv-roller)"/>
+  <!-- Angled belt surface -->
+  <polygon points="14,32 50,28 52,36 16,40" fill="url(#scv-belt)"/>
+  <!-- Belt texture lines -->
+  <line x1="18" y1="34" x2="48" y2="31" stroke="#3a3a3a" stroke-width="1"/>
+  <line x1="20" y1="36" x2="46" y2="33" stroke="#3a3a3a" stroke-width="1"/>
+  <!-- Warning stripe on frame -->
+  <rect x="8" y="54" width="48" height="1" fill="#8a7a20"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_cooling_tower.svg
+++ b/public/assets/raptor/terrain/struct_cooling_tower.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="sct-tower" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="50%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="sct-steam" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5a5a5a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </linearGradient>
+  </defs>
+  <!-- Hyperbolic tower silhouette: wide base, narrow middle, wide top -->
+  <polygon points="12,64 16,54 22,40 26,28 28,14 36,14 38,28 42,40 48,54 52,64" fill="url(#sct-tower)"/>
+  <!-- Inner shadow for depth -->
+  <polygon points="20,58 24,44 28,32 30,22 34,22 36,32 40,44 44,58" fill="#2a2a2a" opacity="0.5"/>
+  <!-- Base ring -->
+  <ellipse cx="32" cy="60" rx="18" ry="4" fill="#3a3a3a"/>
+  <!-- Steam plumes at top -->
+  <ellipse cx="24" cy="2" rx="6" ry="3" fill="#4a4a4a" opacity="0.6"/>
+  <ellipse cx="32" cy="0" rx="8" ry="4" fill="#5a5a5a" opacity="0.5"/>
+  <ellipse cx="42" cy="2" rx="5" ry="3" fill="#4a4a4a" opacity="0.6"/>
+  <!-- Support struts at base -->
+  <rect x="14" y="56" width="3" height="8" fill="#2a2a2a"/>
+  <rect x="47" y="56" width="3" height="8" fill="#2a2a2a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_crane.svg
+++ b/public/assets/raptor/terrain/struct_crane.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="sc-beam" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="50%" stop-color="#6b3a1a"/>
+      <stop offset="100%" stop-color="#3a2f2a"/>
+    </linearGradient>
+    <linearGradient id="sc-rust" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+    <linearGradient id="sc-hook" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#9a5a30"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Base platform -->
+  <rect x="4" y="52" width="56" height="8" fill="#3a2f2a"/>
+  <rect x="8" y="48" width="48" height="6" fill="url(#sc-beam)"/>
+  <!-- Vertical lattice legs -->
+  <rect x="12" y="28" width="4" height="26" fill="#3a2f2a"/>
+  <rect x="48" y="28" width="4" height="26" fill="#3a2f2a"/>
+  <rect x="24" y="36" width="3" height="20" fill="#6b3a1a"/>
+  <rect x="37" y="36" width="3" height="20" fill="#6b3a1a"/>
+  <!-- Cross braces -->
+  <line x1="12" y1="42" x2="27" y2="42" stroke="#6b3a1a" stroke-width="2"/>
+  <line x1="37" y1="42" x2="52" y2="42" stroke="#6b3a1a" stroke-width="2"/>
+  <line x1="14" y1="38" x2="26" y2="48" stroke="#8b5e3c" stroke-width="1.5"/>
+  <line x1="50" y1="38" x2="38" y2="48" stroke="#8b5e3c" stroke-width="1.5"/>
+  <!-- Horizontal boom -->
+  <rect x="8" y="22" width="48" height="6" fill="url(#sc-rust)"/>
+  <rect x="8" y="24" width="48" height="2" fill="#3a2f2a"/>
+  <!-- Jib arm -->
+  <polygon points="32,22 56,22 56,26 32,26" fill="url(#sc-beam)"/>
+  <rect x="54" y="14" width="4" height="14" fill="#6b3a1a"/>
+  <!-- Hook assembly -->
+  <rect x="52" y="8" width="8" height="8" fill="#3a2f2a"/>
+  <path d="M56 8 L58 14 L54 14 Z" fill="url(#sc-hook)"/>
+  <rect x="56" y="14" width="2" height="6" fill="#9a5a30"/>
+  <ellipse cx="58" cy="22" rx="3" ry="2" fill="#3a2f2a"/>
+  <!-- Counterweight -->
+  <rect x="10" y="18" width="12" height="10" fill="#6b3a1a"/>
+  <rect x="12" y="20" width="8" height="6" fill="#8b5e3c"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_cylon_tower.svg
+++ b/public/assets/raptor/terrain/struct_cylon_tower.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="scy-tower" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="50%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="scy-eye" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#cc0000"/>
+      <stop offset="100%" stop-color="#8a0000"/>
+    </linearGradient>
+    <linearGradient id="scy-panel" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+  </defs>
+  <!-- Base platform -->
+  <rect x="20" y="56" width="24" height="8" fill="#0a0a0a"/>
+  <rect x="22" y="52" width="20" height="6" fill="#1a1a1a"/>
+  <!-- Tower body - angular facets -->
+  <polygon points="32,8 44,52 52,52 32,4 12,52 20,52" fill="url(#scy-tower)"/>
+  <!-- Center seam -->
+  <rect x="30" y="12" width="4" height="44" fill="#0a0a0a"/>
+  <!-- Red sensor eye -->
+  <ellipse cx="32" cy="14" rx="6" ry="4" fill="url(#scy-eye)"/>
+  <ellipse cx="32" cy="13" rx="3" ry="2" fill="#cc0000"/>
+  <!-- Angular panels -->
+  <polygon points="18,48 26,48 22,36" fill="url(#scy-panel)"/>
+  <polygon points="46,48 38,48 42,36" fill="url(#scy-panel)"/>
+  <!-- Base detail -->
+  <rect x="24" y="50" width="16" height="2" fill="#2a2a2a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_dead_tree.svg
+++ b/public/assets/raptor/terrain/struct_dead_tree.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="sdt-trunk" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2e2a1e"/>
+      <stop offset="50%" stop-color="#4a4a40"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="sdt-bark" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3a4030"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="sdt-branch" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a40"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+  </defs>
+  <!-- Main trunk -->
+  <path d="M30 64 L32 64 L34 20 Q33 8 32 4 Q31 8 30 20 Z" fill="url(#sdt-trunk)"/>
+  <!-- Bark texture / cracks -->
+  <path d="M31 50 L31 30" stroke="#2e2a1e" stroke-width="1" fill="none"/>
+  <path d="M33 45 L33 25" stroke="#2e2a1e" stroke-width="0.8" fill="none"/>
+  <path d="M30 38 L32 36 L34 38" stroke="#2e2a1e" stroke-width="0.6" fill="none"/>
+  <!-- Gnarled branches -->
+  <path d="M32 28 L20 18 L18 14" stroke="url(#sdt-branch)" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M32 24 L42 12 L46 8" stroke="url(#sdt-branch)" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M32 20 L24 8 L22 4" stroke="url(#sdt-branch)" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M32 16 L38 6 L40 2" stroke="url(#sdt-branch)" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <!-- Lower dead branches -->
+  <path d="M30 44 L22 48" stroke="#3a4030" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M34 40 L42 36" stroke="#3a4030" stroke-width="1.2" fill="none" stroke-linecap="round"/>
+  <path d="M30 56 L26 60" stroke="#2e2a1e" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <path d="M34 54 L38 58" stroke="#2e2a1e" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <!-- Charred patches -->
+  <ellipse cx="28" cy="35" rx="3" ry="4" fill="#2e2a1e"/>
+  <ellipse cx="36" cy="28" rx="2" ry="3" fill="#2e2a1e"/>
+  <!-- Root base -->
+  <path d="M28 62 L26 64 L38 64 L36 62 Z" fill="#2e2a1e"/>
+  <ellipse cx="32" cy="63" rx="8" ry="2" fill="#3a4030"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_drydock.svg
+++ b/public/assets/raptor/terrain/struct_drydock.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="sd-wall" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="30%" stop-color="#6b3a1a"/>
+      <stop offset="70%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#3a2f2a"/>
+    </linearGradient>
+    <linearGradient id="sd-water" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3a2f2a"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="sd-plate" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Left wall -->
+  <rect x="0" y="20" width="14" height="44" fill="url(#sd-wall)"/>
+  <rect x="2" y="22" width="3" height="40" fill="#9a5a30"/>
+  <rect x="7" y="24" width="3" height="38" fill="#6b3a1a"/>
+  <rect x="11" y="26" width="2" height="36" fill="#8b5e3c"/>
+  <!-- Right wall -->
+  <rect x="50" y="20" width="14" height="44" fill="url(#sd-wall)"/>
+  <rect x="52" y="22" width="3" height="40" fill="#9a5a30"/>
+  <rect x="57" y="24" width="3" height="38" fill="#6b3a1a"/>
+  <rect x="59" y="26" width="2" height="36" fill="#8b5e3c"/>
+  <!-- Basin floor / water -->
+  <rect x="14" y="48" width="36" height="16" fill="url(#sd-water)"/>
+  <!-- Gantry left -->
+  <rect x="6" y="32" width="8" height="4" fill="url(#sd-plate)"/>
+  <rect x="8" y="34" width="4" height="14" fill="#3a2f2a"/>
+  <!-- Gantry right -->
+  <rect x="50" y="32" width="8" height="4" fill="url(#sd-plate)"/>
+  <rect x="52" y="34" width="4" height="14" fill="#3a2f2a"/>
+  <!-- Center gantry beam -->
+  <rect x="20" y="28" width="24" height="5" fill="#6b3a1a"/>
+  <rect x="22" y="30" width="20" height="2" fill="#8b5e3c"/>
+  <!-- Rivet plates on walls -->
+  <circle cx="4" cy="30" r="1.5" fill="#3a2f2a"/>
+  <circle cx="4" cy="44" r="1.5" fill="#3a2f2a"/>
+  <circle cx="60" cy="30" r="1.5" fill="#3a2f2a"/>
+  <circle cx="60" cy="44" r="1.5" fill="#3a2f2a"/>
+  <!-- Sloped basin edges -->
+  <polygon points="14,48 14,64 20,64 20,52" fill="#6b3a1a"/>
+  <polygon points="50,48 50,64 44,64 44,52" fill="#6b3a1a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_factory.svg
+++ b/public/assets/raptor/terrain/struct_factory.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="sf-wall" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="50%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="sf-roof" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </linearGradient>
+    <linearGradient id="sf-duct" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a3a3a"/>
+      <stop offset="100%" stop-color="#4a4a4a"/>
+    </linearGradient>
+  </defs>
+  <!-- Main building body -->
+  <rect x="8" y="28" width="48" height="36" fill="url(#sf-wall)"/>
+  <!-- Roof -->
+  <rect x="6" y="24" width="52" height="6" fill="url(#sf-roof)"/>
+  <!-- Ventilation ducts on roof -->
+  <rect x="12" y="18" width="8" height="8" fill="url(#sf-duct)"/>
+  <rect x="24" y="16" width="10" height="10" fill="url(#sf-duct)"/>
+  <rect x="38" y="18" width="8" height="8" fill="url(#sf-duct)"/>
+  <rect x="50" y="20" width="6" height="6" fill="url(#sf-duct)"/>
+  <!-- Duct caps -->
+  <rect x="14" y="14" width="4" height="4" fill="#2a2a2a"/>
+  <rect x="28" y="12" width="2" height="4" fill="#2a2a2a"/>
+  <rect x="40" y="14" width="4" height="4" fill="#2a2a2a"/>
+  <!-- Loading bay door -->
+  <rect x="22" y="44" width="20" height="16" fill="#1a1a1a"/>
+  <rect x="24" y="46" width="16" height="12" fill="#2a2a2a"/>
+  <!-- Door frame / warning stripe -->
+  <rect x="22" y="44" width="2" height="16" fill="#8a7a20"/>
+  <rect x="40" y="44" width="2" height="16" fill="#8a7a20"/>
+  <rect x="22" y="44" width="20" height="2" fill="#8a7a20"/>
+  <!-- Windows -->
+  <rect x="12" y="34" width="6" height="6" fill="#3a4a5a"/>
+  <rect x="46" y="34" width="6" height="6" fill="#3a4a5a"/>
+  <!-- Pipe copper accent -->
+  <rect x="56" y="32" width="4" height="24" fill="#6a4a3a"/>
+  <circle cx="58" cy="32" r="2" fill="#5a3a2a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_heavy_gate.svg
+++ b/public/assets/raptor/terrain/struct_heavy_gate.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="shg-frame" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="50%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="shg-door" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="50%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="shg-piston" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Heavy frame - top -->
+  <rect x="0" y="4" width="64" height="12" fill="url(#shg-frame)"/>
+  <!-- Frame sides -->
+  <rect x="0" y="16" width="12" height="48" fill="url(#shg-frame)"/>
+  <rect x="52" y="16" width="12" height="48" fill="url(#shg-frame)"/>
+  <!-- Frame bottom -->
+  <rect x="0" y="56" width="64" height="8" fill="url(#shg-frame)"/>
+  <!-- Blast doors - left and right halves -->
+  <rect x="14" y="18" width="18" height="36" fill="url(#shg-door)"/>
+  <rect x="32" y="18" width="18" height="36" fill="url(#shg-door)"/>
+  <!-- Center seam -->
+  <rect x="30" y="18" width="4" height="36" fill="#0a0a0a"/>
+  <!-- Hydraulic pistons left -->
+  <rect x="16" y="20" width="4" height="32" fill="url(#shg-piston)"/>
+  <rect x="16" y="18" width="6" height="4" fill="#2a2a2a"/>
+  <rect x="16" y="50" width="6" height="4" fill="#2a2a2a"/>
+  <!-- Hydraulic pistons right -->
+  <rect x="44" y="20" width="4" height="32" fill="url(#shg-piston)"/>
+  <rect x="42" y="18" width="6" height="4" fill="#2a2a2a"/>
+  <rect x="42" y="50" width="6" height="4" fill="#2a2a2a"/>
+  <!-- Door reinforcement strips -->
+  <rect x="16" y="28" width="14" height="3" fill="#1a1a1a"/>
+  <rect x="34" y="28" width="14" height="3" fill="#1a1a1a"/>
+  <rect x="16" y="40" width="14" height="3" fill="#1a1a1a"/>
+  <rect x="34" y="40" width="14" height="3" fill="#1a1a1a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_pipe_cluster.svg
+++ b/public/assets/raptor/terrain/struct_pipe_cluster.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="spc-pipe" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a3a3a"/>
+      <stop offset="50%" stop-color="#6a4a3a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </linearGradient>
+    <linearGradient id="spc-flange" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+  </defs>
+  <!-- Large horizontal pipe -->
+  <rect x="4" y="28" width="56" height="8" fill="url(#spc-pipe)"/>
+  <circle cx="8" cy="32" r="4" fill="url(#spc-flange)"/>
+  <circle cx="56" cy="32" r="4" fill="url(#spc-flange)"/>
+  <!-- Medium vertical pipe -->
+  <rect x="24" y="12" width="6" height="36" fill="url(#spc-pipe)"/>
+  <circle cx="27" cy="12" r="3" fill="url(#spc-flange)"/>
+  <!-- Valve wheel on vertical pipe -->
+  <circle cx="27" cy="24" r="4" fill="#2a2a2a"/>
+  <line x1="23" y1="24" x2="31" y2="24" stroke="#4a4a4a" stroke-width="2"/>
+  <line x1="27" y1="20" x2="27" y2="28" stroke="#4a4a4a" stroke-width="2"/>
+  <line x1="24.5" y1="21.5" x2="29.5" y2="26.5" stroke="#4a4a4a" stroke-width="1.5"/>
+  <line x1="24.5" y1="26.5" x2="29.5" y2="21.5" stroke="#4a4a4a" stroke-width="1.5"/>
+  <!-- Small pipe branch -->
+  <rect x="38" y="20" width="4" height="20" fill="#6a4a3a"/>
+  <circle cx="40" cy="20" r="2" fill="url(#spc-flange)"/>
+  <!-- Second valve -->
+  <circle cx="40" cy="30" r="3" fill="#2a2a2a"/>
+  <line x1="37" y1="30" x2="43" y2="30" stroke="#4a4a4a" stroke-width="1.5"/>
+  <line x1="40" y1="27" x2="40" y2="33" stroke="#4a4a4a" stroke-width="1.5"/>
+  <!-- Support bracket -->
+  <rect x="20" y="48" width="24" height="4" fill="#2a2a2a"/>
+  <rect x="22" y="44" width="4" height="12" fill="#3a3a3a"/>
+  <rect x="38" y="44" width="4" height="12" fill="#3a3a3a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_reactor_core.svg
+++ b/public/assets/raptor/terrain/struct_reactor_core.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="src-frame" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="50%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="src-core" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#cc0000"/>
+      <stop offset="50%" stop-color="#8a0000"/>
+      <stop offset="100%" stop-color="#5a0000"/>
+    </linearGradient>
+    <linearGradient id="src-glow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8a0000"/>
+      <stop offset="100%" stop-color="#cc0000"/>
+    </linearGradient>
+  </defs>
+  <!-- Angular outer frame -->
+  <polygon points="32,4 56,20 56,44 32,60 8,44 8,20" fill="url(#src-frame)"/>
+  <!-- Inner containment -->
+  <polygon points="32,12 48,24 48,40 32,52 16,40 16,24" fill="#1a1a1a"/>
+  <!-- Containment rings -->
+  <ellipse cx="32" cy="32" rx="18" ry="16" fill="none" stroke="#2a2a2a" stroke-width="2"/>
+  <ellipse cx="32" cy="32" rx="14" ry="12" fill="none" stroke="#2a2a2a" stroke-width="1.5"/>
+  <ellipse cx="32" cy="32" rx="10" ry="8" fill="none" stroke="#2a2a2a" stroke-width="1"/>
+  <!-- Glowing core -->
+  <ellipse cx="32" cy="32" rx="8" ry="6" fill="url(#src-core)"/>
+  <ellipse cx="32" cy="31" rx="4" ry="3" fill="url(#src-glow)"/>
+  <!-- Angular support struts -->
+  <polygon points="32,16 36,28 32,32 28,28" fill="#2a2a2a"/>
+  <polygon points="44,24 40,32 44,40 48,32" fill="#2a2a2a"/>
+  <polygon points="32,48 28,40 32,32 36,40" fill="#2a2a2a"/>
+  <polygon points="20,24 24,32 20,40 16,32" fill="#2a2a2a"/>
+  <!-- Base platform -->
+  <rect x="20" y="56" width="24" height="6" fill="#0a0a0a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_ruin.svg
+++ b/public/assets/raptor/terrain/struct_ruin.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="sr-wall" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2e2a1e"/>
+      <stop offset="50%" stop-color="#4a4a40"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="sr-rubble" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a40"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="sr-rebar" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a40"/>
+      <stop offset="100%" stop-color="#3a4030"/>
+    </linearGradient>
+  </defs>
+  <!-- Broken left wall -->
+  <polygon points="4,64 4,24 20,16 20,64" fill="url(#sr-wall)"/>
+  <polygon points="8,60 8,28 16,24 16,60" fill="#3a4030"/>
+  <!-- Collapsed center section -->
+  <polygon points="20,64 20,20 44,12 44,64" fill="url(#sr-rubble)"/>
+  <rect x="24" y="40" width="16" height="24" fill="#2e2a1e"/>
+  <!-- Exposed rebar -->
+  <line x1="18" y1="18" x2="18" y2="50" stroke="url(#sr-rebar)" stroke-width="1.5"/>
+  <line x1="22" y1="22" x2="22" y2="54" stroke="url(#sr-rebar)" stroke-width="1.5"/>
+  <line x1="42" y1="14" x2="42" y2="48" stroke="url(#sr-rebar)" stroke-width="1.5"/>
+  <line x1="38" y1="16" x2="38" y2="52" stroke="url(#sr-rebar)" stroke-width="1.5"/>
+  <!-- Bent beam -->
+  <path d="M12 32 L28 28 L32 44" stroke="#4a4a40" stroke-width="2.5" fill="none"/>
+  <!-- Right wall remnant -->
+  <polygon points="44,64 44,14 58,20 58,64" fill="url(#sr-wall)"/>
+  <polygon points="48,60 48,20 54,18 54,60" fill="#5a5530"/>
+  <!-- Rubble pile -->
+  <ellipse cx="32" cy="58" rx="18" ry="6" fill="#2e2a1e"/>
+  <polygon points="16,56 28,54 36,58 48,56" fill="#4a4a40"/>
+  <!-- Debris chunks -->
+  <rect x="8" y="52" width="6" height="4" fill="#4a4a40" transform="rotate(-15 11 54)"/>
+  <rect x="46" y="50" width="5" height="5" fill="#3a4030" transform="rotate(20 48 52)"/>
+  <polygon points="30,56 34,56 33,60 31,60" fill="#5a5530"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_satellite_dish.svg
+++ b/public/assets/raptor/terrain/struct_satellite_dish.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="ssd-hull" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a3a4a"/>
+      <stop offset="50%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#3a3a4a"/>
+    </linearGradient>
+    <linearGradient id="ssd-dish" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2a3a4a"/>
+      <stop offset="100%" stop-color="#1a1a30"/>
+    </linearGradient>
+    <linearGradient id="ssd-accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2a4a6a"/>
+      <stop offset="100%" stop-color="#3a6a8a"/>
+    </linearGradient>
+  </defs>
+  <!-- Articulated mount base -->
+  <rect x="26" y="48" width="12" height="16" fill="url(#ssd-hull)"/>
+  <rect x="28" y="44" width="8" height="8" fill="#0c0c14"/>
+  <!-- Mount arm -->
+  <rect x="30" y="28" width="4" height="20" fill="url(#ssd-hull)"/>
+  <!-- Parabolic reflector dish -->
+  <ellipse cx="32" cy="20" rx="14" ry="8" fill="url(#ssd-dish)"/>
+  <ellipse cx="32" cy="18" rx="10" ry="5" fill="#0c0c14"/>
+  <!-- Dish rim -->
+  <ellipse cx="32" cy="20" rx="14" ry="8" fill="none" stroke="#3a6a8a" stroke-width="1.5"/>
+  <!-- Feed horn / LNB -->
+  <rect x="30" y="12" width="4" height="8" fill="url(#ssd-hull)"/>
+  <rect x="31" y="8" width="2" height="4" fill="#3a6a8a"/>
+  <!-- Support struts -->
+  <line x1="22" y1="24" x2="30" y2="28" stroke="#5a5a6a" stroke-width="1.5"/>
+  <line x1="42" y1="24" x2="34" y2="28" stroke="#5a5a6a" stroke-width="1.5"/>
+  <!-- Base platform -->
+  <rect x="22" y="60" width="20" height="4" fill="#0c0c14"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_ship_hull.svg
+++ b/public/assets/raptor/terrain/struct_ship_hull.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="sh-hull" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6b3a1a"/>
+      <stop offset="50%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+    <linearGradient id="sh-plate" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#9a5a30"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+    <linearGradient id="sh-rust" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8b5e3c"/>
+      <stop offset="100%" stop-color="#6b3a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Curved hull outline -->
+  <path d="M8 48 Q8 20 32 12 Q56 20 56 48 L56 56 L8 56 Z" fill="url(#sh-hull)"/>
+  <!-- Hull plates / seams -->
+  <path d="M12 44 Q14 28 32 22 Q50 28 52 44" stroke="#3a2f2a" stroke-width="1.5" fill="none"/>
+  <path d="M16 40 Q18 26 32 20 Q46 26 48 40" stroke="#3a2f2a" stroke-width="1" fill="none"/>
+  <!-- Rivet rows -->
+  <circle cx="14" cy="36" r="1.5" fill="#3a2f2a"/>
+  <circle cx="22" cy="32" r="1.5" fill="#3a2f2a"/>
+  <circle cx="32" cy="30" r="1.5" fill="#3a2f2a"/>
+  <circle cx="42" cy="32" r="1.5" fill="#3a2f2a"/>
+  <circle cx="50" cy="36" r="1.5" fill="#3a2f2a"/>
+  <circle cx="16" cy="44" r="1" fill="#3a2f2a"/>
+  <circle cx="32" cy="40" r="1" fill="#3a2f2a"/>
+  <circle cx="48" cy="44" r="1" fill="#3a2f2a"/>
+  <!-- Portholes -->
+  <ellipse cx="20" cy="38" rx="4" ry="3" fill="#2e2a1e"/>
+  <circle cx="20" cy="38" r="2" fill="#3a2f2a"/>
+  <ellipse cx="32" cy="36" rx="4" ry="3" fill="#2e2a1e"/>
+  <circle cx="32" cy="36" r="2" fill="#3a2f2a"/>
+  <ellipse cx="44" cy="38" rx="4" ry="3" fill="#2e2a1e"/>
+  <circle cx="44" cy="38" r="2" fill="#3a2f2a"/>
+  <!-- Plate panels -->
+  <rect x="10" y="48" width="12" height="6" fill="url(#sh-plate)"/>
+  <rect x="24" y="50" width="16" height="4" fill="url(#sh-plate)"/>
+  <rect x="42" y="48" width="12" height="6" fill="url(#sh-plate)"/>
+  <!-- Rust streak -->
+  <path d="M28 24 L30 44" stroke="#6b3a1a" stroke-width="2" fill="none"/>
+  <path d="M36 22 L38 42" stroke="#6b3a1a" stroke-width="1.5" fill="none"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_smokestack.svg
+++ b/public/assets/raptor/terrain/struct_smokestack.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="ssm-stack" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="50%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#2a2a2a"/>
+    </linearGradient>
+    <linearGradient id="ssm-band" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a4a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </linearGradient>
+    <linearGradient id="ssm-smoke" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5a5a5a"/>
+      <stop offset="100%" stop-color="#3a3a3a"/>
+    </linearGradient>
+  </defs>
+  <!-- Base platform -->
+  <rect x="20" y="52" width="24" height="8" fill="#2a2a2a"/>
+  <rect x="22" y="50" width="20" height="4" fill="#3a3a3a"/>
+  <!-- Chimney stack -->
+  <rect x="24" y="8" width="16" height="44" fill="url(#ssm-stack)"/>
+  <!-- Reinforcement bands -->
+  <rect x="22" y="12" width="20" height="3" fill="url(#ssm-band)"/>
+  <rect x="22" y="24" width="20" height="3" fill="url(#ssm-band)"/>
+  <rect x="22" y="36" width="20" height="3" fill="url(#ssm-band)"/>
+  <rect x="22" y="44" width="20" height="3" fill="url(#ssm-band)"/>
+  <!-- Warning stripe -->
+  <rect x="26" y="28" width="12" height="2" fill="#8a7a20"/>
+  <!-- Smoke wisps -->
+  <ellipse cx="28" cy="4" rx="4" ry="3" fill="#4a4a4a" opacity="0.7"/>
+  <ellipse cx="36" cy="2" rx="5" ry="2" fill="#5a5a5a" opacity="0.5"/>
+  <ellipse cx="32" cy="6" rx="3" ry="2" fill="#3a3a3a" opacity="0.6"/>
+  <!-- Rivet details -->
+  <circle cx="26" cy="13" r="1" fill="#2a2a2a"/>
+  <circle cx="38" cy="13" r="1" fill="#2a2a2a"/>
+  <circle cx="26" cy="25" r="1" fill="#2a2a2a"/>
+  <circle cx="38" cy="25" r="1" fill="#2a2a2a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_solar_panel.svg
+++ b/public/assets/raptor/terrain/struct_solar_panel.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="ssp-panel" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2a3a4a"/>
+      <stop offset="100%" stop-color="#0c0c14"/>
+    </linearGradient>
+    <linearGradient id="ssp-cell" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a2a3a"/>
+      <stop offset="100%" stop-color="#3a6a8a"/>
+    </linearGradient>
+    <linearGradient id="ssp-arm" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a3a4a"/>
+      <stop offset="100%" stop-color="#5a5a6a"/>
+    </linearGradient>
+  </defs>
+  <!-- Central mast -->
+  <rect x="30" y="40" width="4" height="24" fill="url(#ssp-arm)"/>
+  <!-- Angular arm structure -->
+  <rect x="8" y="20" width="48" height="4" fill="url(#ssp-arm)"/>
+  <rect x="12" y="12" width="4" height="16" fill="url(#ssp-arm)"/>
+  <rect x="48" y="12" width="4" height="16" fill="url(#ssp-arm)"/>
+  <line x1="16" y1="16" x2="48" y2="16" stroke="#5a5a6a" stroke-width="1"/>
+  <!-- Solar panel arrays (folded out) -->
+  <rect x="8" y="4" width="20" height="14" fill="url(#ssp-panel)"/>
+  <rect x="36" y="4" width="20" height="14" fill="url(#ssp-panel)"/>
+  <!-- Grid cells on left panel -->
+  <rect x="10" y="6" width="5" height="4" fill="url(#ssp-cell)"/>
+  <rect x="17" y="6" width="5" height="4" fill="url(#ssp-cell)"/>
+  <rect x="10" y="12" width="5" height="4" fill="url(#ssp-cell)"/>
+  <rect x="17" y="12" width="5" height="4" fill="url(#ssp-cell)"/>
+  <!-- Grid cells on right panel -->
+  <rect x="38" y="6" width="5" height="4" fill="url(#ssp-cell)"/>
+  <rect x="45" y="6" width="5" height="4" fill="url(#ssp-cell)"/>
+  <rect x="38" y="12" width="5" height="4" fill="url(#ssp-cell)"/>
+  <rect x="45" y="12" width="5" height="4" fill="url(#ssp-cell)"/>
+  <!-- Panel frames -->
+  <rect x="8" y="4" width="20" height="14" fill="none" stroke="#3a6a8a" stroke-width="0.5"/>
+  <rect x="36" y="4" width="20" height="14" fill="none" stroke="#3a6a8a" stroke-width="0.5"/>
+  <!-- Base -->
+  <rect x="26" y="60" width="12" height="4" fill="#0c0c14"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_station_module.svg
+++ b/public/assets/raptor/terrain/struct_station_module.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="ssm2-hull" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a1a30"/>
+      <stop offset="50%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#1a1a30"/>
+    </linearGradient>
+    <linearGradient id="ssm2-cyl" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2a2a40"/>
+      <stop offset="50%" stop-color="#5a5a6a"/>
+      <stop offset="100%" stop-color="#2a2a40"/>
+    </linearGradient>
+    <linearGradient id="ssm2-port" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0c0c14"/>
+      <stop offset="100%" stop-color="#3a6a8a"/>
+    </linearGradient>
+  </defs>
+  <!-- Main cylindrical module -->
+  <ellipse cx="32" cy="36" rx="18" ry="24" fill="url(#ssm2-cyl)"/>
+  <!-- Cylinder end caps -->
+  <ellipse cx="32" cy="12" rx="14" ry="6" fill="url(#ssm2-hull)"/>
+  <ellipse cx="32" cy="60" rx="14" ry="6" fill="url(#ssm2-hull)"/>
+  <!-- Docking ports -->
+  <circle cx="14" cy="32" r="6" fill="url(#ssm2-port)"/>
+  <circle cx="14" cy="32" r="4" fill="#0c0c14"/>
+  <circle cx="50" cy="32" r="6" fill="url(#ssm2-port)"/>
+  <circle cx="50" cy="32" r="4" fill="#0c0c14"/>
+  <!-- Top docking port -->
+  <circle cx="32" cy="8" r="4" fill="url(#ssm2-port)"/>
+  <circle cx="32" cy="8" r="2" fill="#0c0c14"/>
+  <!-- Accent bands -->
+  <ellipse cx="32" cy="24" rx="16" ry="2" fill="#3a6a8a" opacity="0.6"/>
+  <ellipse cx="32" cy="48" rx="16" ry="2" fill="#3a6a8a" opacity="0.6"/>
+  <!-- Window / viewport -->
+  <ellipse cx="32" cy="36" rx="4" ry="3" fill="#1a2a4a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_turret_base.svg
+++ b/public/assets/raptor/terrain/struct_turret_base.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="stb-base" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="50%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="stb-barrel" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="50%" stop-color="#3a3a3a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="stb-armor" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2a2a2a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- Reinforced base platform -->
+  <rect x="4" y="48" width="56" height="16" fill="url(#stb-base)"/>
+  <rect x="8" y="44" width="48" height="8" fill="#2a2a2a"/>
+  <rect x="10" y="42" width="44" height="4" fill="#1a1a1a"/>
+  <!-- Turret housing - armored -->
+  <rect x="18" y="24" width="28" height="24" fill="url(#stb-armor)"/>
+  <rect x="20" y="26" width="24" height="20" fill="#1a1a1a"/>
+  <!-- Barrel pointing up -->
+  <rect x="28" y="4" width="8" height="24" fill="url(#stb-barrel)"/>
+  <rect x="30" y="2" width="4" height="6" fill="#2a2a2a"/>
+  <circle cx="32" cy="6" r="2" fill="#1a1a1a"/>
+  <!-- Barrel housing ring -->
+  <rect x="24" y="22" width="16" height="4" fill="#2a2a2a"/>
+  <!-- Side armor plates -->
+  <rect x="14" y="28" width="6" height="16" fill="#2a2a2a"/>
+  <rect x="44" y="28" width="6" height="16" fill="#2a2a2a"/>
+  <!-- Base reinforcement -->
+  <rect x="12" y="50" width="8" height="12" fill="#1a1a1a"/>
+  <rect x="44" y="50" width="8" height="12" fill="#1a1a1a"/>
+</svg>

--- a/public/assets/raptor/terrain/struct_wrecked_tank.svg
+++ b/public/assets/raptor/terrain/struct_wrecked_tank.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="swt-armor" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4a4a40"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="swt-hull" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3a4030"/>
+      <stop offset="100%" stop-color="#2e2a1e"/>
+    </linearGradient>
+    <linearGradient id="swt-tread" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5a5530"/>
+      <stop offset="100%" stop-color="#3a4030"/>
+    </linearGradient>
+  </defs>
+  <!-- Overturned chassis body -->
+  <polygon points="8,48 8,36 24,28 40,28 56,36 56,48 40,52 24,52" fill="url(#swt-armor)"/>
+  <!-- Hull plates -->
+  <polygon points="12,44 12,38 22,34 38,34 48,38 48,44 38,48 22,48" fill="url(#swt-hull)"/>
+  <!-- Bent/damaged armor -->
+  <path d="M16 40 L28 36 L40 40 L50 38" stroke="#2e2a1e" stroke-width="1.5" fill="none"/>
+  <polygon points="20,42 26,40 28,46 22,48" fill="#3a4030"/>
+  <!-- Broken turret (detached) -->
+  <ellipse cx="18" cy="32" rx="8" ry="6" fill="url(#swt-armor)"/>
+  <ellipse cx="18" cy="32" rx="4" ry="3" fill="#2e2a1e"/>
+  <path d="M14 30 L22 34" stroke="#4a4a40" stroke-width="1" fill="none"/>
+  <!-- Gun barrel (bent) -->
+  <path d="M22 32 L32 28 L38 30" stroke="#3a4030" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Exposed tread (left) -->
+  <rect x="10" y="46" width="6" height="8" fill="url(#swt-tread)"/>
+  <line x1="11" y1="48" x2="15" y2="48" stroke="#2e2a1e" stroke-width="0.5"/>
+  <line x1="11" y1="51" x2="15" y2="51" stroke="#2e2a1e" stroke-width="0.5"/>
+  <line x1="11" y1="54" x2="15" y2="54" stroke="#2e2a1e" stroke-width="0.5"/>
+  <!-- Exposed tread (right) -->
+  <rect x="48" y="46" width="6" height="8" fill="url(#swt-tread)"/>
+  <line x1="49" y1="48" x2="53" y2="48" stroke="#2e2a1e" stroke-width="0.5"/>
+  <line x1="49" y1="51" x2="53" y2="51" stroke="#2e2a1e" stroke-width="0.5"/>
+  <line x1="49" y1="54" x2="53" y2="54" stroke="#2e2a1e" stroke-width="0.5"/>
+  <!-- Road wheels -->
+  <circle cx="22" cy="50" r="4" fill="#2e2a1e"/>
+  <circle cx="22" cy="50" r="2" fill="#4a4a40"/>
+  <circle cx="42" cy="50" r="4" fill="#2e2a1e"/>
+  <circle cx="42" cy="50" r="2" fill="#4a4a40"/>
+  <!-- Hull damage / hole -->
+  <ellipse cx="34" cy="42" rx="5" ry="4" fill="#2e2a1e"/>
+  <!-- Rust / scorch -->
+  <path d="M28 36 L32 44" stroke="#5a5530" stroke-width="1.5" fill="none"/>
+  <ellipse cx="30" cy="38" rx="2" ry="1.5" fill="#5a5530"/>
+</svg>

--- a/src/games/raptor/rendering/assets.ts
+++ b/src/games/raptor/rendering/assets.ts
@@ -52,4 +52,73 @@ export const ASSET_MANIFEST: AssetManifest = {
   prop_rocks:          `${TERRAIN}prop_rocks.svg`,
   prop_tire_tracks:    `${TERRAIN}prop_tire_tracks.svg`,
   prop_debris:         `${TERRAIN}prop_debris.svg`,
+
+  // Level 6–10 Horizons
+  horizon_shipyard:      `${TERRAIN}horizon_shipyard.svg`,
+  horizon_wasteland:     `${TERRAIN}horizon_wasteland.svg`,
+  horizon_industrial:    `${TERRAIN}horizon_industrial.svg`,
+  horizon_orbital:       `${TERRAIN}horizon_orbital.svg`,
+  horizon_stronghold:    `${TERRAIN}horizon_stronghold.svg`,
+
+  // Level 6–10 Ground Textures
+  ground_rust:           `${TERRAIN}ground_rust.svg`,
+  ground_ash:            `${TERRAIN}ground_ash.svg`,
+  ground_metal:          `${TERRAIN}ground_metal.svg`,
+  ground_hull_plate:     `${TERRAIN}ground_hull_plate.svg`,
+  ground_dark_metal:     `${TERRAIN}ground_dark_metal.svg`,
+
+  // Level 6 Structures (Shipyard)
+  struct_crane:          `${TERRAIN}struct_crane.svg`,
+  struct_drydock:        `${TERRAIN}struct_drydock.svg`,
+  struct_ship_hull:      `${TERRAIN}struct_ship_hull.svg`,
+  struct_cargo_container: `${TERRAIN}struct_cargo_container.svg`,
+
+  // Level 7 Structures (Wasteland)
+  struct_ruin:           `${TERRAIN}struct_ruin.svg`,
+  struct_dead_tree:      `${TERRAIN}struct_dead_tree.svg`,
+  struct_wrecked_tank:   `${TERRAIN}struct_wrecked_tank.svg`,
+
+  // Level 8 Structures (Industrial)
+  struct_smokestack:     `${TERRAIN}struct_smokestack.svg`,
+  struct_factory:        `${TERRAIN}struct_factory.svg`,
+  struct_conveyor:       `${TERRAIN}struct_conveyor.svg`,
+  struct_cooling_tower:  `${TERRAIN}struct_cooling_tower.svg`,
+  struct_pipe_cluster:   `${TERRAIN}struct_pipe_cluster.svg`,
+
+  // Level 9 Structures (Orbital)
+  struct_satellite_dish: `${TERRAIN}struct_satellite_dish.svg`,
+  struct_solar_panel:    `${TERRAIN}struct_solar_panel.svg`,
+  struct_station_module: `${TERRAIN}struct_station_module.svg`,
+  struct_antenna_array:  `${TERRAIN}struct_antenna_array.svg`,
+
+  // Level 10 Structures (Stronghold)
+  struct_cylon_tower:    `${TERRAIN}struct_cylon_tower.svg`,
+  struct_turret_base:    `${TERRAIN}struct_turret_base.svg`,
+  struct_heavy_gate:     `${TERRAIN}struct_heavy_gate.svg`,
+  struct_reactor_core:   `${TERRAIN}struct_reactor_core.svg`,
+
+  // Level 6 Props (Shipyard)
+  prop_scrap_metal:      `${TERRAIN}prop_scrap_metal.svg`,
+  prop_oil_drum:         `${TERRAIN}prop_oil_drum.svg`,
+  prop_anchor:           `${TERRAIN}prop_anchor.svg`,
+
+  // Level 7 Props (Wasteland)
+  prop_bones:            `${TERRAIN}prop_bones.svg`,
+  prop_radiation_sign:   `${TERRAIN}prop_radiation_sign.svg`,
+
+  // Level 8 Props (Industrial)
+  prop_grate:            `${TERRAIN}prop_grate.svg`,
+  prop_steam_vent:       `${TERRAIN}prop_steam_vent.svg`,
+
+  // Level 9 Props (Orbital)
+  prop_space_debris:     `${TERRAIN}prop_space_debris.svg`,
+  prop_hull_fragment:    `${TERRAIN}prop_hull_fragment.svg`,
+  prop_wiring:           `${TERRAIN}prop_wiring.svg`,
+  prop_panel_shard:      `${TERRAIN}prop_panel_shard.svg`,
+
+  // Level 10 Props (Stronghold)
+  prop_red_light:        `${TERRAIN}prop_red_light.svg`,
+  prop_cable_cluster:    `${TERRAIN}prop_cable_cluster.svg`,
+  prop_vent_grate:       `${TERRAIN}prop_vent_grate.svg`,
+  prop_blast_mark:       `${TERRAIN}prop_blast_mark.svg`,
 };


### PR DESCRIPTION
## PR: raptor — Add SVG terrain assets for levels 6–10 (BSG grimy aesthetic)

### Summary / Why
This PR adds the missing terrain art for the new Battlestar Galactica–themed Raptor levels (6–10) and wires the assets into the existing loading pipeline.

Previously, levels 6–10 referenced terrain asset keys in `src/games/raptor/levels.ts`, but the corresponding SVG files and manifest entries didn’t exist—so the game would load and run, but terrain elements would render as empty/blank. This PR fills that gap by introducing a full set of grimy, industrial, war-torn SVG assets and registering them in the asset manifest.

### What changed
- Added **45 new SVG terrain assets** under `public/assets/raptor/terrain/`, covering:
  - **Horizons** (5) — `800x200` skyline silhouettes per theme
  - **Ground textures** (5) — `128x128`, designed to be **seamlessly tileable**
  - **Structures** (20) — `64x64` industrial/BSG set dressing, compatible with horizontal mirroring
  - **Props** (15) — `64x64`, designed to read at small sizes and render well with opacity
- Updated the terrain `ASSET_MANIFEST` to include all new keys/paths, matching the **authoritative keys used by the level configs** for levels 6–10.

### Key files modified
- `src/games/raptor/rendering/assets.ts`
  - Registered all new terrain assets in `ASSET_MANIFEST` using the existing `${TERRAIN}` prefix.
- `public/assets/raptor/terrain/`
  - Added 45 new SVG files:
    - Horizons: `horizon_shipyard.svg`, `horizon_wasteland.svg`, `horizon_industrial.svg`, `horizon_orbital.svg`, `horizon_stronghold.svg`
    - Grounds: `ground_rust.svg`, `ground_ash.svg`, `ground_metal.svg`, `ground_hull_plate.svg`, `ground_dark_metal.svg`
    - Structures + Props: shipyard/wasteland/industrial/orbital/stronghold sets (cranes, ruins, towers, debris, vents, etc.)

### Notes / Compatibility
- **No rendering/logic changes** were required—`AssetLoader` + `TerrainRenderer` already support optional assets; this PR supplies the missing files and manifest keys so levels 6–10 render as intended.
- Asset keys were aligned to what `levels.ts` references (including keys that differed from the original issue text), to avoid silent `getOptional()` misses.

### Testing
- **Manual / Visual QA**
  - Loaded levels **6–10** and confirmed ground textures, structures, and props render (no blank terrain).
  - Verified **ground textures tile cleanly** (no visible seams in repeated patterns).
  - Spot-checked that **structures look acceptable when mirrored**, and props remain recognizable at small render sizes/opacity.
- **Runtime**
  - Confirmed no console warnings for missing terrain assets after `AssetLoader.loadAll()` completes.

### Related
- Implements: **Issue: “raptor: Create SVG terrain assets for levels 6–10 (BSG grimy aesthetic)”**
- Part of epic **#418**
- Pairs with previously-merged level config work (levels 6–10 added on `main`).

Ref: https://github.com/asgardtech/archer/issues/442