### PR TITLE
raptor: add dumb-fire rocket weapon type

### DIFF
--- a/public/assets/raptor/bullet_rocket.svg
+++ b/public/assets/raptor/bullet_rocket.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 36">
+  <defs>
+    <linearGradient id="rkBody" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#2e4a20"/>
+      <stop offset="40%" stop-color="#4a6b35"/>
+      <stop offset="60%" stop-color="#3d5c2e"/>
+      <stop offset="100%" stop-color="#2a4020"/>
+    </linearGradient>
+    <radialGradient id="rkNose" cx="0.5" cy="0.3" r="0.6">
+      <stop offset="0%" stop-color="#ffcc66"/>
+      <stop offset="50%" stop-color="#ffaa33"/>
+      <stop offset="100%" stop-color="#cc7700"/>
+    </radialGradient>
+    <linearGradient id="rkExhaust" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffaa33"/>
+      <stop offset="40%" stop-color="#ff6600"/>
+      <stop offset="100%" stop-color="#ff4400" stop-opacity="0.2"/>
+    </linearGradient>
+    <filter id="rkGlow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <!-- Exhaust plume -->
+  <polygon points="6,30 10,36 14,30" fill="url(#rkExhaust)" opacity="0.8"/>
+  <polygon points="7.5,30 10,34 12.5,30" fill="#ffcc44" opacity="0.6"/>
+  <!-- Main body -->
+  <rect x="6" y="10" width="8" height="20" rx="1" fill="url(#rkBody)"/>
+  <!-- Body band -->
+  <rect x="6" y="18" width="8" height="2" fill="#2a4020" opacity="0.5"/>
+  <!-- Stabilizer fins -->
+  <polygon points="4,28 6,24 6,30" fill="#2e4a20"/>
+  <polygon points="16,28 14,24 14,30" fill="#2e4a20"/>
+  <!-- Nose cone -->
+  <polygon points="6,11 10,2 14,11" fill="url(#rkNose)" filter="url(#rkGlow)"/>
+  <!-- Nose highlight -->
+  <ellipse cx="10" cy="7" rx="2" ry="3.5" fill="#ffdd88" opacity="0.4" filter="url(#rkGlow)"/>
+  <!-- Tip highlight -->
+  <ellipse cx="10" cy="4" rx="1" ry="1.5" fill="#ffeecc" opacity="0.7"/>
+</svg>

