### PR TITLE
raptor: Update level-related tests for 10-level game progression

### DIFF
--- a/tests/raptor-combat-commands.test.ts
+++ b/tests/raptor-combat-commands.test.ts
@@ -31,13 +31,18 @@ function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
 
   return {
     currentLevel: 0,
-    levelCount: 5,
+    levelCount: 10,
     levels: [
-      { level: 1, name: "Coastal Raid" },
-      { level: 2, name: "Desert Storm" },
+      { level: 1, name: "Coastal Patrol" },
+      { level: 2, name: "Desert Strike" },
       { level: 3, name: "Mountain Assault" },
-      { level: 4, name: "Arctic Fury" },
-      { level: 5, name: "Fortress" },
+      { level: 4, name: "Arctic Thunder" },
+      { level: 5, name: "Final Fortress" },
+      { level: 6, name: "Shipyard Ruins" },
+      { level: 7, name: "Scorched Wastes" },
+      { level: 8, name: "Industrial Core" },
+      { level: 9, name: "Orbital Debris" },
+      { level: 10, name: "Cylon Stronghold" },
     ] as any,
     startLevel: () => {},
     setState: () => {},
@@ -647,7 +652,7 @@ describe("status command", () => {
     const ctx = makeContext({ currentLevel: 0 });
 
     const result = registry.dispatch("status", ctx);
-    expect(result).toContainEqual("Level: 1 - Coastal Raid");
+    expect(result).toContainEqual("Level: 1 - Coastal Patrol");
   });
 
   test("Status shows correct weapon", () => {

--- a/tests/raptor-player-commands.test.ts
+++ b/tests/raptor-player-commands.test.ts
@@ -18,7 +18,7 @@ function makePlayer(): Player {
 function makeContext(player: Player, overrides: Partial<CommandContext> = {}): CommandContext {
   return {
     currentLevel: 0,
-    levelCount: 5,
+    levelCount: 10,
     levels: [{ level: 1, name: "Test" }] as any,
     startLevel: () => {},
     setState: () => {},
@@ -30,6 +30,16 @@ function makeContext(player: Player, overrides: Partial<CommandContext> = {}): C
     canvasHeight: CANVAS_HEIGHT,
     powerUpManager: new PowerUpManager(),
     weaponSystem: new WeaponSystem(),
+    score: 0,
+    totalScore: 0,
+    setScore: () => {},
+    addScore: (v: number) => v,
+    enemies: [],
+    enemyBullets: [],
+    spawnEnemy: (variant) => new (require("../src/games/raptor/entities/Enemy").Enemy)(100, -30, variant),
+    destroyAllEnemies: () => 0,
+    showFps: false,
+    toggleFps: () => false,
     ...overrides,
   };
 }

--- a/tests/raptor-qa.test.ts
+++ b/tests/raptor-qa.test.ts
@@ -1114,12 +1114,12 @@ describe("Scenario: Audio manifest covers all RaptorSoundEvent values", () => {
     expect(Object.keys(AUDIO_MANIFEST.sfx).length).toBe(18);
   });
 
-  test("AUDIO_MANIFEST.music has entries for menu and level_1 through level_5", () => {
+  test("AUDIO_MANIFEST.music has entries for menu and level_1 through level_10", () => {
     expect(AUDIO_MANIFEST.music.menu).toBeDefined();
-    for (let i = 1; i <= 5; i++) {
+    for (let i = 1; i <= 10; i++) {
       expect(AUDIO_MANIFEST.music[`level_${i}`]).toBeDefined();
     }
-    expect(Object.keys(AUDIO_MANIFEST.music).length).toBe(6);
+    expect(Object.keys(AUDIO_MANIFEST.music).length).toBe(11);
   });
 });
 
@@ -1170,6 +1170,8 @@ describe("Scenario: Music track assets exist for menu and all levels", () => {
   const expectedFiles = [
     "menu.mp3", "level_1_coastal.mp3", "level_2_desert.mp3",
     "level_3_mountain.mp3", "level_4_arctic.mp3", "level_5_fortress.mp3",
+    "level_6_shipyard.mp3", "level_7_wasteland.mp3", "level_8_industrial.mp3",
+    "level_9_orbital.mp3", "level_10_stronghold.mp3",
   ];
 
   for (const file of expectedFiles) {
@@ -1393,11 +1395,9 @@ describe("Scenario: Music buffer playback with fallback", () => {
 
     sound.stopMusic();
     expect(mockAudio.stopBuffer).toHaveBeenCalledWith("menu");
-    expect(mockAudio.stopBuffer).toHaveBeenCalledWith("level_1");
-    expect(mockAudio.stopBuffer).toHaveBeenCalledWith("level_2");
-    expect(mockAudio.stopBuffer).toHaveBeenCalledWith("level_3");
-    expect(mockAudio.stopBuffer).toHaveBeenCalledWith("level_4");
-    expect(mockAudio.stopBuffer).toHaveBeenCalledWith("level_5");
+    for (let i = 1; i <= 10; i++) {
+      expect(mockAudio.stopBuffer).toHaveBeenCalledWith(`level_${i}`);
+    }
 
     sound.destroy();
   });
@@ -1983,7 +1983,7 @@ describe("Scenario: Level configuration validation", () => {
       expect(level.powerUpDropChance).toBeLessThanOrEqual(1);
       expect(level.skyGradient).toBeDefined();
       expect(level.skyGradient.length).toBe(2);
-      expect(level.starDensity).toBeGreaterThan(0);
+      expect(level.starDensity).toBeGreaterThanOrEqual(0);
       expect(level.enemyFireRateMultiplier).toBeGreaterThanOrEqual(1);
     }
   });

--- a/tests/raptor-save.test.ts
+++ b/tests/raptor-save.test.ts
@@ -339,6 +339,23 @@ describe("Scenario: Additional validation edge cases", () => {
     mockStorage["raptor_save"] = "null";
     expect(SaveSystem.load()).toBeNull();
   });
+
+  test("levelReached values 5 through 9 are valid for the 10-level game", () => {
+    for (let level = 5; level <= 9; level++) {
+      const data = validSaveData({ levelReached: level });
+      SaveSystem.save(data);
+      const loaded = SaveSystem.load();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.levelReached).toBe(level);
+    }
+  });
+
+  test("levelReached of 10 (out of bounds) is rejected", () => {
+    const data = validSaveData({ levelReached: 10 } as any);
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
 });
 
 // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## PR: raptor — Update level-related tests for 10-level game progression (Issue #447)

### Summary (what changed + why)
Raptor now has **10 levels**, but several test suites still contained **5-level assumptions** (counts, max indices, music entries, and mock command contexts). This PR updates the affected tests to align with the **10-level progression** and fixes the currently failing QA assertions around audio manifest coverage and level config validation.

Key updates:
- Adjusted QA tests to expect **menu + 10 level music tracks** (11 total) and to validate **level_1 → level_10** entries/files.
- Updated level config validation to allow `starDensity` of **0** (valid for terrain-based levels).
- Updated dev-console command tests to use **levelCount: 10** and a 10-entry levels list with correct names.
- Expanded save/load coverage to explicitly validate `levelReached` values **5–9** and reject **10** as out-of-bounds.

### Key files modified
- `tests/raptor-qa.test.ts`
  - Updated `AUDIO_MANIFEST.music` expectations (count 6 → 11; loop to level_10)
  - Extended music file existence checks through `level_10_*`
  - Updated `stopMusic()` assertions to stop buffers for all 10 levels
  - Relaxed level validation: `starDensity >= 0` (was `> 0`)
- `tests/raptor-combat-commands.test.ts`
  - Updated mock `levelCount` (5 → 10)
  - Expanded mock `levels` array to 10 entries with correct names
  - Fixed `status` output assertion for level 1 name (“Coastal Raid” → “Coastal Patrol”)
- `tests/raptor-player-commands.test.ts`
  - Updated mock `levelCount` (5 → 10)
  - Added missing required `CommandContext` fields to keep mocks consistent
- `tests/raptor-save.test.ts`
  - Added explicit validation tests for `levelReached` **5–9**
  - Added out-of-bounds rejection test for `levelReached: 10`

### Testing notes
- Ran/expected: `npm test`
- Fixes the previously reported failures in `tests/raptor-qa.test.ts`:
  - `AUDIO_MANIFEST.music` count mismatch (now 11)
  - `starDensity` validation now matches actual level configs (allows 0)
- All test suites should pass cleanly after these updates (no source/game logic changes included).

Ref: https://github.com/asgardtech/archer/issues/447