### PR TITLE
raptor: implement enemy laser beam weapon type

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -107,6 +107,7 @@ export class RaptorGame implements IGame {
   private boundResize: (() => void) | null = null;
   private resizeTimer: ReturnType<typeof setTimeout> | undefined;
   private dpr = 1;
+  private enemyLaserHitSoundCooldown = 0;
 
   public onExit: (() => void) | null = null;
 
@@ -540,7 +541,16 @@ export class RaptorGame implements IGame {
 
       if (enemy.canFire()) {
         const weaponConfig = ENEMY_WEAPON_CONFIGS[enemy.weaponType];
-        if (this.enemyBullets.length + weaponConfig.projectileCount <= MAX_ENEMY_BULLETS) {
+
+        if (enemy.weaponType === "laser") {
+          const result = this.enemyWeaponSystem.fire(enemy, this.player.pos.x, this.player.pos.y);
+          if (result.laserActivated) {
+            const totalCycle = (weaponConfig.beamWarmupDuration ?? 0.5)
+              + (weaponConfig.beamActiveDuration ?? 2.5)
+              + (weaponConfig.beamCooldownDuration ?? 3.0);
+            enemy.resetFireCooldown(totalCycle * enemy.fireRate);
+          }
+        } else if (this.enemyBullets.length + weaponConfig.projectileCount <= MAX_ENEMY_BULLETS) {
           const result = this.enemyWeaponSystem.fire(enemy, this.player.pos.x, this.player.pos.y);
           for (const eb of result.bullets) {
             const sprite = this.assets.getOptional(eb.spriteKey);
@@ -551,10 +561,17 @@ export class RaptorGame implements IGame {
             enemy.resetFireCooldown(
               (1 / config.enemyFireRateMultiplier) * (1 / weaponConfig.fireRateMultiplier)
             );
-            this.sound.play(result.soundEvent);
+            if (result.soundEvent) {
+              this.sound.play(result.soundEvent);
+            }
           }
         }
       }
+    }
+
+    const laserSoundEvents = this.enemyWeaponSystem.updateLasers(dt, this.player.pos.x);
+    for (const evt of laserSoundEvents) {
+      this.sound.play(evt);
     }
 
     for (const proj of this.projectiles) {
@@ -621,6 +638,24 @@ export class RaptorGame implements IGame {
           this.sound.play("enemy_missile_hit");
           this.vfx.triggerExplosionFlash(hit.bullet.pos.x, hit.bullet.pos.y, 15);
         }
+      }
+    }
+
+    this.enemyLaserHitSoundCooldown = Math.max(0, this.enemyLaserHitSoundCooldown - dt);
+    const beamHits = this.collisions.checkEnemyBeamPlayer(
+      this.enemyWeaponSystem.getActiveLasers(), this.player, this.height, dt
+    );
+    for (const hit of beamHits) {
+      const dead = this.player.takeDamage(hit.damage);
+      if (dead) {
+        this.sound.play("player_destroy");
+        this.addExplosion(new Explosion(this.player.pos.x, this.player.pos.y, 3));
+        this.vfx.triggerScreenShake(8, 0.4);
+        this.weaponSystem.laserBeam.active = false;
+      } else if (this.enemyLaserHitSoundCooldown <= 0) {
+        this.sound.play("enemy_laser_hit");
+        this.vfx.triggerScreenShake(1, 0.05);
+        this.enemyLaserHitSoundCooldown = 0.15;
       }
     }
 
@@ -699,6 +734,7 @@ export class RaptorGame implements IGame {
       this.enemyBullets = [];
       this.powerUps = [];
       this.weaponSystem.laserBeam.active = false;
+      this.enemyWeaponSystem.resetLasers();
       this.sound.stopMusic();
 
       if (this.currentLevel >= LEVELS.length - 1) {
@@ -870,6 +906,8 @@ export class RaptorGame implements IGame {
     this.powerUps = [];
     this.player.reset(this.width, this.height, fullReset);
 
+    this.enemyWeaponSystem.resetLasers();
+
     if (fullReset) {
       this.weaponSystem.reset();
       this.powerUpManager.reset();
@@ -1039,6 +1077,9 @@ export class RaptorGame implements IGame {
       }
       for (const eb of this.enemyBullets) {
         eb.render(this.ctx);
+      }
+      for (const beam of this.enemyWeaponSystem.getActiveLasers()) {
+        beam.render(this.ctx, this.height);
       }
       for (const exp of this.explosions) {
         exp.render(this.ctx);

--- a/src/games/raptor/entities/EnemyLaserBeam.ts
+++ b/src/games/raptor/entities/EnemyLaserBeam.ts
@@ -1,0 +1,159 @@
+export type EnemyLaserPhase = "idle" | "warmup" | "active" | "cooldown";
+
+export interface EnemyLaserBeamConfig {
+  warmupDuration: number;
+  activeDuration: number;
+  cooldownDuration: number;
+  beamWidth: number;
+  trackingSpeed: number;
+  damage: number;
+}
+
+export class EnemyLaserBeam {
+  phase: EnemyLaserPhase = "idle";
+  beamX = 0;
+  originY = 0;
+  beamWidth: number;
+  damage: number;
+
+  private phaseTimer = 0;
+  private config: EnemyLaserBeamConfig;
+  private time = 0;
+  private targetX = 0;
+  private justActivated = false;
+
+  constructor(config: EnemyLaserBeamConfig) {
+    this.config = config;
+    this.beamWidth = config.beamWidth;
+    this.damage = config.damage;
+  }
+
+  activate(enemyX: number, enemyBottomY: number, playerX: number): void {
+    if (this.phase !== "idle") return;
+    this.phase = "warmup";
+    this.phaseTimer = this.config.warmupDuration;
+    this.beamX = enemyX;
+    this.originY = enemyBottomY;
+    this.targetX = playerX;
+    this.time = 0;
+    this.justActivated = false;
+  }
+
+  update(dt: number, enemyX: number, enemyBottomY: number, playerX: number): void {
+    this.justActivated = false;
+
+    if (this.phase === "idle") return;
+
+    this.time += dt;
+    this.originY = enemyBottomY;
+    this.phaseTimer -= dt;
+
+    if (this.phase === "warmup") {
+      this.beamX = enemyX;
+      if (this.phaseTimer <= 0) {
+        this.phase = "active";
+        this.phaseTimer = this.config.activeDuration;
+        this.justActivated = true;
+      }
+      return;
+    }
+
+    if (this.phase === "active") {
+      this.targetX = playerX;
+      const dx = this.targetX - this.beamX;
+      const maxMove = this.config.trackingSpeed * dt;
+      if (Math.abs(dx) <= maxMove) {
+        this.beamX = this.targetX;
+      } else {
+        this.beamX += Math.sign(dx) * maxMove;
+      }
+
+      if (this.phaseTimer <= 0) {
+        this.phase = "cooldown";
+        this.phaseTimer = this.config.cooldownDuration;
+      }
+      return;
+    }
+
+    if (this.phase === "cooldown") {
+      if (this.phaseTimer <= 0) {
+        this.phase = "idle";
+      }
+    }
+  }
+
+  render(ctx: CanvasRenderingContext2D, canvasHeight: number): void {
+    if (this.phase === "warmup") {
+      this.renderWarning(ctx, canvasHeight);
+    } else if (this.phase === "active") {
+      this.renderBeam(ctx, canvasHeight);
+    }
+  }
+
+  private renderWarning(ctx: CanvasRenderingContext2D, canvasHeight: number): void {
+    ctx.save();
+    const pulse = 0.4 + Math.sin(this.time * 12) * 0.15;
+    ctx.strokeStyle = `rgba(255, 204, 0, ${pulse})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(this.beamX, this.originY);
+    ctx.lineTo(this.beamX, canvasHeight);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  private renderBeam(ctx: CanvasRenderingContext2D, canvasHeight: number): void {
+    const halfWidth = this.beamWidth / 2;
+    const beamTop = this.originY;
+    const beamHeight = canvasHeight - beamTop;
+
+    ctx.save();
+
+    const pulse = 0.6 + Math.sin(this.time * 20) * 0.15;
+
+    const outerGlow = ctx.createLinearGradient(
+      this.beamX - halfWidth * 4, 0, this.beamX + halfWidth * 4, 0
+    );
+    outerGlow.addColorStop(0, "rgba(255, 80, 0, 0)");
+    outerGlow.addColorStop(0.3, `rgba(255, 80, 0, ${0.15 * pulse})`);
+    outerGlow.addColorStop(0.5, `rgba(255, 120, 20, ${0.3 * pulse})`);
+    outerGlow.addColorStop(0.7, `rgba(255, 80, 0, ${0.15 * pulse})`);
+    outerGlow.addColorStop(1, "rgba(255, 80, 0, 0)");
+    ctx.fillStyle = outerGlow;
+    ctx.fillRect(this.beamX - halfWidth * 4, beamTop, halfWidth * 8, beamHeight);
+
+    ctx.fillStyle = `rgba(255, 120, 20, ${0.5 * pulse})`;
+    ctx.fillRect(this.beamX - halfWidth, beamTop, this.beamWidth, beamHeight);
+
+    const coreWidth = halfWidth * 0.5;
+    ctx.fillStyle = `rgba(255, 220, 150, ${0.8 * pulse})`;
+    ctx.fillRect(this.beamX - coreWidth, beamTop, coreWidth * 2, beamHeight);
+
+    ctx.restore();
+  }
+
+  get isActive(): boolean {
+    return this.phase === "active";
+  }
+
+  get isFiring(): boolean {
+    return this.phase === "warmup" || this.phase === "active";
+  }
+
+  get canFire(): boolean {
+    return this.phase === "idle";
+  }
+
+  get didJustActivate(): boolean {
+    return this.justActivated;
+  }
+
+  reset(): void {
+    this.phase = "idle";
+    this.phaseTimer = 0;
+    this.time = 0;
+    this.beamX = 0;
+    this.originY = 0;
+    this.justActivated = false;
+  }
+}

--- a/src/games/raptor/systems/CollisionSystem.ts
+++ b/src/games/raptor/systems/CollisionSystem.ts
@@ -2,6 +2,7 @@ import { Projectile, WEAPON_CONFIGS } from "../types";
 import { Bullet } from "../entities/Bullet";
 import { Missile } from "../entities/Missile";
 import { LaserBeam } from "../entities/LaserBeam";
+import { EnemyLaserBeam } from "../entities/EnemyLaserBeam";
 import { Enemy } from "../entities/Enemy";
 import { EnemyBullet } from "../entities/EnemyBullet";
 import { Player } from "../entities/Player";
@@ -25,6 +26,11 @@ export interface EnemyPlayerHit {
 
 export interface PowerUpPlayerHit {
   powerUp: PowerUp;
+}
+
+export interface EnemyBeamPlayerHit {
+  beam: EnemyLaserBeam;
+  damage: number;
 }
 
 export interface SplashHit {
@@ -177,6 +183,32 @@ export class CollisionSystem {
                     powerUp.left, powerUp.top, powerUp.right, powerUp.bottom)) {
         powerUp.alive = false;
         hits.push({ powerUp });
+      }
+    }
+    return hits;
+  }
+
+  checkEnemyBeamPlayer(
+    beams: EnemyLaserBeam[],
+    player: Player,
+    canvasHeight: number,
+    dt: number
+  ): EnemyBeamPlayerHit[] {
+    if (!player.alive || player.isInvincible) return [];
+
+    const hits: EnemyBeamPlayerHit[] = [];
+    for (const beam of beams) {
+      if (!beam.isActive) continue;
+
+      const halfWidth = beam.beamWidth / 2;
+      const beamLeft = beam.beamX - halfWidth;
+      const beamRight = beam.beamX + halfWidth;
+      const beamTop = beam.originY;
+      const beamBottom = canvasHeight;
+
+      if (this.aabb(beamLeft, beamTop, beamRight, beamBottom,
+                    player.left, player.top, player.right, player.bottom)) {
+        hits.push({ beam, damage: beam.damage * dt });
       }
     }
     return hits;

--- a/src/games/raptor/systems/EnemyWeaponSystem.ts
+++ b/src/games/raptor/systems/EnemyWeaponSystem.ts
@@ -1,11 +1,13 @@
 import { EnemyWeaponType, ENEMY_WEAPON_CONFIGS, RaptorSoundEvent } from "../types";
 import { EnemyBullet } from "../entities/EnemyBullet";
 import { EnemyMissile } from "../entities/EnemyMissile";
+import { EnemyLaserBeam, EnemyLaserBeamConfig } from "../entities/EnemyLaserBeam";
 import { Enemy } from "../entities/Enemy";
 
 export interface EnemyFireResult {
   bullets: EnemyBullet[];
-  soundEvent: RaptorSoundEvent;
+  soundEvent: RaptorSoundEvent | null;
+  laserActivated?: boolean;
 }
 
 const WEAPON_SOUND_MAP: Record<EnemyWeaponType, RaptorSoundEvent> = {
@@ -16,6 +18,8 @@ const WEAPON_SOUND_MAP: Record<EnemyWeaponType, RaptorSoundEvent> = {
 };
 
 export class EnemyWeaponSystem {
+  private laserBeams: Map<Enemy, EnemyLaserBeam> = new Map();
+
   fire(enemy: Enemy, targetX: number, targetY: number): EnemyFireResult {
     const weaponType = enemy.weaponType;
     const config = ENEMY_WEAPON_CONFIGS[weaponType];
@@ -33,11 +37,73 @@ export class EnemyWeaponSystem {
       case "missile":
         return this.fireMissile(enemy, targetX, targetY);
       case "laser":
-        return { bullets: [], soundEvent: "enemy_laser_fire" };
+        return this.fireLaser(enemy, targetX);
       default:
         console.warn(`[EnemyWeaponSystem] Unhandled weapon type "${weaponType}", falling back to standard`);
         return this.fireStandard(enemy, targetX, targetY);
     }
+  }
+
+  fireLaser(enemy: Enemy, playerX: number): EnemyFireResult {
+    let beam = this.laserBeams.get(enemy);
+
+    if (!beam) {
+      const config = ENEMY_WEAPON_CONFIGS["laser"];
+      const beamConfig: EnemyLaserBeamConfig = {
+        warmupDuration: config.beamWarmupDuration ?? 0.5,
+        activeDuration: config.beamActiveDuration ?? 2.5,
+        cooldownDuration: config.beamCooldownDuration ?? 3.0,
+        beamWidth: config.beamWidth ?? 8,
+        trackingSpeed: config.beamTrackingSpeed ?? 40,
+        damage: config.damage,
+      };
+      beam = new EnemyLaserBeam(beamConfig);
+      this.laserBeams.set(enemy, beam);
+    }
+
+    if (beam.canFire) {
+      beam.activate(enemy.pos.x, enemy.bottom, playerX);
+      return { bullets: [], soundEvent: null, laserActivated: true };
+    }
+
+    return { bullets: [], soundEvent: null };
+  }
+
+  updateLasers(dt: number, playerX: number): RaptorSoundEvent[] {
+    const soundEvents: RaptorSoundEvent[] = [];
+
+    for (const [enemy, beam] of this.laserBeams.entries()) {
+      if (!enemy.alive) {
+        beam.reset();
+        this.laserBeams.delete(enemy);
+        continue;
+      }
+
+      beam.update(dt, enemy.pos.x, enemy.bottom, playerX);
+
+      if (beam.didJustActivate) {
+        soundEvents.push("enemy_laser_fire");
+      }
+    }
+
+    return soundEvents;
+  }
+
+  getActiveLasers(): EnemyLaserBeam[] {
+    const active: EnemyLaserBeam[] = [];
+    for (const beam of this.laserBeams.values()) {
+      if (beam.isFiring) {
+        active.push(beam);
+      }
+    }
+    return active;
+  }
+
+  resetLasers(): void {
+    for (const beam of this.laserBeams.values()) {
+      beam.reset();
+    }
+    this.laserBeams.clear();
   }
 
   private fireStandard(enemy: Enemy, targetX: number, targetY: number): EnemyFireResult {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -25,6 +25,11 @@ export interface EnemyWeaponConfig {
   homingStrength: number;
   fireRateMultiplier: number;
   spriteKey: string;
+  beamWarmupDuration?: number;
+  beamActiveDuration?: number;
+  beamCooldownDuration?: number;
+  beamWidth?: number;
+  beamTrackingSpeed?: number;
 }
 
 export const ENEMY_WEAPON_CONFIGS: Record<EnemyWeaponType, EnemyWeaponConfig> = {
@@ -71,6 +76,11 @@ export const ENEMY_WEAPON_CONFIGS: Record<EnemyWeaponType, EnemyWeaponConfig> = 
     homingStrength: 0,
     fireRateMultiplier: 0.0,
     spriteKey: "laser_enemy",
+    beamWarmupDuration: 0.5,
+    beamActiveDuration: 2.5,
+    beamCooldownDuration: 3.0,
+    beamWidth: 8,
+    beamTrackingSpeed: 40,
   },
 };
 

--- a/tests/raptor-issue-450-qa.test.ts
+++ b/tests/raptor-issue-450-qa.test.ts
@@ -201,12 +201,11 @@ describe("EnemyWeaponSystem", () => {
       expect(result.bullets).toHaveLength(0);
     });
 
-    test("returns a sound event (laser fire stub)", () => {
+    test("returns null soundEvent and laserActivated flag", () => {
       const enemy = makeEnemy("laser");
       const result = system.fire(enemy, 400, 500);
-      // The laser type returns enemy_laser_fire but since bullets are empty,
-      // in the game loop the sound won't play (guarded by bullets.length > 0)
-      expect(result.soundEvent).toBeDefined();
+      expect(result.soundEvent).toBeNull();
+      expect(result.laserActivated).toBe(true);
     });
   });
 
@@ -550,9 +549,10 @@ describe("Sound event per weapon type", () => {
     expect(result.soundEvent).toBe("enemy_missile_fire");
   });
 
-  test("laser -> enemy_laser_fire", () => {
+  test("laser -> null (sound emitted by beam lifecycle)", () => {
     const result = system.fire(makeEnemy("laser"), 400, 500);
-    expect(result.soundEvent).toBe("enemy_laser_fire");
+    expect(result.soundEvent).toBeNull();
+    expect(result.laserActivated).toBe(true);
   });
 });
 


### PR DESCRIPTION
## PR: raptor: implement enemy laser beam weapon type (Issue #453, part of epic #419)

### Summary (what + why)
This PR adds a new **enemy laser beam** weapon type intended primarily for bosses. Unlike projectile weapons, the laser is a **sustained beam** with a **warm-up warning phase**, then an **active phase that deals continuous DPS** while the player overlaps the beam’s hitbox. The beam also **slowly tracks/sweeps toward the player’s X position**, creating a dodge-focused pattern and adding variety to enemy/boss attacks.

Key behaviors implemented:
- Fires **downward from the enemy** to the bottom of the screen
- Lifecycle: **idle → warmup → active → cooldown**
- Warm-up shows a **thin yellow warning line**
- Active beam renders as a **red/orange glow laser** and applies **damage per second (damage * dt)**
- **Does not count toward `MAX_ENEMY_BULLETS`**
- Sound: **`enemy_laser_fire`** on activation; **throttled `enemy_laser_hit`** while damaging the player
- Cleans up correctly on enemy death and level transitions

---

### Key files changed
**New**
- `src/games/raptor/entities/EnemyLaserBeam.ts`
  - New entity implementing beam lifecycle, tracking behavior, rendering (warning + 3-layer glow), and config-driven timings/width/tracking/DPS.

**Modified**
- `src/games/raptor/systems/EnemyWeaponSystem.ts`
  - Adds per-enemy beam management via `Map<Enemy, EnemyLaserBeam>`
  - Introduces `fireLaser()`, `updateLasers()`, `getActiveLasers()`, `resetLasers()`
  - Routes `"laser"` weapon type through beam activation instead of bullet spawning

- `src/games/raptor/systems/CollisionSystem.ts`
  - Adds `checkEnemyBeamPlayer()` for beam-rectangle vs player AABB checks
  - Applies continuous damage using `damage * dt` (DPS, frame-rate independent)

- `src/games/raptor/RaptorGame.ts`
  - Integrates laser firing flow (skips `MAX_ENEMY_BULLETS` constraint)
  - Updates and renders active enemy beams
  - Applies beam damage to player with sound throttling
  - Clears beams on level start/transition

- `src/games/raptor/types.ts`
  - Extends `EnemyWeaponConfig` with optional beam-specific fields (warmup/active/cooldown/width/tracking)
  - Ensures `"laser"` config includes beam lifecycle/visual tuning values while reusing `damage` as DPS

---

### Testing notes
Manual verification recommended (no automated tests included in this change set):

- Spawn/force a laser-equipped enemy/boss and confirm:
  - Warm-up renders a **thin yellow warning line** for ~0.5s and deals **no damage**
  - Beam switches to **active** for ~2.5s and plays **`enemy_laser_fire`**
  - Player overlapping the beam takes ~**10 damage per second** (or configured DPS), consistent across FPS (dt-based)
  - Beam **tracks toward player X** gradually (~40px/s), not instantly snapping
  - Beam enters **cooldown** (~3s) and cannot be re-fired until complete
  - Beam **does not** prevent firing when enemy bullets are already at `MAX_ENEMY_BULLETS`
  - Beam stops immediately if the owning enemy dies
  - Beams are cleared on **level transition/start**
  - `enemy_laser_hit` sound is **throttled** (no per-frame audio spam)

Optional stress checks:
- Multiple laser enemies active simultaneously (independent beams, independent tracking)
- Player invincibility frames prevent beam damage as expected

Ref: https://github.com/asgardtech/archer/issues/453