### PR TITLE
raptor: add plasma cannon weapon type

### DIFF
--- a/public/assets/raptor/bullet_plasma.svg
+++ b/public/assets/raptor/bullet_plasma.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <radialGradient id="plasmaCore" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="25%" stop-color="#c77dff"/>
+      <stop offset="70%" stop-color="#7b2ff7"/>
+      <stop offset="100%" stop-color="#5b1aad" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="plasmaGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#9b59b6" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#7b2ff7" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="plasmaBlur">
+      <feGaussianBlur stdDeviation="1" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <circle cx="8" cy="8" r="7" fill="url(#plasmaGlow)"/>
+  <circle cx="8" cy="8" r="4" fill="url(#plasmaCore)" filter="url(#plasmaBlur)"/>
+  <circle cx="8" cy="8" r="2" fill="#FFFFFF" opacity="0.7"/>
+</svg>

--- a/public/assets/raptor/powerup_plasma.svg
+++ b/public/assets/raptor/powerup_plasma.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <radialGradient id="ppCore" cx="0.5" cy="0.4" r="0.5">
+      <stop offset="0%" stop-color="#D7BDE2"/>
+      <stop offset="40%" stop-color="#8e44ad"/>
+      <stop offset="100%" stop-color="#4A235A"/>
+    </radialGradient>
+    <radialGradient id="ppGlow" cx="0.5" cy="0.4" r="0.55">
+      <stop offset="0%" stop-color="#c77dff" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#7b2ff7" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="ppBlur">
+      <feGaussianBlur stdDeviation="0.8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <!-- Outer glow -->
+  <circle cx="12" cy="12" r="11" fill="url(#ppGlow)"/>
+  <!-- Energy ring -->
+  <circle cx="12" cy="12" r="9" fill="none" stroke="#9b59b6" stroke-width="0.8" stroke-opacity="0.5"/>
+  <!-- Main orb -->
+  <circle cx="12" cy="12" r="7" fill="url(#ppCore)" filter="url(#ppBlur)"/>
+  <!-- Inner bright core -->
+  <circle cx="12" cy="10" r="3" fill="#D7BDE2" opacity="0.5"/>
+  <!-- P label -->
+  <text x="12" y="15" text-anchor="middle" font-family="sans-serif" font-weight="bold" font-size="10" fill="#FFFFFF" opacity="0.9">P</text>
+  <!-- Energy arcs -->
+  <polyline points="5,8 7,10 5.5,12" stroke="#c77dff" stroke-width="0.5" stroke-opacity="0.5" fill="none" stroke-linecap="round"/>
+  <polyline points="19,8 17,10 18.5,12" stroke="#c77dff" stroke-width="0.5" stroke-opacity="0.5" fill="none" stroke-linecap="round"/>
+</svg>

--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,4 +1,4 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS } from "./types";
 import { InputManager } from "./systems/InputManager";
 import { DevConsole } from "./systems/DevConsole";
 import { CollisionSystem } from "./systems/CollisionSystem";
@@ -12,6 +12,7 @@ import { CommandRegistry, CommandContext, registerLevelCommands, registerWeaponC
 import { Player } from "./entities/Player";
 import { Bullet } from "./entities/Bullet";
 import { Missile } from "./entities/Missile";
+import { PlasmaBolt } from "./entities/PlasmaBolt";
 import { Enemy } from "./entities/Enemy";
 import { EnemyBullet } from "./entities/EnemyBullet";
 import { EnemyMissile } from "./entities/EnemyMissile";
@@ -581,6 +582,9 @@ export class RaptorGame implements IGame {
       } else if (proj instanceof Missile) {
         proj.update(dt, this.width, this.height, this.enemies);
         this.vfx.addMissileTrail(proj.pos.x, proj.pos.y + 6);
+      } else if (proj instanceof PlasmaBolt) {
+        proj.update(dt, this.width);
+        this.vfx.addPlasmaTrail(proj.pos.x, proj.pos.y + 3);
       }
     }
     for (const eb of this.enemyBullets) {
@@ -610,11 +614,17 @@ export class RaptorGame implements IGame {
         if (hit.bullet instanceof Missile) {
           this.sound.play("missile_hit");
           this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 25);
+        } else if (hit.bullet instanceof PlasmaBolt) {
+          this.sound.play("plasma_hit");
+          this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 20);
         }
       } else {
         if (hit.bullet instanceof Missile) {
           this.sound.play("missile_hit");
           this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 15);
+        } else if (hit.bullet instanceof PlasmaBolt) {
+          this.sound.play("plasma_hit");
+          this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 12);
         } else if (hit.enemy.variant === "boss") {
           this.sound.play("boss_hit");
         } else {
@@ -710,6 +720,11 @@ export class RaptorGame implements IGame {
             this.sound.play("weapon_switch");
           }
           break;
+        case "weapon-plasma":
+          if (this.powerUpManager.setWeapon("plasma")) {
+            this.sound.play("weapon_switch");
+          }
+          break;
       }
     }
 
