### PR TITLE
Replace flat ground bar with themed terrain rendering per level

### DIFF
--- a/src/games/archer/ArcherGame.ts
+++ b/src/games/archer/ArcherGame.ts
@@ -10,6 +10,7 @@ import { Obstacle } from "./entities/Obstacle";
 import { Bow } from "./entities/Bow";
 import { Landmark } from "./entities/Landmark";
 import { HUD } from "./rendering/HUD";
+import { TerrainRenderer } from "./rendering/TerrainRenderer";
 import { LEVELS, LevelConfig } from "./levels";
 import { IGame } from "../../shared/types";
 import { AudioManager } from "../../shared/AudioManager";
@@ -443,11 +444,18 @@ export class ArcherGame implements IGame {
   private render(): void {
     this.renderSky();
 
-    if (this.landmark && (this.state === "playing" || this.state === "gameover" || this.state === "level_complete")) {
+    const config = this.currentLevelConfig;
+    const isGameplay = this.state === "playing" || this.state === "gameover" || this.state === "level_complete";
+
+    if (isGameplay) {
+      TerrainRenderer.render(this.ctx, this.width, this.height, config.terrain);
+    }
+
+    if (this.landmark && isGameplay) {
       this.landmark.render(this.ctx);
     }
 
-    if (this.state === "playing" || this.state === "gameover" || this.state === "level_complete") {
+    if (isGameplay) {
       for (const obstacle of this.obstacles) {
         obstacle.render(this.ctx);
       }
@@ -458,12 +466,8 @@ export class ArcherGame implements IGame {
         arrow.render(this.ctx);
       }
       this.bow.render(this.ctx, this.arrowsRemaining > 0, this.upgradeManager.getActive());
-
-      this.ctx.fillStyle = "#3a7d44";
-      this.ctx.fillRect(0, this.height - 15, this.width, 15);
     }
 
-    const config = this.currentLevelConfig;
     this.hud.render(
       this.ctx,
       this.state,

--- a/src/games/archer/entities/Landmark.ts
+++ b/src/games/archer/entities/Landmark.ts
@@ -1,6 +1,4 @@
-import { LandmarkConfig, LandmarkType } from "../types";
-
-const GROUND_BAR_HEIGHT = 15;
+import { LandmarkConfig, LandmarkType, GROUND_HEIGHT } from "../types";
 
 export class Landmark {
   private type: LandmarkType;
@@ -15,7 +13,7 @@ export class Landmark {
   constructor(config: LandmarkConfig, canvasWidth: number, canvasHeight: number) {
     this.type = config.type;
     this.x = Math.max(0, Math.min(1, config.positionX)) * canvasWidth;
-    this.groundY = canvasHeight - GROUND_BAR_HEIGHT;
+    this.groundY = canvasHeight - GROUND_HEIGHT;
   }
 
   update(dt: number): void {

--- a/src/games/archer/levels.ts
+++ b/src/games/archer/levels.ts
@@ -1,4 +1,4 @@
-import { ObstacleType, LandmarkConfig } from "./types";
+import { ObstacleType, LandmarkConfig, TerrainStyle } from "./types";
 
 export interface LevelConfig {
   level: number;
@@ -25,6 +25,7 @@ export interface LevelConfig {
   obstacleSpeedMin: number;
   obstacleSpeedMax: number;
   landmark: LandmarkConfig;
+  terrain: TerrainStyle;
 }
 
 export const LEVELS: LevelConfig[] = [
@@ -59,6 +60,12 @@ export const LEVELS: LevelConfig[] = [
       positionX: 0.5,
       hitPoints: 3,
     },
+    terrain: {
+      type: "meadow",
+      baseColor: "#4a8c3f",
+      surfaceColor: "#2d6b2e",
+      accentColor: "#e8554e",
+    },
   },
   {
     level: 2,
@@ -90,6 +97,12 @@ export const LEVELS: LevelConfig[] = [
       description: "The forest treehouse is under siege by balloons!",
       positionX: 0.6,
       hitPoints: 4,
+    },
+    terrain: {
+      type: "forest",
+      baseColor: "#3b5a2e",
+      surfaceColor: "#1e3a1e",
+      accentColor: "#c0392b",
     },
   },
   {
@@ -123,6 +136,12 @@ export const LEVELS: LevelConfig[] = [
       positionX: 0.45,
       hitPoints: 5,
     },
+    terrain: {
+      type: "mountains",
+      baseColor: "#6b6b6b",
+      surfaceColor: "#4a4a4a",
+      accentColor: "#e8e8f0",
+    },
   },
   {
     level: 4,
@@ -155,6 +174,12 @@ export const LEVELS: LevelConfig[] = [
       positionX: 0.55,
       hitPoints: 6,
     },
+    terrain: {
+      type: "storm",
+      baseColor: "#3a3530",
+      surfaceColor: "#252220",
+      accentColor: "rgba(100, 140, 180, 0.4)",
+    },
   },
   {
     level: 5,
@@ -186,6 +211,12 @@ export const LEVELS: LevelConfig[] = [
       description: "The sky fortress has fallen to the balloon horde!",
       positionX: 0.5,
       hitPoints: 8,
+    },
+    terrain: {
+      type: "sky_fortress",
+      baseColor: "#7B7872",
+      surfaceColor: "#5a5552",
+      accentColor: "#6B6462",
     },
   },
 ];

--- a/src/games/archer/rendering/TerrainRenderer.ts
+++ b/src/games/archer/rendering/TerrainRenderer.ts
@@ -1,0 +1,396 @@
+import { TerrainStyle, GROUND_HEIGHT } from "../types";
+
+export class TerrainRenderer {
+  static render(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    canvasHeight: number,
+    terrain: TerrainStyle,
+  ): void {
+    switch (terrain.type) {
+      case "meadow":
+        this.renderMeadow(ctx, canvasWidth, canvasHeight, terrain);
+        break;
+      case "forest":
+        this.renderForest(ctx, canvasWidth, canvasHeight, terrain);
+        break;
+      case "mountains":
+        this.renderMountains(ctx, canvasWidth, canvasHeight, terrain);
+        break;
+      case "storm":
+        this.renderStorm(ctx, canvasWidth, canvasHeight, terrain);
+        break;
+      case "sky_fortress":
+        this.renderSkyFortress(ctx, canvasWidth, canvasHeight, terrain);
+        break;
+      default: {
+        const _exhaustive: never = terrain.type;
+        void _exhaustive;
+      }
+    }
+  }
+
+  private static deterministicRandom(seed: number): number {
+    const x = Math.sin(seed * 127.1 + 311.7) * 43758.5453;
+    return x - Math.floor(x);
+  }
+
+  private static drawWavySurface(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    canvasHeight: number,
+    baseColor: string,
+    surfaceColor: string,
+    amplitude: number,
+    frequency: number,
+  ): void {
+    const terrainY = canvasHeight - GROUND_HEIGHT;
+
+    const grad = ctx.createLinearGradient(0, terrainY, 0, canvasHeight);
+    grad.addColorStop(0, surfaceColor);
+    grad.addColorStop(0.3, baseColor);
+    grad.addColorStop(1, baseColor);
+    ctx.fillStyle = grad;
+
+    ctx.beginPath();
+    ctx.moveTo(0, canvasHeight);
+    for (let x = 0; x <= canvasWidth; x += 4) {
+      const y = terrainY + Math.sin(x * frequency) * amplitude;
+      ctx.lineTo(x, y);
+    }
+    ctx.lineTo(canvasWidth, canvasHeight);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  private static renderMeadow(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    canvasHeight: number,
+    terrain: TerrainStyle,
+  ): void {
+    this.drawWavySurface(ctx, canvasWidth, canvasHeight, terrain.baseColor, terrain.surfaceColor, 3, 0.04);
+
+    const terrainY = canvasHeight - GROUND_HEIGHT;
+
+    // Grass tufts
+    for (let x = 5; x < canvasWidth; x += 18) {
+      const r = this.deterministicRandom(x);
+      const surfaceY = terrainY + Math.sin(x * 0.04) * 3;
+      const h = 4 + r * 4;
+
+      ctx.fillStyle = r > 0.5 ? "#5ca34e" : "#3a7d32";
+      ctx.beginPath();
+      ctx.moveTo(x - 1, surfaceY);
+      ctx.lineTo(x, surfaceY - h);
+      ctx.lineTo(x + 1, surfaceY);
+      ctx.closePath();
+      ctx.fill();
+
+      ctx.beginPath();
+      ctx.moveTo(x + 2, surfaceY);
+      ctx.lineTo(x + 3.5, surfaceY - h * 0.8);
+      ctx.lineTo(x + 4, surfaceY);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    // Flowers
+    for (let x = 12; x < canvasWidth; x += 45) {
+      const r = this.deterministicRandom(x + 100);
+      const surfaceY = terrainY + Math.sin(x * 0.04) * 3;
+      const flowerX = x + r * 15;
+      const flowerY = surfaceY - 2;
+      const color = r > 0.5 ? terrain.accentColor : "#f5d742";
+
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(flowerX, flowerY, 2, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = "#fff";
+      ctx.beginPath();
+      ctx.arc(flowerX, flowerY, 1, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  private static renderForest(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    canvasHeight: number,
+    terrain: TerrainStyle,
+  ): void {
+    const terrainY = canvasHeight - GROUND_HEIGHT;
+
+    // Bumpy contour fill
+    const grad = ctx.createLinearGradient(0, terrainY, 0, canvasHeight);
+    grad.addColorStop(0, terrain.surfaceColor);
+    grad.addColorStop(0.35, terrain.baseColor);
+    grad.addColorStop(1, "#2a4420");
+    ctx.fillStyle = grad;
+
+    ctx.beginPath();
+    ctx.moveTo(0, canvasHeight);
+    for (let x = 0; x <= canvasWidth; x += 4) {
+      const r = this.deterministicRandom(x * 0.3);
+      const bump = Math.sin(x * 0.06) * 2 + r * 3;
+      ctx.lineTo(x, terrainY + bump);
+    }
+    ctx.lineTo(canvasWidth, canvasHeight);
+    ctx.closePath();
+    ctx.fill();
+
+    // Bushes
+    for (let x = 20; x < canvasWidth; x += 55) {
+      const r = this.deterministicRandom(x + 200);
+      const surfaceY = terrainY + Math.sin(x * 0.06) * 2 + r * 3;
+      ctx.fillStyle = "#2d5a27";
+      ctx.beginPath();
+      ctx.arc(x, surfaceY, 5, Math.PI, 0, false);
+      ctx.fill();
+
+      ctx.fillStyle = "#3a7d32";
+      ctx.beginPath();
+      ctx.arc(x + 3, surfaceY - 1, 3, Math.PI, 0, false);
+      ctx.fill();
+    }
+
+    // Mushrooms
+    for (let x = 40; x < canvasWidth; x += 85) {
+      const r = this.deterministicRandom(x + 300);
+      const surfaceY = terrainY + Math.sin(x * 0.06) * 2 + r * 3;
+      const mx = x + r * 10;
+
+      // Stem
+      ctx.fillStyle = "#d4c5a9";
+      ctx.fillRect(mx - 1, surfaceY - 5, 2, 5);
+
+      // Cap
+      ctx.fillStyle = terrain.accentColor;
+      ctx.beginPath();
+      ctx.arc(mx, surfaceY - 5, 3, Math.PI, 0, false);
+      ctx.fill();
+
+      // Cap spots
+      ctx.fillStyle = "#fff";
+      ctx.beginPath();
+      ctx.arc(mx - 1, surfaceY - 6, 0.8, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(mx + 1, surfaceY - 6.5, 0.6, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Tree stumps
+    for (let x = 70; x < canvasWidth; x += 110) {
+      const r = this.deterministicRandom(x + 400);
+      const surfaceY = terrainY + Math.sin(x * 0.06) * 2 + r * 3;
+
+      ctx.fillStyle = "#5C4033";
+      ctx.fillRect(x - 3, surfaceY - 4, 6, 4);
+
+      ctx.fillStyle = "#8B7355";
+      ctx.beginPath();
+      ctx.ellipse(x, surfaceY - 4, 3, 1.5, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  private static renderMountains(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    canvasHeight: number,
+    terrain: TerrainStyle,
+  ): void {
+    const terrainY = canvasHeight - GROUND_HEIGHT;
+
+    // Jagged angular contour
+    const grad = ctx.createLinearGradient(0, terrainY, 0, canvasHeight);
+    grad.addColorStop(0, terrain.surfaceColor);
+    grad.addColorStop(0.3, terrain.baseColor);
+    grad.addColorStop(1, "#5a5a5a");
+    ctx.fillStyle = grad;
+
+    ctx.beginPath();
+    ctx.moveTo(0, canvasHeight);
+    for (let x = 0; x <= canvasWidth; x += 12) {
+      const r = this.deterministicRandom(x * 0.5);
+      const peak = (r - 0.5) * 8;
+      ctx.lineTo(x, terrainY + peak);
+      ctx.lineTo(x + 6, terrainY + peak + 3 + r * 2);
+    }
+    ctx.lineTo(canvasWidth, canvasHeight);
+    ctx.closePath();
+    ctx.fill();
+
+    // Rocks
+    for (let x = 10; x < canvasWidth; x += 35) {
+      const r = this.deterministicRandom(x + 500);
+      const surfaceY = terrainY + (r - 0.5) * 6;
+      const rockX = x + r * 8;
+
+      ctx.fillStyle = r > 0.5 ? "#7a7a7a" : "#888";
+      ctx.beginPath();
+      ctx.moveTo(rockX - 3, surfaceY);
+      ctx.lineTo(rockX - 1, surfaceY - 3 - r * 2);
+      ctx.lineTo(rockX + 2, surfaceY - 2);
+      ctx.lineTo(rockX + 3, surfaceY);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    // Snow patches at edges
+    ctx.fillStyle = terrain.accentColor;
+    ctx.beginPath();
+    ctx.ellipse(30, terrainY + 2, 25, 4, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.ellipse(canvasWidth - 35, terrainY + 1, 30, 5, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.ellipse(canvasWidth - 90, terrainY + 3, 15, 3, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  private static renderStorm(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    canvasHeight: number,
+    terrain: TerrainStyle,
+  ): void {
+    const terrainY = canvasHeight - GROUND_HEIGHT;
+
+    // Gentle uneven contour
+    const grad = ctx.createLinearGradient(0, terrainY, 0, canvasHeight);
+    grad.addColorStop(0, terrain.surfaceColor);
+    grad.addColorStop(0.3, terrain.baseColor);
+    grad.addColorStop(1, "#2a2520");
+    ctx.fillStyle = grad;
+
+    ctx.beginPath();
+    ctx.moveTo(0, canvasHeight);
+    for (let x = 0; x <= canvasWidth; x += 4) {
+      const r = this.deterministicRandom(x * 0.2);
+      const y = terrainY + Math.sin(x * 0.025) * 2 + r * 1.5;
+      ctx.lineTo(x, y);
+    }
+    ctx.lineTo(canvasWidth, canvasHeight);
+    ctx.closePath();
+    ctx.fill();
+
+    // Mud speckles
+    for (let x = 3; x < canvasWidth; x += 8) {
+      const r = this.deterministicRandom(x + 600);
+      const speckleY = terrainY + 8 + r * 18;
+      if (speckleY < canvasHeight) {
+        ctx.fillStyle = `rgba(0, 0, 0, ${0.1 + r * 0.15})`;
+        ctx.beginPath();
+        ctx.arc(x + r * 5, speckleY, 0.8 + r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    // Puddles
+    for (let x = 30; x < canvasWidth; x += 65) {
+      const r = this.deterministicRandom(x + 700);
+      const surfaceY = terrainY + Math.sin(x * 0.025) * 2 + r * 1.5;
+      const px = x + r * 20;
+      const pw = 12 + r * 10;
+      const ph = 3 + r * 2;
+
+      ctx.fillStyle = terrain.accentColor;
+      ctx.beginPath();
+      ctx.ellipse(px, surfaceY + 5, pw, ph, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Reflection highlight
+      ctx.fillStyle = "rgba(180, 210, 230, 0.25)";
+      ctx.beginPath();
+      ctx.ellipse(px, surfaceY + 4, pw * 0.6, ph * 0.4, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  private static renderSkyFortress(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    canvasHeight: number,
+    terrain: TerrainStyle,
+  ): void {
+    const terrainY = canvasHeight - GROUND_HEIGHT;
+    const crenH = 6;
+    const crenW = 8;
+
+    // Main platform body
+    ctx.fillStyle = terrain.baseColor;
+    ctx.fillRect(0, terrainY + crenH, canvasWidth, GROUND_HEIGHT - crenH);
+
+    // Crenellations along top edge
+    ctx.fillStyle = terrain.surfaceColor;
+    for (let x = 0; x < canvasWidth; x += crenW * 2) {
+      ctx.fillRect(x, terrainY, crenW, crenH);
+    }
+
+    // Flat walkway between crenellations
+    ctx.fillStyle = terrain.baseColor;
+    ctx.fillRect(0, terrainY + crenH, canvasWidth, 3);
+
+    // Brick pattern
+    ctx.strokeStyle = terrain.accentColor;
+    ctx.lineWidth = 0.5;
+    let rowIndex = 0;
+    for (let y = terrainY + crenH + 4; y < canvasHeight - 2; y += 7) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvasWidth, y);
+      ctx.stroke();
+
+      const offset = (rowIndex % 2) * 12;
+      for (let x = offset; x < canvasWidth; x += 24) {
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+        ctx.lineTo(x, y + 7);
+        ctx.stroke();
+      }
+      rowIndex++;
+    }
+
+    // Broken edge pieces (floating island feel)
+    ctx.fillStyle = terrain.surfaceColor;
+
+    // Left edge
+    ctx.beginPath();
+    ctx.moveTo(0, canvasHeight);
+    ctx.lineTo(8, canvasHeight);
+    ctx.lineTo(5, canvasHeight + 6);
+    ctx.lineTo(0, canvasHeight + 4);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.moveTo(12, canvasHeight);
+    ctx.lineTo(20, canvasHeight);
+    ctx.lineTo(16, canvasHeight + 8);
+    ctx.lineTo(10, canvasHeight + 3);
+    ctx.closePath();
+    ctx.fill();
+
+    // Right edge
+    ctx.beginPath();
+    ctx.moveTo(canvasWidth - 18, canvasHeight);
+    ctx.lineTo(canvasWidth - 8, canvasHeight);
+    ctx.lineTo(canvasWidth - 10, canvasHeight + 7);
+    ctx.lineTo(canvasWidth - 20, canvasHeight + 3);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.moveTo(canvasWidth - 6, canvasHeight);
+    ctx.lineTo(canvasWidth, canvasHeight);
+    ctx.lineTo(canvasWidth, canvasHeight + 5);
+    ctx.lineTo(canvasWidth - 4, canvasHeight + 4);
+    ctx.closePath();
+    ctx.fill();
+  }
+}

--- a/src/games/archer/systems/Spawner.ts
+++ b/src/games/archer/systems/Spawner.ts
@@ -36,6 +36,12 @@ const DEFAULT_CONFIG: LevelConfig = {
     positionX: 0.5,
     hitPoints: 3,
   },
+  terrain: {
+    type: "meadow",
+    baseColor: "#4a8c3f",
+    surfaceColor: "#2d6b2e",
+    accentColor: "#e8554e",
+  },
 };
 
 export class Spawner {

--- a/src/games/archer/types.ts
+++ b/src/games/archer/types.ts
@@ -56,3 +56,15 @@ export interface LandmarkConfig {
   positionX: number;
   hitPoints: number;
 }
+
+export const GROUND_HEIGHT = 35;
+
+export interface TerrainStyle {
+  type: "meadow" | "forest" | "mountains" | "storm" | "sky_fortress";
+  /** Base fill color for the ground body */
+  baseColor: string;
+  /** Darker shade for the terrain surface/edge line */
+  surfaceColor: string;
+  /** Accent color for decorative details (flowers, snow, puddles, etc.) */
+  accentColor: string;
+}


### PR DESCRIPTION
## PR: Replace flat ground bar with themed terrain rendering per level (Issue #505)

### Summary / Why
This PR replaces the hard-coded, single-color 15px green ground bar with a **per-level themed terrain strip** rendered via the Canvas 2D API. Each of the 5 Archer levels now has terrain that matches its theme (and complements the existing sky gradients/landmarks), improving visual richness without introducing new image assets.

Key goals addressed:
- Distinct terrain for **Meadow / Forest / Mountains / Storm / Sky Fortress**
- Taller terrain (**35px**) with contour + decorative details (not a flat fill)
- Correct layering: **sky → terrain → landmark/entities → HUD**, so gameplay elements remain visible and unobstructed
- Shared ground height constant so landmarks sit correctly on the new terrain

### What changed
- Added a dedicated `TerrainRenderer` responsible for drawing themed terrain per level (contours + details), using deterministic placement so decorations don’t jitter frame-to-frame.
- Extended level configuration to include a structured `terrain` style (type + palette).
- Increased ground height to **35px** via a shared constant and updated landmark positioning accordingly.
- Updated `ArcherGame` render pipeline to draw terrain **after the sky** but **before entities**, ensuring the bow/arrows/balloons render on top of terrain.

### Key files modified
- `src/games/archer/rendering/TerrainRenderer.ts` *(new)*  
  Implements themed terrain rendering for:
  - Meadow (grass tufts + flowers)
  - Forest (bushes + mushrooms + stumps)
  - Mountains (rocky contour + rocks + snow patches)
  - Storm (mud texture + puddles with subtle reflections)
  - Sky Fortress (stone/brick platform + crenellations + broken edges)

- `src/games/archer/types.ts`  
  - Added `TerrainStyle` interface
  - Added shared `GROUND_HEIGHT = 35` constant

- `src/games/archer/levels.ts`  
  - Extended `LevelConfig` with `terrain: TerrainStyle`
  - Added terrain config (type + colors) to all 5 levels

- `src/games/archer/ArcherGame.ts`  
  - Removed old `fillRect` ground bar
  - Integrated `TerrainRenderer.render(...)`
  - Adjusted render order so terrain is behind entities but in front of the sky

- `src/games/archer/entities/Landmark.ts`  
  - Updated to use shared `GROUND_HEIGHT` so landmarks align with the taller terrain

- `src/games/archer/Spawner.ts`  
  - Updated default config to include the new required `terrain` field

### Testing notes
- **TypeScript:** `npx tsc --noEmit` (verify clean compile)
- **Visual/manual verification:**
  1. Load each level (1–5) and confirm the bottom terrain is ~35px tall and visually distinct.
  2. Confirm layering: terrain renders over the sky, while landmark/entities (bow, arrows, balloons) render on top of terrain.
  3. Confirm the bow remains fully visible and usable on:
     - Desktop (bow at `canvasH - 30`)
     - Touch (bow at `canvasH - 60`)
  4. Confirm landmarks sit on the terrain surface (no floating/sinking).

### Related
- Fixes/implements: **Issue #505**
- Part of epic: **#464**

Ref: https://github.com/asgardtech/archer/issues/505