### PR TITLE
raptor: define EnemyWeaponType type system and configuration

### DIFF
--- a/src/games/raptor/entities/Enemy.ts
+++ b/src/games/raptor/entities/Enemy.ts
@@ -1,4 +1,4 @@
-import { Vec2, EnemyVariant, EnemyConfig, ENEMY_CONFIGS } from "../types";
+import { Vec2, EnemyVariant, EnemyConfig, EnemyWeaponType, ENEMY_CONFIGS } from "../types";
 
 export class Enemy {
   public pos: Vec2;
@@ -11,6 +11,7 @@ export class Enemy {
   public fireCooldown: number;
   public width: number;
   public height: number;
+  public readonly weaponType: EnemyWeaponType;
   public alive = true;
 
   private flashTimer = 0;
@@ -29,6 +30,7 @@ export class Enemy {
     this.fireCooldown = Math.random() * (1 / Math.max(this.fireRate, 0.1));
     this.width = config.width;
     this.height = config.height;
+    this.weaponType = config.weaponType ?? "standard";
 
     const actualSpeed = speed ?? config.speed;
     this.pos = { x, y };

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -13,6 +13,67 @@ export type RaptorGameState =
 
 export type EnemyVariant = "scout" | "fighter" | "bomber" | "boss";
 
+export type EnemyWeaponType = "standard" | "spread" | "missile" | "laser";
+
+export interface EnemyWeaponConfig {
+  type: EnemyWeaponType;
+  damage: number;
+  projectileSpeed: number;
+  projectileCount: number;
+  spreadAngle: number;
+  homing: boolean;
+  homingStrength: number;
+  fireRateMultiplier: number;
+  spriteKey: string;
+}
+
+export const ENEMY_WEAPON_CONFIGS: Record<EnemyWeaponType, EnemyWeaponConfig> = {
+  standard: {
+    type: "standard",
+    damage: 25,
+    projectileSpeed: 300,
+    projectileCount: 1,
+    spreadAngle: 0,
+    homing: false,
+    homingStrength: 0,
+    fireRateMultiplier: 1.0,
+    spriteKey: "bullet_enemy",
+  },
+  spread: {
+    type: "spread",
+    damage: 15,
+    projectileSpeed: 280,
+    projectileCount: 3,
+    spreadAngle: 0.5,
+    homing: false,
+    homingStrength: 0,
+    fireRateMultiplier: 0.7,
+    spriteKey: "bullet_enemy",
+  },
+  missile: {
+    type: "missile",
+    damage: 40,
+    projectileSpeed: 200,
+    projectileCount: 1,
+    spreadAngle: 0,
+    homing: true,
+    homingStrength: 1.5,
+    fireRateMultiplier: 0.4,
+    spriteKey: "missile_enemy",
+  },
+  laser: {
+    type: "laser",
+    damage: 10,
+    projectileSpeed: 0,
+    projectileCount: 1,
+    spreadAngle: 0,
+    homing: false,
+    homingStrength: 0,
+    fireRateMultiplier: 0.0,
+    spriteKey: "laser_enemy",
+  },
+};
+
 export interface EnemyConfig {
   variant: EnemyVariant;
   hitPoints: number;
@@ -21,6 +82,7 @@ export interface EnemyConfig {
   fireRate: number;
   width: number;
   height: number;
+  weaponType?: EnemyWeaponType;
 }
 
 export type RaptorPowerUpType =
@@ -49,7 +111,12 @@ export type RaptorSoundEvent =
   | "missile_hit"
   | "laser_fire"
   | "laser_hit"
-  | "weapon_switch";
+  | "weapon_switch"
+  | "enemy_spread_fire"
+  | "enemy_missile_fire"
+  | "enemy_laser_fire"
+  | "enemy_missile_hit"
+  | "enemy_laser_hit";
 
 export type WeaponType = "machine-gun" | "missile" | "laser";
 
@@ -224,6 +291,7 @@ export const ENEMY_CONFIGS: Record<EnemyVariant, EnemyConfig> = {
     fireRate: 0.8,
     width: 30,
     height: 30,
+    weaponType: "standard",
   },
   bomber: {
     variant: "bomber",
@@ -233,6 +301,7 @@ export const ENEMY_CONFIGS: Record<EnemyVariant, EnemyConfig> = {
     fireRate: 0.5,
     width: 40,
     height: 36,
+    weaponType: "standard",
   },
   boss: {
     variant: "boss",
@@ -242,5 +311,6 @@ export const ENEMY_CONFIGS: Record<EnemyVariant, EnemyConfig> = {
     fireRate: 1.5,
     width: 64,
     height: 56,
+    weaponType: "standard",
   },
 };

--- a/tests/raptor-enemy-weapons.test.ts
+++ b/tests/raptor-enemy-weapons.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for Issue #449: EnemyWeaponType type system and configuration
+ */
+
+import {
+  EnemyWeaponType,
+  EnemyWeaponConfig,
+  ENEMY_WEAPON_CONFIGS,
+  EnemyConfig,
+  ENEMY_CONFIGS,
+  RaptorSoundEvent,
+} from "../src/games/raptor/types";
+import { Enemy } from "../src/games/raptor/entities/Enemy";
+
+// ─── EnemyWeaponType union type ──────────────────────────────────
+
+describe("EnemyWeaponType", () => {
+  test("all four values are assignable to EnemyWeaponType", () => {
+    const types: EnemyWeaponType[] = ["standard", "spread", "missile", "laser"];
+    expect(types).toHaveLength(4);
+  });
+});
+
+// ─── ENEMY_WEAPON_CONFIGS record ──────────────────────────────────
+
+describe("ENEMY_WEAPON_CONFIGS", () => {
+  test("has exactly 4 entries", () => {
+    expect(Object.keys(ENEMY_WEAPON_CONFIGS)).toHaveLength(4);
+  });
+
+  test("has a key for each EnemyWeaponType", () => {
+    expect(ENEMY_WEAPON_CONFIGS["standard"]).toBeDefined();
+    expect(ENEMY_WEAPON_CONFIGS["spread"]).toBeDefined();
+    expect(ENEMY_WEAPON_CONFIGS["missile"]).toBeDefined();
+    expect(ENEMY_WEAPON_CONFIGS["laser"]).toBeDefined();
+  });
+
+  test("each config type field matches its key", () => {
+    for (const key of Object.keys(ENEMY_WEAPON_CONFIGS) as EnemyWeaponType[]) {
+      expect(ENEMY_WEAPON_CONFIGS[key].type).toBe(key);
+    }
+  });
+
+  test("all weapon configs have positive damage", () => {
+    for (const key of Object.keys(ENEMY_WEAPON_CONFIGS) as EnemyWeaponType[]) {
+      expect(ENEMY_WEAPON_CONFIGS[key].damage).toBeGreaterThan(0);
+    }
+  });
+
+  test("all weapon configs have non-negative projectile speed", () => {
+    for (const key of Object.keys(ENEMY_WEAPON_CONFIGS) as EnemyWeaponType[]) {
+      expect(ENEMY_WEAPON_CONFIGS[key].projectileSpeed).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+// ─── Standard weapon config ──────────────────────────────────────
+
+describe("ENEMY_WEAPON_CONFIGS standard", () => {
+  const cfg = ENEMY_WEAPON_CONFIGS["standard"];
+
+  test("preserves existing enemy bullet behavior", () => {
+    expect(cfg.damage).toBe(25);
+    expect(cfg.projectileSpeed).toBe(300);
+    expect(cfg.projectileCount).toBe(1);
+    expect(cfg.spreadAngle).toBe(0);
+    expect(cfg.homing).toBe(false);
+    expect(cfg.homingStrength).toBe(0);
+    expect(cfg.fireRateMultiplier).toBe(1.0);
+    expect(cfg.spriteKey).toBe("bullet_enemy");
+  });
+});
+
+// ─── Spread weapon config ────────────────────────────────────────
+
+describe("ENEMY_WEAPON_CONFIGS spread", () => {
+  const cfg = ENEMY_WEAPON_CONFIGS["spread"];
+
+  test("defines multi-projectile behavior", () => {
+    expect(cfg.projectileCount).toBeGreaterThan(1);
+    expect(cfg.spreadAngle).toBeGreaterThan(0);
+    expect(cfg.damage).toBeLessThan(25);
+    expect(cfg.fireRateMultiplier).toBeLessThan(1.0);
+  });
+});
+
+// ─── Missile weapon config ───────────────────────────────────────
+
+describe("ENEMY_WEAPON_CONFIGS missile", () => {
+  const cfg = ENEMY_WEAPON_CONFIGS["missile"];
+
+  test("defines homing behavior", () => {
+    expect(cfg.homing).toBe(true);
+    expect(cfg.homingStrength).toBeGreaterThan(0);
+    expect(cfg.homingStrength).toBeLessThan(2.5);
+    expect(cfg.damage).toBeGreaterThan(25);
+    expect(cfg.fireRateMultiplier).toBeLessThan(1.0);
+  });
+});
+
+// ─── Laser weapon config ─────────────────────────────────────────
+
+describe("ENEMY_WEAPON_CONFIGS laser", () => {
+  const cfg = ENEMY_WEAPON_CONFIGS["laser"];
+
+  test("defines continuous beam behavior", () => {
+    expect(cfg.projectileSpeed).toBe(0);
+    expect(cfg.fireRateMultiplier).toBe(0);
+    expect(cfg.damage).toBeLessThan(25);
+  });
+});
+
+// ─── EnemyConfig optional weaponType field ───────────────────────
+
+describe("EnemyConfig weaponType field", () => {
+  test("EnemyConfig without weaponType is valid", () => {
+    const config: EnemyConfig = {
+      variant: "scout",
+      hitPoints: 1,
+      speed: 180,
+      scoreValue: 10,
+      fireRate: 0,
+      width: 24,
+      height: 24,
+    };
+    expect(config.weaponType).toBeUndefined();
+  });
+
+  test("ENEMY_CONFIGS fighter has weaponType standard", () => {
+    expect(ENEMY_CONFIGS["fighter"].weaponType).toBe("standard");
+  });
+
+  test("ENEMY_CONFIGS bomber has weaponType standard", () => {
+    expect(ENEMY_CONFIGS["bomber"].weaponType).toBe("standard");
+  });
+
+  test("ENEMY_CONFIGS boss has weaponType standard", () => {
+    expect(ENEMY_CONFIGS["boss"].weaponType).toBe("standard");
+  });
+
+  test("ENEMY_CONFIGS scout has no weaponType", () => {
+    expect(ENEMY_CONFIGS["scout"].weaponType).toBeUndefined();
+  });
+});
+
+// ─── Enemy entity weaponType property ────────────────────────────
+
+describe("Enemy weaponType property", () => {
+  test("defaults to standard when not in config (scout)", () => {
+    const enemy = new Enemy(100, 0, "scout");
+    expect(enemy.weaponType).toBe("standard");
+  });
+
+  test("reads weaponType from ENEMY_CONFIGS (fighter)", () => {
+    const enemy = new Enemy(100, 0, "fighter");
+    expect(enemy.weaponType).toBe("standard");
+  });
+
+  test("reads weaponType from ENEMY_CONFIGS (boss)", () => {
+    const enemy = new Enemy(400, 0, "boss");
+    expect(enemy.weaponType).toBe("standard");
+  });
+
+  test("can be overridden via overrideConfig", () => {
+    const enemy = new Enemy(100, 0, "fighter", undefined, { weaponType: "spread" });
+    expect(enemy.weaponType).toBe("spread");
+  });
+
+  test("override to missile works", () => {
+    const enemy = new Enemy(100, 0, "bomber", undefined, { weaponType: "missile" });
+    expect(enemy.weaponType).toBe("missile");
+  });
+
+  test("override to laser works", () => {
+    const enemy = new Enemy(100, 0, "boss", undefined, { weaponType: "laser" });
+    expect(enemy.weaponType).toBe("laser");
+  });
+});
+
+// ─── RaptorSoundEvent extensions ─────────────────────────────────
+
+describe("RaptorSoundEvent enemy weapon events", () => {
+  test("enemy_spread_fire is a valid RaptorSoundEvent", () => {
+    const event: RaptorSoundEvent = "enemy_spread_fire";
+    expect(event).toBe("enemy_spread_fire");
+  });
+
+  test("enemy_missile_fire is a valid RaptorSoundEvent", () => {
+    const event: RaptorSoundEvent = "enemy_missile_fire";
+    expect(event).toBe("enemy_missile_fire");
+  });
+
+  test("enemy_laser_fire is a valid RaptorSoundEvent", () => {
+    const event: RaptorSoundEvent = "enemy_laser_fire";
+    expect(event).toBe("enemy_laser_fire");
+  });
+
+  test("enemy_missile_hit is a valid RaptorSoundEvent", () => {
+    const event: RaptorSoundEvent = "enemy_missile_hit";
+    expect(event).toBe("enemy_missile_hit");
+  });
+
+  test("enemy_laser_hit is a valid RaptorSoundEvent", () => {
+    const event: RaptorSoundEvent = "enemy_laser_hit";
+    expect(event).toBe("enemy_laser_hit");
+  });
+});


### PR DESCRIPTION
## PR: raptor: define `EnemyWeaponType` type system and configuration (Issue #449, part of #419)

### Summary (what changed + why)
This PR introduces a foundational **enemy weapon type system** in the Raptor game type model, mirroring the existing player weapon architecture. Previously, all shooting enemies effectively shared one hardcoded bullet behavior with no weapon distinction.  

Key additions:
- New `EnemyWeaponType` union (`"standard" | "spread" | "missile" | "laser"`)
- New `EnemyWeaponConfig` interface and `ENEMY_WEAPON_CONFIGS` record with balanced default values
- `EnemyConfig` now supports an optional `weaponType` (defaulting to `"standard"` when omitted)
- `Enemy` entity now exposes a readonly `weaponType` resolved from config
- `RaptorSoundEvent` extended with new enemy-weapon-related sound event strings

**Why:** This is a **data-only** scaffolding change that enables follow-up PRs to implement distinct enemy firing behaviors without refactoring the type system later. It maintains structural parity with the player weapon system and keeps existing runtime behavior unchanged.

---

### Key files modified
- **`src/games/raptor/types.ts`**
  - Added `EnemyWeaponType`
  - Added `EnemyWeaponConfig`
  - Added `ENEMY_WEAPON_CONFIGS` with defaults for `standard`, `spread`, `missile`, `laser`
  - Extended `EnemyConfig` with `weaponType?: EnemyWeaponType`
  - Updated `ENEMY_CONFIGS` so `fighter`, `bomber`, and `boss` explicitly use `"standard"`
  - Extended `RaptorSoundEvent` with:
    - `enemy_spread_fire`, `enemy_missile_fire`, `enemy_laser_fire`
    - `enemy_missile_hit`, `enemy_laser_hit`

- **`src/games/raptor/entities/Enemy.ts`**
  - Added `public readonly weaponType: EnemyWeaponType`
  - Constructor now resolves `weaponType` via `config.weaponType ?? "standard"` (supports overrides)

---

### Behavior / compatibility notes
- Intended to be **no gameplay change**: enemies still fire the existing `EnemyBullet` and damage remains hardcoded elsewhere (future work will wire `ENEMY_WEAPON_CONFIGS` into runtime logic).
- `weaponType` is optional on `EnemyConfig` to remain backward-compatible; non-shooting variants can omit it.

---

### Testing notes
- Existing test suite should continue to pass with no behavioral changes.
- New/updated tests (expected/covered by this change) should validate:
  - `ENEMY_WEAPON_CONFIGS` completeness and key invariants (config `type` matches key, sane defaults)
  - `Enemy.weaponType` defaulting to `"standard"` when omitted and honoring overrides
  - `RaptorSoundEvent` accepts the new enemy sound event strings

Run:
- `npm test` (or the repo’s standard test command) to confirm full regression coverage.

Ref: https://github.com/asgardtech/archer/issues/449