### PR TITLE
Add landmark type definitions and extend LevelConfig for per-level defining features

### DIFF
--- a/src/games/archer/levels.ts
+++ b/src/games/archer/levels.ts
@@ -1,4 +1,4 @@
-import { ObstacleType } from "./types";
+import { ObstacleType, LandmarkConfig } from "./types";
 
 export interface LevelConfig {
   level: number;
@@ -24,6 +24,7 @@ export interface LevelConfig {
   obstacleMaxInterval: number;
   obstacleSpeedMin: number;
   obstacleSpeedMax: number;
+  landmark: LandmarkConfig;
 }
 
 export const LEVELS: LevelConfig[] = [
@@ -51,6 +52,13 @@ export const LEVELS: LevelConfig[] = [
     obstacleMaxInterval: 15,
     obstacleSpeedMin: 80,
     obstacleSpeedMax: 140,
+    landmark: {
+      type: "windmill",
+      label: "Ancient Windmill",
+      description: "The balloons have overrun the meadow windmill!",
+      positionX: 0.5,
+      hitPoints: 3,
+    },
   },
   {
     level: 2,
@@ -76,6 +84,13 @@ export const LEVELS: LevelConfig[] = [
     obstacleMaxInterval: 15,
     obstacleSpeedMin: 80,
     obstacleSpeedMax: 140,
+    landmark: {
+      type: "treehouse",
+      label: "Great Treehouse",
+      description: "The forest treehouse is under siege by balloons!",
+      positionX: 0.6,
+      hitPoints: 4,
+    },
   },
   {
     level: 3,
@@ -101,6 +116,13 @@ export const LEVELS: LevelConfig[] = [
     obstacleMaxInterval: 10,
     obstacleSpeedMin: 80,
     obstacleSpeedMax: 250,
+    landmark: {
+      type: "watchtower",
+      label: "Stone Watchtower",
+      description: "Balloons swarm the mountain watchtower!",
+      positionX: 0.45,
+      hitPoints: 5,
+    },
   },
   {
     level: 4,
@@ -126,6 +148,13 @@ export const LEVELS: LevelConfig[] = [
     obstacleMaxInterval: 10,
     obstacleSpeedMin: 80,
     obstacleSpeedMax: 250,
+    landmark: {
+      type: "lighthouse",
+      label: "Storm Lighthouse",
+      description: "The lighthouse beacon is lost in a sea of balloons!",
+      positionX: 0.55,
+      hitPoints: 6,
+    },
   },
   {
     level: 5,
@@ -151,5 +180,12 @@ export const LEVELS: LevelConfig[] = [
     obstacleMaxInterval: 7,
     obstacleSpeedMin: 60,
     obstacleSpeedMax: 250,
+    landmark: {
+      type: "castle",
+      label: "Sky Castle",
+      description: "The sky fortress has fallen to the balloon horde!",
+      positionX: 0.5,
+      hitPoints: 8,
+    },
   },
 ];

--- a/src/games/archer/systems/Spawner.ts
+++ b/src/games/archer/systems/Spawner.ts
@@ -29,6 +29,13 @@ const DEFAULT_CONFIG: LevelConfig = {
   obstacleMaxInterval: 15,
   obstacleSpeedMin: 80,
   obstacleSpeedMax: 140,
+  landmark: {
+    type: "windmill",
+    label: "Ancient Windmill",
+    description: "The balloons have overrun the meadow windmill!",
+    positionX: 0.5,
+    hitPoints: 3,
+  },
 };
 
 export class Spawner {

--- a/src/games/archer/types.ts
+++ b/src/games/archer/types.ts
@@ -46,3 +46,13 @@ export type SoundEvent =
   | "victory"
   | "menu_start"
   | "low_ammo";
+
+export type LandmarkType = "windmill" | "treehouse" | "watchtower" | "lighthouse" | "castle";
+
+export interface LandmarkConfig {
+  type: LandmarkType;
+  label: string;
+  description: string;
+  positionX: number;
+  hitPoints: number;
+}


### PR DESCRIPTION
## PR: Add landmark definitions + per-level landmark config (Issue #503, part of epic #464)

### Summary (what changed & why)
This PR introduces the **data-model foundation for per-level “defining features”** in the archer game by adding a first-class **landmark** concept to level configuration.

- Added **`LandmarkType`** (string union) and **`LandmarkConfig`** to provide a type-safe set of landmark identifiers and required metadata (label, description, placement, hit points).
- Extended **`LevelConfig`** with a required **`landmark: LandmarkConfig`** field and populated landmark data for all **5 existing levels**, giving each level a unique thematic landmark.
- Updated **Spawner `DEFAULT_CONFIG`** to include the new required `landmark` field so TypeScript remains satisfied anywhere a `LevelConfig` is constructed.

This change is intentionally **data-only**: no rendering/gameplay behavior is added yet. It unblocks future work for landmark rendering and siege mechanics without requiring another schema change later.

### Key files modified
- `src/games/archer/types.ts`
  - Added `LandmarkType` union: `"windmill" | "treehouse" | "watchtower" | "lighthouse" | "castle"`
  - Added `LandmarkConfig` interface: `{ type, label, description, positionX, hitPoints }`
- `src/games/archer/levels.ts`
  - Extended `LevelConfig` to require `landmark: LandmarkConfig`
  - Populated all entries in `LEVELS` with themed landmark configs (one unique type per level)
- `src/games/archer/systems/Spawner.ts` (or equivalent spawner module)
  - Updated `DEFAULT_CONFIG` to include a valid `landmark` value (to satisfy the new required `LevelConfig` field)

### Landmark data added (high level)
- Level 1 (Meadow): `windmill` — “Ancient Windmill”
- Level 2 (Forest): `treehouse` — “Great Treehouse”
- Level 3 (Mountains): `watchtower` — “Stone Watchtower”
- Level 4 (Storm): `lighthouse` — “Storm Lighthouse”
- Level 5 (Sky Fortress): `castle` — “Sky Castle”

Each includes:
- `description` for future level intro flavor text
- `positionX` normalized `[0..1]` for resolution-independent placement
- `hitPoints` (forward-looking for siege/visual oppression mechanics)

### Testing notes
- `npm test` — should pass (no behavior changes; updated configs satisfy new required type)
- TypeScript compile — should succeed with no errors after updating `LEVELS` and spawner defaults

No new tests were added in this PR; this is a schema/config update meant to be exercised by existing compilation + test suite.

Ref: https://github.com/asgardtech/archer/issues/503