### PR TITLE
raptor: implement enemy spread-shot weapon type

### DIFF
--- a/public/assets/raptor/bullet_enemy_spread.svg
+++ b/public/assets/raptor/bullet_enemy_spread.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8">
+  <defs>
+    <radialGradient id="spread-glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFDD44" stop-opacity="0.9"/>
+      <stop offset="50%" stop-color="#FF8800" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#CC4400" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="spread-core" cx="0.5" cy="0.4" r="0.4">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="40%" stop-color="#FFCC66"/>
+      <stop offset="100%" stop-color="#FF8800"/>
+    </radialGradient>
+  </defs>
+  <circle cx="4" cy="4" r="3.5" fill="url(#spread-glow)"/>
+  <circle cx="4" cy="4" r="2" fill="url(#spread-core)"/>
+  <circle cx="4" cy="3.5" r="0.8" fill="#FFFFCC" opacity="0.85"/>
+</svg>

--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -537,19 +537,21 @@ export class RaptorGame implements IGame {
     for (const enemy of this.enemies) {
       enemy.update(dt, this.height);
 
-      if (enemy.canFire() && this.enemyBullets.length < MAX_ENEMY_BULLETS) {
-        const result = this.enemyWeaponSystem.fire(enemy, this.player.pos.x, this.player.pos.y);
-        for (const eb of result.bullets) {
-          const sprite = this.assets.getOptional(eb.spriteKey);
-          if (sprite) eb.setSprite(sprite);
-          this.enemyBullets.push(eb);
-        }
-        if (result.bullets.length > 0) {
-          const weaponConfig = ENEMY_WEAPON_CONFIGS[enemy.weaponType];
-          enemy.resetFireCooldown(
-            (1 / config.enemyFireRateMultiplier) * (1 / weaponConfig.fireRateMultiplier)
-          );
-          this.sound.play(result.soundEvent);
+      if (enemy.canFire()) {
+        const weaponConfig = ENEMY_WEAPON_CONFIGS[enemy.weaponType];
+        if (this.enemyBullets.length + weaponConfig.projectileCount <= MAX_ENEMY_BULLETS) {
+          const result = this.enemyWeaponSystem.fire(enemy, this.player.pos.x, this.player.pos.y);
+          for (const eb of result.bullets) {
+            const sprite = this.assets.getOptional(eb.spriteKey);
+            if (sprite) eb.setSprite(sprite);
+            this.enemyBullets.push(eb);
+          }
+          if (result.bullets.length > 0) {
+            enemy.resetFireCooldown(
+              (1 / config.enemyFireRateMultiplier) * (1 / weaponConfig.fireRateMultiplier)
+            );
+            this.sound.play(result.soundEvent);
+          }
         }
       }
     }

--- a/src/games/raptor/entities/EnemyBullet.ts
+++ b/src/games/raptor/entities/EnemyBullet.ts
@@ -5,21 +5,24 @@ const ENEMY_BULLET_SPEED = 300;
 export interface EnemyBulletOptions {
   damage?: number;
   speed?: number;
+  radius?: number;
   homing?: boolean;
   homingStrength?: number;
   spriteKey?: string;
+  fallbackColor?: string;
 }
 
 export class EnemyBullet {
   public pos: Vec2;
   public vel: Vec2;
   public alive = true;
-  public radius = 4;
+  public radius: number;
   public damage: number;
   public homing: boolean;
   public homingStrength: number;
   public speed: number;
   public spriteKey: string;
+  public fallbackColor: string;
 
   private angle: number;
   private sprite: HTMLImageElement | null = null;
@@ -28,9 +31,11 @@ export class EnemyBullet {
     this.pos = { x, y };
     this.damage = options?.damage ?? 25;
     this.speed = options?.speed ?? ENEMY_BULLET_SPEED;
+    this.radius = options?.radius ?? 4;
     this.homing = options?.homing ?? false;
     this.homingStrength = options?.homingStrength ?? 0;
     this.spriteKey = options?.spriteKey ?? "bullet_enemy";
+    this.fallbackColor = options?.fallbackColor ?? "#ff3333";
 
     const dx = targetX - x;
     const dy = targetY - y;
@@ -108,17 +113,23 @@ export class EnemyBullet {
 
   private renderFallback(ctx: CanvasRenderingContext2D): void {
     ctx.save();
-    ctx.fillStyle = "#ff3333";
-    ctx.shadowColor = "#ff3333";
+    ctx.fillStyle = this.fallbackColor;
+    ctx.shadowColor = this.fallbackColor;
     ctx.shadowBlur = 4;
     ctx.beginPath();
     ctx.arc(this.pos.x, this.pos.y, this.radius, 0, Math.PI * 2);
     ctx.fill();
 
-    ctx.fillStyle = "#ff8888";
+    ctx.fillStyle = this.fallbackCoreColor;
     ctx.beginPath();
     ctx.arc(this.pos.x, this.pos.y, this.radius * 0.5, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
+  }
+
+  private get fallbackCoreColor(): string {
+    if (this.fallbackColor === "#ff3333") return "#ff8888";
+    if (this.fallbackColor === "#ff8800") return "#ffcc66";
+    return "#ffffff";
   }
 }

--- a/src/games/raptor/rendering/assets.ts
+++ b/src/games/raptor/rendering/assets.ts
@@ -11,6 +11,7 @@ export const ASSET_MANIFEST: AssetManifest = {
   enemy_boss:       `${BASE}enemy_boss.png`,
   bullet_player:    `${BASE}bullet_player.svg`,
   bullet_enemy:     `${BASE}bullet_enemy.svg`,
+  bullet_enemy_spread: `${BASE}bullet_enemy_spread.svg`,
   missile_player:   `${BASE}missile_player.svg`,
   powerup_spread:   `${BASE}powerup_spread.svg`,
   powerup_rapid:    `${BASE}powerup_rapid.svg`,

--- a/src/games/raptor/systems/EnemyWeaponSystem.ts
+++ b/src/games/raptor/systems/EnemyWeaponSystem.ts
@@ -70,7 +70,9 @@ export class EnemyWeaponSystem {
       bullets.push(new EnemyBullet(enemy.pos.x, enemy.bottom, bTargetX, bTargetY, {
         damage: config.damage,
         speed: config.projectileSpeed,
+        radius: 3,
         spriteKey: config.spriteKey,
+        fallbackColor: "#ff8800",
       }));
     }
 

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -44,11 +44,11 @@ export const ENEMY_WEAPON_CONFIGS: Record<EnemyWeaponType, EnemyWeaponConfig> = 
     damage: 15,
     projectileSpeed: 280,
     projectileCount: 3,
-    spreadAngle: 0.5,
+    spreadAngle: 0.5, // radians between each adjacent bullet in the fan
     homing: false,
     homingStrength: 0,
     fireRateMultiplier: 0.7,
-    spriteKey: "bullet_enemy",
+    spriteKey: "bullet_enemy_spread",
   },
   missile: {
     type: "missile",
@@ -301,7 +301,7 @@ export const ENEMY_CONFIGS: Record<EnemyVariant, EnemyConfig> = {
     fireRate: 0.5,
     width: 40,
     height: 36,
-    weaponType: "standard",
+    weaponType: "spread",
   },
   boss: {
     variant: "boss",


### PR DESCRIPTION
## PR: raptor — implement enemy spread-shot weapon type

### Summary (what changed + why)
This PR completes the **enemy `weaponType: "spread"`** implementation so certain enemies (notably **bombers**) can fire **multi-bullet volleys** in a fan pattern aimed roughly at the player. The goal is to add a more threatening, area-denial attack pattern (mirroring the player’s spread-shot concept) and ensure it’s balanced and visually distinct.

Key additions:
- Spread bullets now have a **distinct visual identity** (new sprite + orange fallback rendering) and a **slightly smaller radius** for clarity.
- The enemy bullet cap is now enforced correctly for **multi-projectile volleys** (preventing overshooting `MAX_ENEMY_BULLETS`).
- Bombers are wired to use `weaponType: "spread"` so the behavior is exercised in gameplay.

Part of epic **#419**.

---

### Key files modified
- **`src/games/raptor/entities/EnemyBullet.ts`**
  - Added `radius` and `fallbackColor` to `EnemyBulletOptions`.
  - Fallback rendering now uses `fallbackColor` (with a small helper for the inner “core” color).

- **`src/games/raptor/types.ts`**
  - Updated `ENEMY_WEAPON_CONFIGS["spread"]` to use `spriteKey: "bullet_enemy_spread"`.
  - Set **bomber** variant default `weaponType` to `"spread"`.

- **`src/games/raptor/systems/EnemyWeaponSystem.ts`**
  - Spread-shot bullet creation now passes `radius: 3` and `fallbackColor: "#ff8800"` to distinguish from standard enemy bullets.

- **`src/games/raptor/RaptorGame.ts`**
  - Fixed `MAX_ENEMY_BULLETS` enforcement by checking:
    `enemyBullets.length + projectileCount <= MAX_ENEMY_BULLETS`
    before firing (so volleys don’t exceed the cap).

- **`src/games/raptor/rendering/assets.ts`**
  - Registered the new spread bullet sprite asset key: `bullet_enemy_spread`.

- **`assets/raptor/bullet_enemy_spread.svg`** (new)
  - Added an orange/amber spread bullet sprite.

---

### Testing notes
Manual verification recommended (no automated tests included in this PR):
- Spawn/encounter **bomber** enemies and confirm they fire a **3-bullet fan** centered toward the player.
- Confirm spread bullets:
  - Render using `bullet_enemy_spread.svg` when available.
  - Fall back to **orange** canvas rendering if the sprite is missing/unloaded.
  - Have a **smaller radius** than standard enemy bullets (3 vs default 4).
- Confirm `MAX_ENEMY_BULLETS` behavior:
  - When near cap, spread volleys are **skipped** if they’d exceed the limit.
  - Bullet count never exceeds the configured maximum.
- Audio sanity check:
  - Spread-shot plays **one sound per volley** (not per bullet).

Ref: https://github.com/asgardtech/archer/issues/451