@@ -780,8 +795,18 @@ export class RaptorGame implements IGame {
     } else if (proj instanceof Missile) {
       const sprite = this.assets.getOptional("missile_player");
       if (sprite) proj.setSprite(sprite);
+    } else if (proj instanceof PlasmaBolt) {
+      const sprite = this.assets.getOptional("bullet_plasma");
+      if (sprite) proj.setSprite(sprite);
     }
   }
+
+  private static readonly WEAPON_DROP_MAP: Record<WeaponType, RaptorPowerUpType> = {
+    "machine-gun": "weapon-missile",
+    missile: "weapon-missile",
+    laser: "weapon-laser",
+    plasma: "weapon-plasma",
+  };
 
   private spawnPowerUp(x: number, y: number): void {
     const config = this.currentLevelConfig;
@@ -790,7 +815,7 @@ export class RaptorGame implements IGame {
 
     if (weaponDrops && weaponDrops.length > 0 && Math.random() < 0.25) {
       const weaponType = weaponDrops[Math.floor(Math.random() * weaponDrops.length)];
-      type = weaponType === "missile" ? "weapon-missile" : "weapon-laser";
+      type = RaptorGame.WEAPON_DROP_MAP[weaponType];
     }
 
     const pu = new PowerUp(x, y, type);

--- a/src/games/raptor/entities/PlasmaBolt.ts
+++ b/src/games/raptor/entities/PlasmaBolt.ts
@@ -1,0 +1,92 @@
+import { Vec2, Projectile } from "../types";
+
+const PLASMA_SPEED = 400;
+
+export class PlasmaBolt implements Projectile {
+  public pos: Vec2;
+  public alive = true;
+  public width = 8;
+  public height = 8;
+  public damage = 2;
+  public piercing = false;
+
+  private angle: number;
+  private sprite: HTMLImageElement | null = null;
+  private time = 0;
+
+  constructor(x: number, y: number, angle = 0) {
+    this.pos = { x, y };
+    this.angle = angle;
+  }
+
+  setSprite(sprite: HTMLImageElement): void {
+    this.sprite = sprite;
+  }
+
+  get left(): number { return this.pos.x - this.width / 2; }
+  get right(): number { return this.pos.x + this.width / 2; }
+  get top(): number { return this.pos.y - this.height / 2; }
+  get bottom(): number { return this.pos.y + this.height / 2; }
+
+  update(dt: number, canvasWidth = 800, _canvasHeight?: number, _enemies?: unknown[]): void {
+    if (!this.alive) return;
+    this.time += dt;
+    this.pos.x += Math.sin(this.angle) * PLASMA_SPEED * dt;
+    this.pos.y -= Math.cos(this.angle) * PLASMA_SPEED * dt;
+
+    if (this.pos.y < -20 || this.pos.x < -20 || this.pos.x > canvasWidth + 20) {
+      this.alive = false;
+    }
+  }
+
+  render(ctx: CanvasRenderingContext2D): void {
+    if (!this.alive) return;
+
+    if (this.sprite) {
+      this.renderSprite(ctx);
+    } else {
+      this.renderFallback(ctx);
+    }
+  }
+
+  private renderSprite(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.translate(this.pos.x, this.pos.y);
+    if (this.angle !== 0) {
+      ctx.rotate(this.angle);
+    }
+    ctx.drawImage(this.sprite!, -this.width / 2, -this.height / 2, this.width, this.height);
+    ctx.restore();
+  }
+
+  private renderFallback(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+
+    const pulse = 1 + Math.sin(this.time * 12) * 0.15;
+    const r = (this.width / 2) * pulse;
+
+    ctx.shadowColor = "#9b59b6";
+    ctx.shadowBlur = 4 + Math.sin(this.time * 10) * 4;
+
+    const grad = ctx.createRadialGradient(
+      this.pos.x, this.pos.y, 0,
+      this.pos.x, this.pos.y, r
+    );
+    grad.addColorStop(0, "#c77dff");
+    grad.addColorStop(1, "#7b2ff7");
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(this.pos.x, this.pos.y, r, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.shadowBlur = 0;
+    ctx.globalAlpha = 0.3 + Math.sin(this.time * 8) * 0.15;
+    ctx.strokeStyle = "#c77dff";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(this.pos.x, this.pos.y, r + 2, 0, Math.PI * 2);
+    ctx.stroke();
+
+    ctx.restore();
+  }
+}

--- a/src/games/raptor/entities/PowerUp.ts
+++ b/src/games/raptor/entities/PowerUp.ts
@@ -10,6 +10,7 @@ const COLORS: Record<RaptorPowerUpType, string> = {
   "bonus-life": "#e74c3c",
   "weapon-missile": "#e67e22",
   "weapon-laser": "#9b59b6",
+  "weapon-plasma": "#8e44ad",
 };
 
 const ICONS: Record<RaptorPowerUpType, string> = {
@@ -19,6 +20,7 @@ const ICONS: Record<RaptorPowerUpType, string> = {
   "bonus-life": "+",
   "weapon-missile": "M",
   "weapon-laser": "L",
+  "weapon-plasma": "P",
 };
 
 const SPRITE_KEYS: Record<RaptorPowerUpType, string> = {
@@ -28,6 +30,7 @@ const SPRITE_KEYS: Record<RaptorPowerUpType, string> = {
   "bonus-life": "powerup_life",
   "weapon-missile": "powerup_missile",
   "weapon-laser": "powerup_laser",
+  "weapon-plasma": "powerup_plasma",
 };
 
 export { SPRITE_KEYS as POWERUP_SPRITE_KEYS };

--- a/src/games/raptor/levels.ts
+++ b/src/games/raptor/levels.ts
@@ -131,7 +131,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#B0C4DE", "#D3D3D3"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.4,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
     terrain: {
       theme: "arctic",
       horizonAssets: ["horizon_arctic"],
@@ -172,7 +172,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#2F1B14", "#1a1a1a"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.6,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
     terrain: {
       theme: "fortress",
       horizonAssets: ["horizon_fortress"],
@@ -217,7 +217,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#2b1d1d", "#4a3333"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.8,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
     terrain: {
       theme: "shipyard",
       horizonAssets: ["horizon_shipyard"],
@@ -270,7 +270,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#1a1a0e", "#3d3520"],
     starDensity: 0,
     enemyFireRateMultiplier: 2.0,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
     terrain: {
       theme: "wasteland",
       horizonAssets: ["horizon_wasteland"],
@@ -323,7 +323,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#1c1c1c", "#333030"],
     starDensity: 0,
     enemyFireRateMultiplier: 2.2,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
     terrain: {
       theme: "industrial",
       horizonAssets: ["horizon_industrial"],
@@ -378,7 +378,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#050510", "#0a0a20"],
     starDensity: 40,
     enemyFireRateMultiplier: 2.4,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
     terrain: {
       theme: "orbital",
       horizonAssets: ["horizon_orbital"],
@@ -434,7 +434,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#0a0000", "#1a0505"],
     starDensity: 50,
     enemyFireRateMultiplier: 2.5,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
     terrain: {
       theme: "stronghold",
       horizonAssets: ["horizon_stronghold"],

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -22,6 +22,7 @@ const EFFECT_COLORS: Partial<Record<RaptorPowerUpType, string>> = {
   "rapid-fire": "#f39c12",
   "weapon-missile": "#e67e22",
   "weapon-laser": "#9b59b6",
+  "weapon-plasma": "#8e44ad",
 };
 
 const EFFECT_LABELS: Partial<Record<RaptorPowerUpType, string>> = {
@@ -29,18 +30,21 @@ const EFFECT_LABELS: Partial<Record<RaptorPowerUpType, string>> = {
   "rapid-fire": "RPD",
   "weapon-missile": "MSL",
   "weapon-laser": "LSR",
+  "weapon-plasma": "PLS",
 };
 
 const WEAPON_LABELS: Record<WeaponType, string> = {
   "machine-gun": "GUN",
   "missile": "MSL",
   "laser": "LSR",
+  "plasma": "PLS",
 };
 
 const WEAPON_COLORS: Record<WeaponType, string> = {
   "machine-gun": "#ffdd00",
   "missile": "#e67e22",
   "laser": "#9b59b6",
+  "plasma": "#8e44ad",
 };
 
 interface SliderLayout {

--- a/src/games/raptor/rendering/VFXManager.ts
+++ b/src/games/raptor/rendering/VFXManager.ts
@@ -126,6 +126,17 @@ export class VFXManager {
     });
   }
 
+  addPlasmaTrail(x: number, y: number): void {
+    if (this.trails.length > 300) return;
+    this.trails.push({
+      x: x + (Math.random() - 0.5) * 3,
+      y: y + (Math.random() - 0.5) * 2,
+      alpha: 0.6,
+      size: 1.5 + Math.random() * 1.5,
+      color: `rgba(${140 + Math.random() * 30}, ${60 + Math.random() * 40}, ${200 + Math.random() * 55}, 0.7)`,
+    });
+  }
+
   addLaserSpark(x: number, y: number): void {
     if (this.trails.length > 300) return;
     this.trails.push({

--- a/src/games/raptor/rendering/assets.ts
+++ b/src/games/raptor/rendering/assets.ts
@@ -20,6 +20,8 @@ export const ASSET_MANIFEST: AssetManifest = {
   powerup_life:     `${BASE}powerup_life.svg`,
   powerup_missile:  `${BASE}powerup_missile.svg`,
   powerup_laser:    `${BASE}powerup_laser.svg`,
+  bullet_plasma:    `${BASE}bullet_plasma.svg`,
+  powerup_plasma:   `${BASE}powerup_plasma.svg`,
   bg_nebula:        `${BASE}bg_nebula.svg`,
   planet_01:        `${BASE}planet_01.svg`,
   planet_02:        `${BASE}planet_02.svg`,

--- a/src/games/raptor/systems/CollisionSystem.ts
+++ b/src/games/raptor/systems/CollisionSystem.ts
@@ -1,6 +1,7 @@
 import { Projectile, WEAPON_CONFIGS } from "../types";
 import { Bullet } from "../entities/Bullet";
 import { Missile } from "../entities/Missile";
+import { PlasmaBolt } from "../entities/PlasmaBolt";
 import { LaserBeam } from "../entities/LaserBeam";
 import { EnemyLaserBeam } from "../entities/EnemyLaserBeam";
 import { Enemy } from "../entities/Enemy";
@@ -107,6 +108,19 @@ export class CollisionSystem {
 
           if (bullet instanceof Missile) {
             const splashHits = this.applySplashDamage(enemy, enemies, WEAPON_CONFIGS["missile"].splashRadius);
+            for (const sh of splashHits) {
+              hits.push({
+                bullet,
+                enemy: sh.enemy,
+                destroyed: sh.destroyed,
+                damage: 1,
+                splash: true,
+              });
+            }
+          }
+
+          if (bullet instanceof PlasmaBolt) {
+            const splashHits = this.applySplashDamage(enemy, enemies, WEAPON_CONFIGS["plasma"].splashRadius);
             for (const sh of splashHits) {
               hits.push({
                 bullet,

--- a/src/games/raptor/systems/CommandRegistry.ts
+++ b/src/games/raptor/systems/CommandRegistry.ts
@@ -107,6 +107,8 @@ const WEAPON_ALIASES: Record<string, WeaponType> = {
   msl: "missile",
   laser: "laser",
   lsr: "laser",
+  plasma: "plasma",
+  pls: "plasma",
 };
 
 const POWERUP_ALIASES: Record<string, RaptorPowerUpType> = {
@@ -154,7 +156,7 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
 
     const resolved = WEAPON_ALIASES[sub];
     if (!resolved) {
-      return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr)`;
+      return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr), plasma (pls)`;
     }
 
     ctx.powerUpManager.setWeapon(resolved);

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -2,7 +2,7 @@ import { RaptorSaveData, WeaponType } from "../types";
 import { LEVELS } from "../levels";
 import { tryGetStorage, trySetStorage, tryRemoveStorage } from "../../../shared/storage";
 
-const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser"];
+const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser", "plasma"];
 
 export class SaveSystem {
   private static readonly STORAGE_KEY = "raptor_save";

--- a/src/games/raptor/systems/WeaponSystem.ts
+++ b/src/games/raptor/systems/WeaponSystem.ts
@@ -2,6 +2,7 @@ import { WeaponType, WEAPON_CONFIGS, Projectile, RaptorLevelConfig, RaptorSoundE
 import { Player } from "../entities/Player";
 import { Bullet } from "../entities/Bullet";
 import { Missile } from "../entities/Missile";
+import { PlasmaBolt } from "../entities/PlasmaBolt";
 import { LaserBeam } from "../entities/LaserBeam";
 import { PowerUpManager } from "./PowerUpManager";
 
@@ -79,6 +80,15 @@ export class WeaponSystem {
           newProjectiles.push(this.createMissile(player.pos.x, player.top));
         }
         soundEvent = "missile_fire";
+      } else if (this.currentWeapon === "plasma") {
+        if (spreadShot) {
+          newProjectiles.push(this.createPlasmaBolt(player.pos.x, player.top, -0.2));
+          newProjectiles.push(this.createPlasmaBolt(player.pos.x, player.top, 0));
+          newProjectiles.push(this.createPlasmaBolt(player.pos.x, player.top, 0.2));
+        } else {
+          newProjectiles.push(this.createPlasmaBolt(player.pos.x, player.top));
+        }
+        soundEvent = "plasma_fire";
       }
     }
 
@@ -92,6 +102,10 @@ export class WeaponSystem {
   private createMissile(x: number, y: number, angle = 0): Missile {
     const config = WEAPON_CONFIGS["missile"];
     return new Missile(x, y, angle, config.homingStrength);
+  }
+
+  private createPlasmaBolt(x: number, y: number, angle = 0): PlasmaBolt {
+    return new PlasmaBolt(x, y, angle);
   }
 
   getLaserSoundEvent(dt: number, hasHits: boolean): RaptorSoundEvent | null {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -101,7 +101,8 @@ export type RaptorPowerUpType =
   | "shield-restore"
   | "bonus-life"
   | "weapon-missile"
-  | "weapon-laser";
+  | "weapon-laser"
+  | "weapon-plasma";
 
 export type RaptorSoundEvent =
   | "player_shoot"
@@ -126,9 +127,11 @@ export type RaptorSoundEvent =
   | "enemy_missile_fire"
   | "enemy_laser_fire"
   | "enemy_missile_hit"
-  | "enemy_laser_hit";
+  | "enemy_laser_hit"
+  | "plasma_fire"
+  | "plasma_hit";
 
-export type WeaponType = "machine-gun" | "missile" | "laser";
+export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma";
 
 export interface RaptorSaveData {
   version: 1;
@@ -193,6 +196,18 @@ export const WEAPON_CONFIGS: Record<WeaponType, WeaponConfig> = {
     splashRadius: 0,
     rapidFireBonus: 1.5,
     spreadShotBehavior: "wider-beam",
+  },
+  "plasma": {
+    type: "plasma",
+    damage: 2,
+    fireRateMultiplier: 0.6,
+    projectileSpeed: 400,
+    piercing: false,
+    homing: false,
+    homingStrength: 0,
+    splashRadius: 30,
+    rapidFireBonus: 1.8,
+    spreadShotBehavior: "multi-projectile",
   },
 };
 

--- a/tests/raptor-weapons-qa.test.ts
+++ b/tests/raptor-weapons-qa.test.ts
@@ -1097,11 +1097,12 @@ describe("HUD Weapon Indicator", () => {
     }
   });
 
-  test("All three WeaponType values are represented in WEAPON_CONFIGS", () => {
-    expect(Object.keys(WEAPON_CONFIGS)).toHaveLength(3);
+  test("All WeaponType values are represented in WEAPON_CONFIGS", () => {
+    expect(Object.keys(WEAPON_CONFIGS)).toHaveLength(4);
     expect(WEAPON_CONFIGS["machine-gun"]).toBeDefined();
     expect(WEAPON_CONFIGS["missile"]).toBeDefined();
     expect(WEAPON_CONFIGS["laser"]).toBeDefined();
+    expect(WEAPON_CONFIGS["plasma"]).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## PR: raptor: add plasma cannon weapon type (Issue #473, part of epic #420)

### Summary (what + why)
This PR adds a new player weapon type, **Plasma Cannon**, inspired by *Raptor: Call of the Shadows*. Plasma fills the gameplay gap between the fast/low-damage machine gun and the slow/homing missiles by firing **medium-speed energy bolts** that deal **splash (AoE) damage** on impact.

Key player-facing additions:
- New weapon: `plasma` (HUD label **PLS**, purple theme)
- New power-up: `weapon-plasma` (purple, “P” icon)
- Dev console support: `weapon plasma` / `weapon pls`
- Appears as a weapon drop starting in **levels 4–10**
- Save/load support for persisting plasma as the active weapon

---

### Key changes
- **New projectile entity:** `PlasmaBolt` (larger energy orb, pulsing fallback renderer, optional sprite rendering)
- **Weapon firing logic:** Plasma firing path added to `WeaponSystem`, including spread-shot behavior (3-bolt fan pattern)
- **Damage model:** Plasma bolts apply **direct hit damage** plus **splash damage** via existing collision splash helper (new `instanceof PlasmaBolt` branch)
- **Game integration:** power-up pickup handling, projectile sprite assignment, and distinct plasma trail VFX
- **Tooling/UI:** HUD indicator, command aliases, asset manifest entries, save validation updates, and level drop tables

---

### Key files modified / added
- `src/games/raptor/types.ts`
  - Adds `plasma` to `WeaponType`, adds `weapon-plasma` power-up type, adds plasma config in `WEAPON_CONFIGS`, and sound events if used.
- `src/games/raptor/entities/PlasmaBolt.ts` **(new)**
  - Implements `Projectile`; straight-line motion; pulsing purple/blue fallback rendering; supports optional sprite.
- `src/games/raptor/systems/WeaponSystem.ts`
  - Adds plasma firing branch + `createPlasmaBolt()`; spread-shot fires 3 bolts in a fan.
- `src/games/raptor/systems/CollisionSystem.ts`
  - Adds splash handling for `PlasmaBolt` using the existing splash damage helper.
- `src/games/raptor/entities/PowerUp.ts`
  - Adds `weapon-plasma` to color/icon/sprite maps.
- `src/games/raptor/RaptorGame.ts`
  - Handles `weapon-plasma` pickup; assigns plasma projectile sprites; adds plasma-specific trail VFX; generalizes weapon->powerup mapping for drops.
- `src/games/raptor/rendering/HUD.ts`
  - Adds plasma HUD label (`PLS`) and color (`#8e44ad`).
- `src/games/raptor/systems/CommandRegistry.ts`
  - Adds `plasma` / `pls` weapon aliases.
- `src/games/raptor/systems/SaveSystem.ts`
  - Adds `plasma` to `VALID_WEAPONS` so save/load supports the new weapon.
- `src/games/raptor/levels.ts`
  - Adds plasma to `weaponDrops` for levels 4–10.
- `src/games/raptor/rendering/assets.ts`
  - Adds `bullet_plasma` and `powerup_plasma` to the asset manifest.
- `src/games/raptor/rendering/VFXManager.ts`
  - Adds `addPlasmaTrail()` for a distinct purple energy trail.
- `public/assets/raptor/bullet_plasma.svg` **(new)**
- `public/assets/raptor/powerup_plasma.svg` **(new)**
- Tests: updated an existing test to account for **4** weapon types.

---

### Balance / config notes
Plasma config (as implemented in `WEAPON_CONFIGS`):
- Damage: **2**
- Fire rate multiplier: **0.6x**
- Projectile speed: **400**
- Splash radius: **30**
- No homing, no piercing
- Rapid-fire bonus: **1.8x**
- Spread-shot: multi-projectile fan

---

### Testing notes
Manual verification recommended:
- Pick up `weapon-plasma` and confirm weapon switches + HUD shows **PLS** in purple.
- Fire plasma into clustered enemies; confirm hit target takes full damage and nearby enemies take splash damage.
- Confirm spread-shot fires **3** plasma bolts in a fan; confirm rapid-fire increases plasma cadence appropriately.
- Dev console: `weapon plasma`, `weapon pls`, and `weapon list` show plasma.
- Save/load round-trip with plasma equipped.
- Asset fallback: remove/skip SVG assets and verify the pulsing orb fallback renderer still displays correctly.
- Visual: plasma trail is distinct from bullet/missile trails and respects trail particle cap.

---

Ref: https://github.com/asgardtech/archer/issues/473