### PR TITLE
raptor: add plasma cannon weapon type

### DIFF
--- a/src/games/raptor/rendering/audioAssets.ts
+++ b/src/games/raptor/rendering/audioAssets.ts
@@ -28,6 +28,8 @@ export const AUDIO_MANIFEST: AudioAssetManifest = {
     enemy_spread_fire:  "assets/raptor/audio/sfx/enemy_spread_fire.mp3",
     enemy_laser_fire:   "assets/raptor/audio/sfx/enemy_laser_fire.mp3",
     enemy_laser_hit:    "assets/raptor/audio/sfx/enemy_laser_hit.mp3",
+    plasma_fire:        "assets/raptor/audio/sfx/plasma_fire.mp3",
+    plasma_hit:         "assets/raptor/audio/sfx/plasma_hit.mp3",
   },
   music: {
     menu:    "assets/raptor/audio/music/menu.mp3",

--- a/src/games/raptor/systems/SoundSystem.ts
+++ b/src/games/raptor/systems/SoundSystem.ts
@@ -47,6 +47,8 @@ export class SoundSystem {
       case "enemy_laser_fire": this.playEnemyLaserFire(); break;
       case "enemy_missile_hit": this.playEnemyMissileHit(); break;
       case "enemy_laser_hit": this.playEnemyLaserHit(); break;
+      case "plasma_fire": this.playPlasmaFire(); break;
+      case "plasma_hit": this.playPlasmaHit(); break;
     }
   }
 
@@ -216,6 +218,22 @@ export class SoundSystem {
     this.audio.playTone(1200, 0.04, "triangle", {
       attack: 0.002, decay: 0.01, sustain: 0.2, release: 0.01,
     }, this.sfxNode);
+  }
+
+  private playPlasmaFire(): void {
+    this.audio.playToneSwept(600, 1200, 0.1, "sine", {
+      attack: 0.005, decay: 0.02, sustain: 0.3, release: 0.03,
+    }, this.sfxNode);
+    this.audio.playTone(150, 0.08, "triangle", {
+      attack: 0.003, decay: 0.02, sustain: 0.2, release: 0.03,
+    }, this.sfxNode);
+  }
+
+  private playPlasmaHit(): void {
+    this.audio.playToneSwept(400, 100, 0.18, "sawtooth", {
+      attack: 0.005, decay: 0.03, sustain: 0.4, release: 0.08,
+    }, this.sfxNode);
+    this.audio.playNoise(0.12, 2500, this.sfxNode);
   }
 
   private get musicNode(): AudioNode | undefined {


### PR DESCRIPTION
## PR: raptor — Add Plasma Cannon weapon type (Issue #474, epic #420)

### Summary (what & why)
This PR adds **Plasma Cannon** as a new player weapon type for Raptor, inspired by *Raptor: Call of the Shadows*. Plasma fills the gameplay gap between the **fast/low-damage machine gun** and the **slow/homing missiles** by firing **medium-speed energy bolts** that deal **direct damage plus splash (AoE) on impact**.

Key player-facing additions:
- New weapon: **`plasma`** (DMG 2, rate 0.6x, speed 400, splash radius 30)
- New pickup: **`weapon-plasma`**
- HUD indicator: **`PLS`** with purple styling
- Dev console support: `weapon plasma` / `weapon pls`
- Save/load support and level drop integration (levels 4–10)

### Implementation highlights
- Introduced **`PlasmaBolt`** projectile with pulsing purple/blue fallback rendering and optional sprite support.
- Added **splash damage** behavior for plasma bolts (reusing existing splash mechanics used by missiles).
- Added **spread-shot** behavior (3-shot fan) and **rapid-fire** scaling via plasma’s `rapidFireBonus`.
- Added distinct **plasma trail VFX** and **sound events** (`plasma_fire`, `plasma_hit`). (Audio assets may be missing; playback no-ops gracefully.)

### Key files modified / added
- **`src/games/raptor/types.ts`** — adds `plasma` weapon config, `weapon-plasma` power-up type, plasma sound events
- **`src/games/raptor/entities/PlasmaBolt.ts`** *(new)* — plasma projectile entity + fallback visuals
- **`src/games/raptor/systems/WeaponSystem.ts`** — plasma firing path + spread-shot fan support
- **`src/games/raptor/systems/CollisionSystem.ts`** — plasma splash damage handling
- **`src/games/raptor/RaptorGame.ts`** — power-up pickup handling, projectile sprite assignment, plasma VFX/sfx wiring
- **`src/games/raptor/entities/PowerUp.ts`** — adds icon/color/sprite key for `weapon-plasma`
- **`src/games/raptor/rendering/HUD.ts`** — `PLS` weapon label + purple color mapping
- **`src/games/raptor/systems/CommandRegistry.ts`** — weapon aliases (`plasma`, `pls`)
- **`src/games/raptor/rendering/VFXManager.ts`** — plasma trail effect
- **`src/games/raptor/rendering/assets.ts`** — asset manifest entries (plasma bolt + power-up sprites; plasma sound entries)
- **`src/games/raptor/systems/SaveSystem.ts`** — allows `plasma` in `VALID_WEAPONS`
- **`src/games/raptor/levels.ts`** — adds plasma to weapon drops for levels 4–10
- **Assets:** `public/assets/raptor/bullet_plasma.svg`, `public/assets/raptor/powerup_plasma.svg`

### Testing notes
Manual verification:
- Pick up **weapon-plasma** → weapon switches to plasma; HUD shows **[PLS]** in purple.
- Fire plasma → bolts travel at medium speed; on impact, direct target takes full damage and nearby enemies take splash damage.
- Confirm **spread-shot** spawns 3 bolts in a fan; **rapid-fire** increases firing cadence; combo behaves as expected and respects projectile cap.
- Dev console: `weapon plasma` and `weapon pls` both switch correctly; `weapon list` includes plasma stats.
- Save/load: saving with plasma active persists and restores on load; validation accepts `plasma`.
- Assets: plasma bolt/power-up sprites load when present; fallback rendering works if missing.
- Audio: `plasma_fire` / `plasma_hit` events emit; if mp3s are absent, game continues silently.

Known follow-up:
- Add actual audio files: `assets/raptor/audio/sfx/plasma_fire.mp3` and `plasma_hit.mp3` (currently handled as graceful no-op if missing).

Ref: https://github.com/asgardtech/archer/issues/474