--- a/public/assets/raptor/powerup_rocket.svg
+++ b/public/assets/raptor/powerup_rocket.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <radialGradient id="rkpCore" cx="0.5" cy="0.4" r="0.5">
+      <stop offset="0%" stop-color="#4a6b7a"/>
+      <stop offset="40%" stop-color="#2c3e50"/>
+      <stop offset="100%" stop-color="#1a2530"/>
+    </radialGradient>
+    <radialGradient id="rkpGlow" cx="0.5" cy="0.4" r="0.55">
+      <stop offset="0%" stop-color="#4a6b7a" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#2c3e50" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="rkpBlur">
+      <feGaussianBlur stdDeviation="0.8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <circle cx="12" cy="12" r="11" fill="url(#rkpGlow)"/>
+  <circle cx="12" cy="12" r="9" fill="none" stroke="#2c3e50" stroke-width="0.8" stroke-opacity="0.5"/>
+  <circle cx="12" cy="12" r="7" fill="url(#rkpCore)" filter="url(#rkpBlur)"/>
+  <circle cx="12" cy="10" r="3" fill="#4a6b7a" opacity="0.5"/>
+  <text x="12" y="15" text-anchor="middle" font-family="sans-serif" font-weight="bold" font-size="10" fill="#FFFFFF" opacity="0.9">R</text>
+</svg>

--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -15,6 +15,7 @@ import { Missile } from "./entities/Missile";
 import { TrackingBullet } from "./entities/TrackingBullet";
 import { PlasmaBolt } from "./entities/PlasmaBolt";
 import { IonBolt } from "./entities/IonBolt";
+import { Rocket } from "./entities/Rocket";
 import { Enemy } from "./entities/Enemy";
 import { EnemyBullet } from "./entities/EnemyBullet";
 import { EnemyMissile } from "./entities/EnemyMissile";
@@ -612,6 +613,9 @@ export class RaptorGame implements IGame {
       } else if (proj instanceof IonBolt) {
         proj.update(dt, this.width);
         this.vfx.addTrail(proj.pos.x, proj.pos.y + 4, "rgba(0, 188, 212, 0.5)", 2);
+      } else if (proj instanceof Rocket) {
+        proj.update(dt, this.width, this.height);
+        this.vfx.addRocketTrail(proj.pos.x, proj.pos.y + 8);
       }
     }
     for (const eb of this.enemyBullets) {
@@ -647,6 +651,9 @@ export class RaptorGame implements IGame {
         } else if (hit.bullet instanceof IonBolt) {
           this.sound.play("ion_hit");
           this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 22);
+        } else if (hit.bullet instanceof Rocket) {
+          this.sound.play("missile_hit");
+          this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 30);
         }
       } else {
         if (hit.bullet instanceof Missile) {
@@ -658,6 +665,9 @@ export class RaptorGame implements IGame {
         } else if (hit.bullet instanceof IonBolt) {
           this.sound.play("ion_hit");
           this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 14);
+        } else if (hit.bullet instanceof Rocket) {
+          this.sound.play("missile_hit");
+          this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 20);
         } else if (hit.enemy.variant === "boss") {
           this.sound.play("boss_hit");
         } else {
@@ -768,6 +778,11 @@ export class RaptorGame implements IGame {
             this.sound.play("weapon_switch");
           }
           break;
+        case "weapon-rocket":
+          if (this.powerUpManager.setWeapon("rocket")) {
+            this.sound.play("weapon_switch");
+          }
+          break;
         case "mega-bomb":
           if (this.player.bombs < this.player.maxBombs) {
             this.player.bombs++;
@@ -853,6 +868,9 @@ export class RaptorGame implements IGame {
     } else if (proj instanceof IonBolt) {
       const sprite = this.assets.getOptional("bullet_ion");
       if (sprite) proj.setSprite(sprite);
+    } else if (proj instanceof Rocket) {
+      const sprite = this.assets.getOptional("bullet_rocket");
+      if (sprite) proj.setSprite(sprite);
     }
   }
 
@@ -863,6 +881,7 @@ export class RaptorGame implements IGame {
     plasma: "weapon-plasma",
     "ion-cannon": "weapon-ion",
     "auto-gun": "weapon-autogun",
+    rocket: "weapon-rocket",
   };
 
   private spawnPowerUp(x: number, y: number): void {

--- a/src/games/raptor/entities/PowerUp.ts
+++ b/src/games/raptor/entities/PowerUp.ts
@@ -13,6 +13,7 @@ const COLORS: Record<RaptorPowerUpType, string> = {
   "weapon-plasma": "#8e44ad",
   "weapon-ion": "#00bcd4",
   "weapon-autogun": "#27ae60",
+  "weapon-rocket": "#2c3e50",
   "mega-bomb": "#e74c3c",
 };
 
@@ -26,6 +27,7 @@ const ICONS: Record<RaptorPowerUpType, string> = {
   "weapon-plasma": "P",
   "weapon-ion": "I",
   "weapon-autogun": "A",
+  "weapon-rocket": "R",
   "mega-bomb": "B",
 };
 
@@ -39,6 +41,7 @@ const SPRITE_KEYS: Record<RaptorPowerUpType, string> = {
   "weapon-plasma": "powerup_plasma",
   "weapon-ion": "powerup_ion",
   "weapon-autogun": "powerup_autogun",
+  "weapon-rocket": "powerup_rocket",
   "mega-bomb": "powerup_bomb",
 };
 

--- a/src/games/raptor/entities/Rocket.ts
+++ b/src/games/raptor/entities/Rocket.ts
@@ -1,0 +1,112 @@
+import { Vec2, Projectile } from "../types";
+
+const ROCKET_SPEED = 450;
+
+export class Rocket implements Projectile {
+  public pos: Vec2;
+  public alive = true;
+  public width = 10;
+  public height = 18;
+  public damage = 5;
+  public piercing = false;
+
+  private angle: number;
+  private vx: number;
+  private vy: number;
+  private sprite: HTMLImageElement | null = null;
+  private time = 0;
+
+  constructor(x: number, y: number, angle = 0) {
+    this.pos = { x, y };
+    this.angle = angle;
+    this.vx = Math.sin(angle) * ROCKET_SPEED;
+    this.vy = -Math.cos(angle) * ROCKET_SPEED;
+  }
+
+  setSprite(sprite: HTMLImageElement): void {
+    this.sprite = sprite;
+  }
+
+  get left(): number { return this.pos.x - this.width / 2; }
+  get right(): number { return this.pos.x + this.width / 2; }
+  get top(): number { return this.pos.y - this.height / 2; }
+  get bottom(): number { return this.pos.y + this.height / 2; }
+
+  update(dt: number, canvasWidth = 800, canvasHeight = 600): void {
+    if (!this.alive) return;
+    this.time += dt;
+
+    this.pos.x += this.vx * dt;
+    this.pos.y += this.vy * dt;
+
+    if (
+      this.pos.y < -30 || this.pos.x < -30 ||
+      this.pos.x > canvasWidth + 30 || this.pos.y > canvasHeight + 30
+    ) {
+      this.alive = false;
+    }
+  }
+
+  render(ctx: CanvasRenderingContext2D): void {
+    if (!this.alive) return;
+
+    if (this.sprite) {
+      this.renderSprite(ctx);
+    } else {
+      this.renderFallback(ctx);
+    }
+  }
+
+  private renderSprite(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.translate(this.pos.x, this.pos.y);
+    ctx.rotate(this.angle);
+    ctx.drawImage(this.sprite!, -this.width / 2, -this.height / 2, this.width, this.height);
+    ctx.restore();
+  }
+
+  private renderFallback(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.translate(this.pos.x, this.pos.y);
+    ctx.rotate(this.angle);
+
+    // Dark olive/green rocket body
+    ctx.fillStyle = "#3d5c2e";
+    ctx.beginPath();
+    ctx.moveTo(0, -this.height / 2);
+    ctx.lineTo(-this.width / 2, this.height / 3);
+    ctx.lineTo(-this.width / 2, this.height / 2);
+    ctx.lineTo(this.width / 2, this.height / 2);
+    ctx.lineTo(this.width / 2, this.height / 3);
+    ctx.closePath();
+    ctx.fill();
+
+    // Orange nose tip
+    ctx.fillStyle = "#ffaa33";
+    ctx.beginPath();
+    ctx.moveTo(0, -this.height / 2);
+    ctx.lineTo(-this.width / 3, -this.height / 6);
+    ctx.lineTo(this.width / 3, -this.height / 6);
+    ctx.closePath();
+    ctx.fill();
+
+    // Fins
+    ctx.fillStyle = "#2e4a20";
+    ctx.fillRect(-this.width / 2 - 2, this.height / 4, 4, this.height / 4);
+    ctx.fillRect(this.width / 2 - 2, this.height / 4, 4, this.height / 4);
+
+    // Flickering exhaust flame
+    ctx.fillStyle = "#ff4400";
+    ctx.shadowColor = "#ff4400";
+    ctx.shadowBlur = 8;
+    const flicker = 4 + Math.sin(this.time * 30) * 3;
+    ctx.beginPath();
+    ctx.moveTo(-this.width / 3, this.height / 2);
+    ctx.lineTo(0, this.height / 2 + flicker);
+    ctx.lineTo(this.width / 3, this.height / 2);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.restore();
+  }
+}

--- a/src/games/raptor/levels.ts
+++ b/src/games/raptor/levels.ts
@@ -172,7 +172,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#2F1B14", "#1a1a1a"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.6,
-    weaponDrops: ["missile", "laser", "plasma", "auto-gun"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "auto-gun", "rocket"] as WeaponType[],
     terrain: {
       theme: "fortress",
       horizonAssets: ["horizon_fortress"],
@@ -217,7 +217,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#2b1d1d", "#4a3333"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.8,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
     terrain: {
       theme: "shipyard",
       horizonAssets: ["horizon_shipyard"],
@@ -270,7 +270,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#1a1a0e", "#3d3520"],
     starDensity: 0,
     enemyFireRateMultiplier: 2.0,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
     terrain: {
       theme: "wasteland",
       horizonAssets: ["horizon_wasteland"],
@@ -323,7 +323,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#1c1c1c", "#333030"],
     starDensity: 0,
     enemyFireRateMultiplier: 2.2,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
     terrain: {
       theme: "industrial",
       horizonAssets: ["horizon_industrial"],
@@ -378,7 +378,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#050510", "#0a0a20"],
     starDensity: 40,
     enemyFireRateMultiplier: 2.4,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
     terrain: {
       theme: "orbital",
       horizonAssets: ["horizon_orbital"],
@@ -434,7 +434,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#0a0000", "#1a0505"],
     starDensity: 50,
     enemyFireRateMultiplier: 2.5,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon"] as WeaponType[],
+    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
     terrain: {
       theme: "stronghold",
       horizonAssets: ["horizon_stronghold"],

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -42,6 +42,7 @@ const WEAPON_LABELS: Record<WeaponType, string> = {
   "plasma": "PLS",
   "ion-cannon": "ION",
   "auto-gun": "ATG",
+  "rocket": "RKT",
 };
 
 const WEAPON_COLORS: Record<WeaponType, string> = {
@@ -51,6 +52,7 @@ const WEAPON_COLORS: Record<WeaponType, string> = {
   "plasma": "#8e44ad",
   "ion-cannon": "#00bcd4",
   "auto-gun": "#27ae60",
+  "rocket": "#2c3e50",
 };
 
 interface SliderLayout {

--- a/src/games/raptor/rendering/VFXManager.ts
+++ b/src/games/raptor/rendering/VFXManager.ts
@@ -192,6 +192,17 @@ export class VFXManager {
     });
   }
 
+  addRocketTrail(x: number, y: number): void {
+    if (this.trails.length > 300) return;
+    this.trails.push({
+      x: x + (Math.random() - 0.5) * 6,
+      y: y + (Math.random() - 0.5) * 3,
+      alpha: 0.6,
+      size: 2.0 + Math.random() * 2.0,
+      color: `rgba(${140 + Math.random() * 40}, ${130 + Math.random() * 30}, ${100 + Math.random() * 30}, 0.7)`,
+    });
+  }
+
   addPlasmaTrail(x: number, y: number): void {
     if (this.trails.length > 300) return;
     this.trails.push({

--- a/src/games/raptor/rendering/assets.ts
+++ b/src/games/raptor/rendering/assets.ts
@@ -26,6 +26,8 @@ export const ASSET_MANIFEST: AssetManifest = {
   powerup_ion:      `${BASE}powerup_ion.svg`,
   bullet_autogun:   `${BASE}bullet_autogun.svg`,
   powerup_autogun:  `${BASE}powerup_autogun.svg`,
+  bullet_rocket:    `${BASE}bullet_rocket.svg`,
+  powerup_rocket:   `${BASE}powerup_rocket.svg`,
   powerup_bomb:     `${BASE}powerup_bomb.svg`,
   bg_nebula:        `${BASE}bg_nebula.svg`,
   planet_01:        `${BASE}planet_01.svg`,

--- a/src/games/raptor/rendering/audioAssets.ts
+++ b/src/games/raptor/rendering/audioAssets.ts
@@ -32,6 +32,7 @@ export const AUDIO_MANIFEST: AudioAssetManifest = {
     plasma_hit:         "assets/raptor/audio/sfx/plasma_hit.mp3",
     ion_fire:           "assets/raptor/audio/sfx/ion_fire.mp3",
     ion_hit:            "assets/raptor/audio/sfx/ion_hit.mp3",
+    rocket_fire:        "assets/raptor/audio/sfx/rocket_fire.mp3",
     mega_bomb_fire:     "assets/raptor/audio/sfx/mega_bomb_fire.mp3",
   },
   music: {

--- a/src/games/raptor/systems/CollisionSystem.ts
+++ b/src/games/raptor/systems/CollisionSystem.ts
@@ -2,6 +2,7 @@ import { Projectile, WEAPON_CONFIGS } from "../types";
 import { Bullet } from "../entities/Bullet";
 import { Missile } from "../entities/Missile";
 import { PlasmaBolt } from "../entities/PlasmaBolt";
+import { Rocket } from "../entities/Rocket";
 import { LaserBeam } from "../entities/LaserBeam";
 import { EnemyLaserBeam } from "../entities/EnemyLaserBeam";
 import { Enemy } from "../entities/Enemy";
@@ -121,6 +122,19 @@ export class CollisionSystem {
 
           if (bullet instanceof PlasmaBolt) {
             const splashHits = this.applySplashDamage(enemy, enemies, WEAPON_CONFIGS["plasma"].splashRadius);
+            for (const sh of splashHits) {
+              hits.push({
+                bullet,
+                enemy: sh.enemy,
+                destroyed: sh.destroyed,
+                damage: 1,
+                splash: true,
+              });
+            }
+          }
+
+          if (bullet instanceof Rocket) {
+            const splashHits = this.applySplashDamage(enemy, enemies, WEAPON_CONFIGS["rocket"].splashRadius);
             for (const sh of splashHits) {
               hits.push({
                 bullet,

--- a/src/games/raptor/systems/CommandRegistry.ts
+++ b/src/games/raptor/systems/CommandRegistry.ts
@@ -114,6 +114,8 @@ const WEAPON_ALIASES: Record<string, WeaponType> = {
   "auto-gun": "auto-gun",
   autogun: "auto-gun",
   atg: "auto-gun",
+  rocket: "rocket",
+  rkt: "rocket",
 };
 
 const POWERUP_ALIASES: Record<string, RaptorPowerUpType> = {
@@ -161,7 +163,7 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
 
     const resolved = WEAPON_ALIASES[sub];
     if (!resolved) {
-      return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr), plasma (pls), ion-cannon (ion), auto-gun (atg)`;
+      return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr), plasma (pls), ion-cannon (ion), auto-gun (atg), rocket (rkt)`;
     }
 
     ctx.powerUpManager.setWeapon(resolved);

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -2,7 +2,7 @@ import { RaptorSaveData, WeaponType } from "../types";
 import { LEVELS } from "../levels";
 import { tryGetStorage, trySetStorage, tryRemoveStorage } from "../../../shared/storage";
 
-const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser", "plasma", "ion-cannon", "auto-gun"];
+const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser", "plasma", "ion-cannon", "auto-gun", "rocket"];
 
 export class SaveSystem {
   private static readonly STORAGE_KEY = "raptor_save";

--- a/src/games/raptor/systems/WeaponSystem.ts
+++ b/src/games/raptor/systems/WeaponSystem.ts
@@ -5,6 +5,7 @@ import { Missile } from "../entities/Missile";
 import { PlasmaBolt } from "../entities/PlasmaBolt";
 import { IonBolt } from "../entities/IonBolt";
 import { TrackingBullet } from "../entities/TrackingBullet";
+import { Rocket } from "../entities/Rocket";
 import { LaserBeam } from "../entities/LaserBeam";
 import { PowerUpManager } from "./PowerUpManager";
 
@@ -134,6 +135,15 @@ export class WeaponSystem {
           newProjectiles.push(this.createTrackingBullet(player.pos.x + 4, player.top));
         }
         soundEvent = "player_shoot";
+      } else if (this.currentWeapon === "rocket") {
+        if (spreadShot) {
+          newProjectiles.push(this.createRocket(player.pos.x, player.top, -0.15));
+          newProjectiles.push(this.createRocket(player.pos.x, player.top, 0));
+          newProjectiles.push(this.createRocket(player.pos.x, player.top, 0.15));
+        } else {
+          newProjectiles.push(this.createRocket(player.pos.x, player.top));
+        }
+        soundEvent = "rocket_fire";
       }
     }
 
@@ -156,6 +166,10 @@ export class WeaponSystem {
   private createTrackingBullet(x: number, y: number, angle = 0): TrackingBullet {
     const config = WEAPON_CONFIGS["auto-gun"];
     return new TrackingBullet(x, y, angle, config.homingStrength);
+  }
+
+  private createRocket(x: number, y: number, angle = 0): Rocket {
+    return new Rocket(x, y, angle);
   }
 
   private createIonBolt(x: number, y: number, chargeLevel: number, angle = 0): IonBolt {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -105,6 +105,7 @@ export type RaptorPowerUpType =
   | "weapon-plasma"
   | "weapon-ion"
   | "weapon-autogun"
+  | "weapon-rocket"
   | "mega-bomb";
 
 export type RaptorSoundEvent =
@@ -135,9 +136,10 @@ export type RaptorSoundEvent =
   | "plasma_hit"
   | "ion_fire"
   | "ion_hit"
+  | "rocket_fire"
   | "mega_bomb_fire";
 
-export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon" | "auto-gun";
+export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon" | "auto-gun" | "rocket";
 
 export interface RaptorSaveData {
   version: 1;
@@ -241,6 +243,18 @@ export const WEAPON_CONFIGS: Record<WeaponType, WeaponConfig> = {
     homingStrength: 1.0,
     splashRadius: 0,
     rapidFireBonus: 1.8,
+    spreadShotBehavior: "multi-projectile",
+  },
+  "rocket": {
+    type: "rocket",
+    damage: 5,
+    fireRateMultiplier: 0.25,
+    projectileSpeed: 450,
+    piercing: false,
+    homing: false,
+    homingStrength: 0,
+    splashRadius: 55,
+    rapidFireBonus: 1.4,
     spreadShotBehavior: "multi-projectile",
   },
 };


### PR DESCRIPTION
## PR: raptor — add dumb-fire rocket weapon type (Issue: archer-issue-478, part of epic #420)

### Summary (what/why)
This PR adds a new player weapon type: **Dumb-Fire Rocket** (`"rocket"`), inspired by the original *Raptor: Call of the Shadows*. Rockets **do not home**, instead flying in a straight line, but compensate with **higher direct damage (5)** and a **larger AoE splash radius (55px)**. The goal is to provide a high-risk, high-reward option that’s strong against slow enemies and bosses while requiring more precise aim than missiles.

### Key changes
- **New weapon type + configuration**
  - Adds `"rocket"` to `WeaponType` and `WEAPON_CONFIGS` (slow fire rate `0.25x`, speed `450`, splash `55`, non-homing).
- **New projectile entity**
  - Introduces `Rocket` projectile with straight-line motion, larger visuals, sprite support + procedural fallback rendering.
- **Weapon firing & modifiers**
  - WeaponSystem now spawns rockets; **spread-shot** fires **3 rockets** in a narrow fan (±0.15 rad).
- **Collision + splash**
  - Hooks rockets into the existing splash damage flow using the larger radius.
- **VFX / HUD / powerups / console / save / levels**
  - Adds rocket smoke trail (thicker than missiles), larger impact flash, HUD indicator (`RKT`), rocket power-up, dev-console aliases, save validation support, and level drop integration (levels 5–10).
- **Assets / audio**
  - Adds SVG sprite entries (`bullet_rocket`, `powerup_rocket`) and `rocket_fire` SFX (reuses `missile_hit` for impact).

### Key files modified
- `src/games/raptor/types.ts` — weapon/powerup/sound unions + `WEAPON_CONFIGS.rocket`
- `src/games/raptor/entities/Rocket.ts` — **new** dumb-fire rocket projectile
- `src/games/raptor/systems/WeaponSystem.ts` — rocket firing logic + spread-shot behavior
- `src/games/raptor/systems/CollisionSystem.ts` — rocket splash damage integration
- `src/games/raptor/RaptorGame.ts` — power-up handling, sprite assignment, trail + impact VFX, fire/impact sounds
- `src/games/raptor/rendering/VFXManager.ts` — `addRocketTrail()` + larger explosion flash tuning
- `src/games/raptor/entities/PowerUp.ts` — `weapon-rocket` visuals + sprite key
- `src/games/raptor/rendering/HUD.ts` — weapon label/color (`RKT`, `#2c3e50`)
- `src/games/raptor/systems/CommandRegistry.ts` — dev console aliases: `rocket`, `rkt`
- `src/games/raptor/systems/SaveSystem.ts` — allowlist includes `"rocket"`
- `src/games/raptor/levels.ts` — rocket added to `weaponDrops` for levels 5–10
- `src/games/raptor/rendering/assets.ts` — sprite manifest entries
- `src/games/raptor/rendering/audioAssets.ts` — `rocket_fire` SFX manifest entry
- `public/assets/raptor/bullet_rocket.svg` / `public/assets/raptor/powerup_rocket.svg` — **new** SVG assets

### Testing notes
Manual verification (no automated suite):
- Dev console:
  - `weapon list` shows `rocket`
  - `weapon rocket` and `weapon rkt` switch weapon; HUD shows **RKT**
- Gameplay:
  - Fire rocket: travels straight (no homing), slow cadence
  - Spread-shot: 3 rockets in narrow fan
  - Splash damage: nearby enemies take AoE damage (55px radius)
  - VFX: rocket trail is visibly thicker than missile trail; impact flash is larger
  - Power-up: collecting `weapon-rocket` switches weapon
- Persistence:
  - Equip rocket → save → reload/continue restores `"rocket"` weapon

### Notes / compatibility
- Save validation now accepts `"rocket"`; older builds loading a save containing `"rocket"` will fail validation (consistent with existing behavior for unknown weapons).
- Impact SFX reuses `missile_hit`; only the fire sound is new (`rocket_fire`).

Ref: https://github.com/asgardtech/archer/issues/478