### PR TITLE
raptor: add auto-tracking minigun weapon type

### DIFF
--- a/public/assets/raptor/bullet_autogun.svg
+++ b/public/assets/raptor/bullet_autogun.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 16">
+  <defs>
+    <linearGradient id="agBullet" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#e0ffc0"/>
+      <stop offset="40%" stop-color="#a8e06c"/>
+      <stop offset="100%" stop-color="#6abf40" stop-opacity="0.8"/>
+    </linearGradient>
+    <filter id="agGlow">
+      <feGaussianBlur stdDeviation="0.6" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="1" y="1" width="4" height="14" rx="2" fill="url(#agBullet)" filter="url(#agGlow)"/>
+  <rect x="2" y="1" width="2" height="8" rx="1" fill="#e0ffc0" opacity="0.7"/>
+</svg>

--- a/public/assets/raptor/powerup_autogun.svg
+++ b/public/assets/raptor/powerup_autogun.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <radialGradient id="agCore" cx="0.5" cy="0.4" r="0.5">
+      <stop offset="0%" stop-color="#a8e06c"/>
+      <stop offset="40%" stop-color="#27ae60"/>
+      <stop offset="100%" stop-color="#1a6b3c"/>
+    </radialGradient>
+    <radialGradient id="agGlow" cx="0.5" cy="0.4" r="0.55">
+      <stop offset="0%" stop-color="#a8e06c" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#27ae60" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="agBlur">
+      <feGaussianBlur stdDeviation="0.8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <circle cx="12" cy="12" r="11" fill="url(#agGlow)"/>
+  <circle cx="12" cy="12" r="9" fill="none" stroke="#27ae60" stroke-width="0.8" stroke-opacity="0.5"/>
+  <circle cx="12" cy="12" r="7" fill="url(#agCore)" filter="url(#agBlur)"/>
+  <circle cx="12" cy="10" r="3" fill="#a8e06c" opacity="0.5"/>
+  <text x="12" y="15" text-anchor="middle" font-family="sans-serif" font-weight="bold" font-size="10" fill="#FFFFFF" opacity="0.9">A</text>
+  <line x1="5" y1="7" x2="5" y2="12" stroke="#a8e06c" stroke-width="0.5" stroke-opacity="0.5" stroke-linecap="round"/>
+  <line x1="19" y1="7" x2="19" y2="12" stroke="#a8e06c" stroke-width="0.5" stroke-opacity="0.5" stroke-linecap="round"/>
+</svg>

--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -12,6 +12,7 @@ import { CommandRegistry, CommandContext, registerLevelCommands, registerWeaponC
 import { Player } from "./entities/Player";
 import { Bullet } from "./entities/Bullet";
 import { Missile } from "./entities/Missile";
+import { TrackingBullet } from "./entities/TrackingBullet";
 import { PlasmaBolt } from "./entities/PlasmaBolt";
 import { IonBolt } from "./entities/IonBolt";
 import { Enemy } from "./entities/Enemy";
@@ -596,7 +597,10 @@ export class RaptorGame implements IGame {
     }
 
     for (const proj of this.projectiles) {
-      if (proj instanceof Bullet) {
+      if (proj instanceof TrackingBullet) {
+        proj.update(dt, this.width, this.height, this.enemies);
+        this.vfx.addTrail(proj.pos.x, proj.pos.y + 3, "rgba(168, 224, 108, 0.4)", 1.5);
+      } else if (proj instanceof Bullet) {
         proj.update(dt, this.width);
         this.vfx.addTrail(proj.pos.x, proj.pos.y + 4, "rgba(255, 220, 0, 0.4)", 1.5);
       } else if (proj instanceof Missile) {
@@ -759,6 +763,11 @@ export class RaptorGame implements IGame {
             this.sound.play("weapon_switch");
           }
           break;
+        case "weapon-autogun":
+          if (this.powerUpManager.setWeapon("auto-gun")) {
+            this.sound.play("weapon_switch");
+          }
+          break;
         case "mega-bomb":
           if (this.player.bombs < this.player.maxBombs) {
             this.player.bombs++;
@@ -829,7 +838,10 @@ export class RaptorGame implements IGame {
   }
 
   private assignProjectileSprite(proj: Projectile): void {
-    if (proj instanceof Bullet) {
+    if (proj instanceof TrackingBullet) {
+      const sprite = this.assets.getOptional("bullet_autogun");
+      if (sprite) proj.setSprite(sprite);
+    } else if (proj instanceof Bullet) {
       const sprite = this.assets.getOptional("bullet_player");
       if (sprite) proj.setSprite(sprite);
     } else if (proj instanceof Missile) {
@@ -850,6 +862,7 @@ export class RaptorGame implements IGame {
     laser: "weapon-laser",
     plasma: "weapon-plasma",
     "ion-cannon": "weapon-ion",
+    "auto-gun": "weapon-autogun",
   };
 
   private spawnPowerUp(x: number, y: number): void {

--- a/src/games/raptor/entities/PowerUp.ts
+++ b/src/games/raptor/entities/PowerUp.ts
@@ -12,6 +12,7 @@ const COLORS: Record<RaptorPowerUpType, string> = {
   "weapon-laser": "#9b59b6",
   "weapon-plasma": "#8e44ad",
   "weapon-ion": "#00bcd4",
+  "weapon-autogun": "#27ae60",
   "mega-bomb": "#e74c3c",
 };
 
@@ -24,6 +25,7 @@ const ICONS: Record<RaptorPowerUpType, string> = {
   "weapon-laser": "L",
   "weapon-plasma": "P",
   "weapon-ion": "I",
+  "weapon-autogun": "A",
   "mega-bomb": "B",
 };
 
@@ -36,6 +38,7 @@ const SPRITE_KEYS: Record<RaptorPowerUpType, string> = {
   "weapon-laser": "powerup_laser",
   "weapon-plasma": "powerup_plasma",
   "weapon-ion": "powerup_ion",
+  "weapon-autogun": "powerup_autogun",
   "mega-bomb": "powerup_bomb",
 };
 

--- a/src/games/raptor/entities/TrackingBullet.ts
+++ b/src/games/raptor/entities/TrackingBullet.ts
@@ -1,0 +1,125 @@
+import { Vec2, Projectile } from "../types";
+import { Enemy } from "./Enemy";
+
+const TRACKING_BULLET_SPEED = 480;
+
+export class TrackingBullet implements Projectile {
+  public pos: Vec2;
+  public alive = true;
+  public width = 3;
+  public height = 8;
+  public damage = 1;
+  public piercing = false;
+
+  private angle: number;
+  private vx: number;
+  private vy: number;
+  private homingStrength: number;
+  private sprite: HTMLImageElement | null = null;
+  private time = 0;
+
+  constructor(x: number, y: number, angle = 0, homingStrength = 1.0) {
+    this.pos = { x, y };
+    this.angle = angle;
+    this.homingStrength = homingStrength;
+    this.vx = Math.sin(angle) * TRACKING_BULLET_SPEED;
+    this.vy = -Math.cos(angle) * TRACKING_BULLET_SPEED;
+  }
+
+  setSprite(sprite: HTMLImageElement): void {
+    this.sprite = sprite;
+  }
+
+  get left(): number { return this.pos.x - this.width / 2; }
+  get right(): number { return this.pos.x + this.width / 2; }
+  get top(): number { return this.pos.y - this.height / 2; }
+  get bottom(): number { return this.pos.y + this.height / 2; }
+
+  update(dt: number, canvasWidth = 800, canvasHeight = 600, enemies?: Enemy[]): void {
+    if (!this.alive) return;
+    this.time += dt;
+
+    if (enemies && enemies.length > 0) {
+      const target = this.findNearestEnemy(enemies);
+      if (target) {
+        const desiredAngle = Math.atan2(
+          target.pos.x - this.pos.x,
+          -(target.pos.y - this.pos.y)
+        );
+        let angleDiff = desiredAngle - this.angle;
+        while (angleDiff > Math.PI) angleDiff -= Math.PI * 2;
+        while (angleDiff < -Math.PI) angleDiff += Math.PI * 2;
+
+        const maxTurn = this.homingStrength * dt;
+        this.angle += Math.max(-maxTurn, Math.min(maxTurn, angleDiff));
+      }
+    }
+
+    this.vx = Math.sin(this.angle) * TRACKING_BULLET_SPEED;
+    this.vy = -Math.cos(this.angle) * TRACKING_BULLET_SPEED;
+
+    this.pos.x += this.vx * dt;
+    this.pos.y += this.vy * dt;
+
+    if (
+      this.pos.y < -20 ||
+      this.pos.x < -20 ||
+      this.pos.x > canvasWidth + 20 ||
+      this.pos.y > canvasHeight + 20
+    ) {
+      this.alive = false;
+    }
+  }
+
+  private findNearestEnemy(enemies: Enemy[]): Enemy | null {
+    let nearest: Enemy | null = null;
+    let minDist = Infinity;
+
+    for (const enemy of enemies) {
+      if (!enemy.alive) continue;
+      const dx = enemy.pos.x - this.pos.x;
+      const dy = enemy.pos.y - this.pos.y;
+      const dist = dx * dx + dy * dy;
+      if (dist < minDist) {
+        minDist = dist;
+        nearest = enemy;
+      }
+    }
+    return nearest;
+  }
+
+  render(ctx: CanvasRenderingContext2D): void {
+    if (!this.alive) return;
+
+    if (this.sprite) {
+      this.renderSprite(ctx);
+    } else {
+      this.renderFallback(ctx);
+    }
+  }
+
+  private renderSprite(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.translate(this.pos.x, this.pos.y);
+    ctx.rotate(this.angle);
+    ctx.drawImage(
+      this.sprite!,
+      -this.width / 2, -this.height / 2,
+      this.width, this.height
+    );
+    ctx.restore();
+  }
+
+  private renderFallback(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.fillStyle = "#a8e06c";
+    ctx.shadowColor = "#a8e06c";
+    ctx.shadowBlur = 4;
+    ctx.translate(this.pos.x, this.pos.y);
+    ctx.rotate(this.angle);
+    ctx.fillRect(-this.width / 2, -this.height / 2, this.width, this.height);
+    ctx.fillStyle = "#e0ffc0";
+    ctx.fillRect(-1, -this.height / 2, 2, this.height * 0.5);
+    ctx.restore();
+  }
+}

--- a/src/games/raptor/levels.ts
+++ b/src/games/raptor/levels.ts
@@ -91,7 +91,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#4A6670", "#8BA8B7"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.2,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "auto-gun"] as WeaponType[],
     terrain: {
       theme: "mountain",
       horizonAssets: ["horizon_mountain"],
@@ -131,7 +131,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#B0C4DE", "#D3D3D3"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.4,
-    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "auto-gun"] as WeaponType[],
     terrain: {
       theme: "arctic",
       horizonAssets: ["horizon_arctic"],
@@ -172,7 +172,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#2F1B14", "#1a1a1a"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.6,
-    weaponDrops: ["missile", "laser", "plasma"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "auto-gun"] as WeaponType[],
     terrain: {
       theme: "fortress",
       horizonAssets: ["horizon_fortress"],

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -41,6 +41,7 @@ const WEAPON_LABELS: Record<WeaponType, string> = {
   "laser": "LSR",
   "plasma": "PLS",
   "ion-cannon": "ION",
+  "auto-gun": "ATG",
 };
 
 const WEAPON_COLORS: Record<WeaponType, string> = {
@@ -49,6 +50,7 @@ const WEAPON_COLORS: Record<WeaponType, string> = {
   "laser": "#9b59b6",
   "plasma": "#8e44ad",
   "ion-cannon": "#00bcd4",
+  "auto-gun": "#27ae60",
 };
 
 interface SliderLayout {

--- a/src/games/raptor/rendering/assets.ts
+++ b/src/games/raptor/rendering/assets.ts
@@ -24,6 +24,8 @@ export const ASSET_MANIFEST: AssetManifest = {
   powerup_plasma:   `${BASE}powerup_plasma.svg`,
   bullet_ion:       `${BASE}bullet_ion.svg`,
   powerup_ion:      `${BASE}powerup_ion.svg`,
+  bullet_autogun:   `${BASE}bullet_autogun.svg`,
+  powerup_autogun:  `${BASE}powerup_autogun.svg`,
   powerup_bomb:     `${BASE}powerup_bomb.svg`,
   bg_nebula:        `${BASE}bg_nebula.svg`,
   planet_01:        `${BASE}planet_01.svg`,

--- a/src/games/raptor/systems/CommandRegistry.ts
+++ b/src/games/raptor/systems/CommandRegistry.ts
@@ -111,6 +111,9 @@ const WEAPON_ALIASES: Record<string, WeaponType> = {
   pls: "plasma",
   "ion-cannon": "ion-cannon",
   ion: "ion-cannon",
+  "auto-gun": "auto-gun",
+  autogun: "auto-gun",
+  atg: "auto-gun",
 };
 
 const POWERUP_ALIASES: Record<string, RaptorPowerUpType> = {
@@ -158,7 +161,7 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
 
     const resolved = WEAPON_ALIASES[sub];
     if (!resolved) {
-      return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr), plasma (pls), ion-cannon (ion)`;
+      return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr), plasma (pls), ion-cannon (ion), auto-gun (atg)`;
     }
 
     ctx.powerUpManager.setWeapon(resolved);

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -2,7 +2,7 @@ import { RaptorSaveData, WeaponType } from "../types";
 import { LEVELS } from "../levels";
 import { tryGetStorage, trySetStorage, tryRemoveStorage } from "../../../shared/storage";
 
-const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser", "plasma", "ion-cannon"];
+const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser", "plasma", "ion-cannon", "auto-gun"];
 
 export class SaveSystem {
   private static readonly STORAGE_KEY = "raptor_save";

--- a/src/games/raptor/systems/WeaponSystem.ts
+++ b/src/games/raptor/systems/WeaponSystem.ts
@@ -4,6 +4,7 @@ import { Bullet } from "../entities/Bullet";
 import { Missile } from "../entities/Missile";
 import { PlasmaBolt } from "../entities/PlasmaBolt";
 import { IonBolt } from "../entities/IonBolt";
+import { TrackingBullet } from "../entities/TrackingBullet";
 import { LaserBeam } from "../entities/LaserBeam";
 import { PowerUpManager } from "./PowerUpManager";
 
@@ -122,6 +123,17 @@ export class WeaponSystem {
           newProjectiles.push(this.createPlasmaBolt(player.pos.x, player.top));
         }
         soundEvent = "plasma_fire";
+      } else if (this.currentWeapon === "auto-gun") {
+        if (spreadShot) {
+          newProjectiles.push(this.createTrackingBullet(player.pos.x - 12, player.top));
+          newProjectiles.push(this.createTrackingBullet(player.pos.x - 4, player.top));
+          newProjectiles.push(this.createTrackingBullet(player.pos.x + 4, player.top));
+          newProjectiles.push(this.createTrackingBullet(player.pos.x + 12, player.top));
+        } else {
+          newProjectiles.push(this.createTrackingBullet(player.pos.x - 4, player.top));
+          newProjectiles.push(this.createTrackingBullet(player.pos.x + 4, player.top));
+        }
+        soundEvent = "player_shoot";
       }
     }
 
@@ -139,6 +151,11 @@ export class WeaponSystem {
 
   private createPlasmaBolt(x: number, y: number, angle = 0): PlasmaBolt {
     return new PlasmaBolt(x, y, angle);
+  }
+
+  private createTrackingBullet(x: number, y: number, angle = 0): TrackingBullet {
+    const config = WEAPON_CONFIGS["auto-gun"];
+    return new TrackingBullet(x, y, angle, config.homingStrength);
   }
 
   private createIonBolt(x: number, y: number, chargeLevel: number, angle = 0): IonBolt {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -104,6 +104,7 @@ export type RaptorPowerUpType =
   | "weapon-laser"
   | "weapon-plasma"
   | "weapon-ion"
+  | "weapon-autogun"
   | "mega-bomb";
 
 export type RaptorSoundEvent =
@@ -136,7 +137,7 @@ export type RaptorSoundEvent =
   | "ion_hit"
   | "mega_bomb_fire";
 
-export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon";
+export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon" | "auto-gun";
 
 export interface RaptorSaveData {
   version: 1;
@@ -229,6 +230,18 @@ export const WEAPON_CONFIGS: Record<WeaponType, WeaponConfig> = {
     rapidFireBonus: 1.4,
     spreadShotBehavior: "multi-projectile",
     chargeTime: 2.0,
+  },
+  "auto-gun": {
+    type: "auto-gun",
+    damage: 1,
+    fireRateMultiplier: 1.4,
+    projectileSpeed: 480,
+    piercing: false,
+    homing: true,
+    homingStrength: 1.0,
+    splashRadius: 0,
+    rapidFireBonus: 1.8,
+    spreadShotBehavior: "multi-projectile",
   },
 };
 


### PR DESCRIPTION
## PR: raptor: add auto-tracking minigun weapon type (auto-gun)

Part of epic #420 • Issue: **raptor: add auto-tracking minigun weapon type**

### Summary (what / why)
This PR adds a new player weapon type, **Auto-Tracking Minigun** (`auto-gun`), inspired by *Raptor: Call of the Shadows*. It fires **twin streams** of low-damage bullets that **gently home toward the nearest enemy**, trading raw DPS for improved hit consistency—especially useful against fast scouts and spread-out formations.

Key behaviors:
- **New `TrackingBullet` projectile** with mild per-frame homing (`homingStrength: 1.0`)
- **Twin-shot pattern** by default (2 bullets per fire), **4 bullets with spread-shot**
- Integrated into the existing weapon/power-up/HUD/save/asset pipelines

### Key files modified / added
**New**
- `src/games/raptor/entities/TrackingBullet.ts` — new projectile entity implementing mild homing toward the nearest alive enemy
- `public/assets/raptor/bullet_autogun.svg` — auto-gun bullet sprite
- `public/assets/raptor/powerup_autogun.svg` — auto-gun power-up sprite

**Updated**
- `src/games/raptor/types.ts` — adds `auto-gun` to `WeaponType`, `WEAPON_CONFIGS`, and power-up typing (plus optional sound event typing)
- `src/games/raptor/systems/WeaponSystem.ts` — fires `TrackingBullet` (2-shot base, 4-shot with spread); uses config homing strength
- `src/games/raptor/RaptorGame.ts` — sprite assignment for `TrackingBullet`, update loop passes enemies for homing, adds trail VFX, handles `weapon-autogun` pickup, updates drop mapping
- `src/games/raptor/entities/PowerUp.ts` — adds color/icon/sprite-key wiring for `weapon-autogun`
- `src/games/raptor/rendering/HUD.ts` — displays **ATG** label with green color (`#27ae60`)
- `src/games/raptor/systems/CommandRegistry.ts` — adds console aliases: `auto-gun`, `autogun`, `atg` (+ help text)
- `src/games/raptor/levels.ts` — includes `auto-gun` in weapon drop pools for levels 3–5
- `src/games/raptor/systems/SaveSystem.ts` — adds `auto-gun` to `VALID_WEAPONS` for save/load validation
- `src/games/raptor/rendering/assets.ts` — registers `bullet_autogun` and `powerup_autogun` in the asset manifest

### Gameplay / balance notes
- Config: `damage: 1`, `fireRateMultiplier: 1.4`, `projectileSpeed: 480`, `homingStrength: 1.0`, no piercing/splash
- Designed to **nudge** toward targets (not hard lock-on); bullets continue straight if no enemies exist.

### Testing notes
**Manual verification**
- Pick up `weapon-autogun` → weapon switches to `auto-gun` and plays weapon switch SFX
- Fire behavior: 2 bullets per shot with ±4px offset; with spread-shot: 4 bullets (±4px, ±12px)
- Homing: bullets gently curve toward nearest alive enemy; with no enemies they fly straight
- HUD shows **ATG** in green; VFX trails render for tracking bullets
- Dev console: `weapon autogun` / `weapon atg` switches correctly
- Save/load: active weapon persists and passes validation with `auto-gun`

**Suggested automated coverage (if/when added)**
- Unit tests for `TrackingBullet` homing vs. no-enemy straight flight
- WeaponSystem projectile count assertions (2 base / 4 spread)
- SaveSystem validation round-trip with `auto-gun` equipped

Ref: https://github.com/asgardtech/archer/issues/477