### PR TITLE
Add level intro screen announcing the landmark to liberate

### DIFF
--- a/src/games/archer/ArcherGame.ts
+++ b/src/games/archer/ArcherGame.ts
@@ -225,8 +225,14 @@ export class ArcherGame implements IGame {
           this.audio.ensureContext();
           this.sound.play("menu_start");
           this.resetGame();
+          this.state = "level_intro";
+        }
+        break;
+
+      case "level_intro":
+        if (this.input.wasClicked) {
           this.state = "playing";
-          this.sound.startMusic("playing", 0);
+          this.sound.startMusic("playing", this.currentLevel);
         }
         break;
 
@@ -240,8 +246,7 @@ export class ArcherGame implements IGame {
         }
         if (this.input.wasClicked) {
           this.startLevel(this.currentLevel + 1);
-          this.state = "playing";
-          this.sound.startMusic("playing", this.currentLevel);
+          this.state = "level_intro";
         }
         break;
 
@@ -454,7 +459,7 @@ export class ArcherGame implements IGame {
     this.renderSky();
 
     const config = this.currentLevelConfig;
-    const isGameplay = this.state === "playing" || this.state === "gameover" || this.state === "level_complete";
+    const isGameplay = this.state === "playing" || this.state === "gameover" || this.state === "level_complete" || this.state === "level_intro";
 
     if (isGameplay) {
       TerrainRenderer.render(this.ctx, this.width, this.height, config.terrain);
@@ -490,7 +495,9 @@ export class ArcherGame implements IGame {
       config.name,
       this.totalScore + (this.state === "playing" ? this.score : 0),
       this.upgradeManager.getPermanentUpgrades(),
-      this.upgradeManager.getCollectionCounts()
+      this.upgradeManager.getCollectionCounts(),
+      config.landmark.label,
+      config.landmark.description
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
   }

--- a/src/games/archer/rendering/HUD.ts
+++ b/src/games/archer/rendering/HUD.ts
@@ -68,7 +68,9 @@ export class HUD {
     levelName = "",
     totalScore = 0,
     permanentUpgrades: ReadonlySet<UpgradeType> = new Set(),
-    collectionCounts: ReadonlyMap<UpgradeType, number> = new Map()
+    collectionCounts: ReadonlyMap<UpgradeType, number> = new Map(),
+    landmarkLabel = "",
+    landmarkDescription = ""
   ): void {
     for (const t of this.ammoGainTexts) {
       t.age += dt;
@@ -86,6 +88,9 @@ export class HUD {
         break;
       case "menu":
         this.renderMenu(ctx, canvasW, canvasH);
+        break;
+      case "level_intro":
+        this.renderLevelIntro(ctx, level, levelName, landmarkLabel, landmarkDescription, canvasW, canvasH);
         break;
       case "playing":
         this.renderPlaying(ctx, score, arrowsRemaining, canvasW, activeUpgrades, level, levelName, permanentUpgrades);
@@ -360,6 +365,45 @@ export class HUD {
     ctx.fillStyle = "rgba(255,255,255,0.7)";
     ctx.font = "20px sans-serif";
     ctx.fillText(this.isTouchDevice ? "Tap to Return to Menu" : "Click to Return to Menu", w / 2, h / 2 + 80);
+
+    ctx.restore();
+  }
+
+  private renderLevelIntro(
+    ctx: CanvasRenderingContext2D,
+    level: number,
+    levelName: string,
+    landmarkLabel: string,
+    landmarkDescription: string,
+    w: number,
+    h: number
+  ): void {
+    ctx.save();
+
+    ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
+    ctx.fillRect(0, 0, w, h);
+
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    ctx.fillStyle = "#fff";
+    ctx.font = "bold 44px sans-serif";
+    ctx.fillText(`Level ${level} — ${levelName}`, w / 2, h / 2 - 70);
+
+    ctx.fillStyle = "#f1c40f";
+    ctx.font = "bold 28px sans-serif";
+    ctx.fillText(landmarkLabel, w / 2, h / 2 - 15);
+
+    ctx.fillStyle = "rgba(255, 255, 255, 0.8)";
+    ctx.font = "italic 20px sans-serif";
+    ctx.fillText(landmarkDescription, w / 2, h / 2 + 25);
+
+    ctx.fillStyle = "rgba(255, 255, 255, 0.7)";
+    ctx.font = "20px sans-serif";
+    ctx.fillText(
+      this.isTouchDevice ? "Tap to Begin" : "Click to Begin",
+      w / 2, h / 2 + 80
+    );
 
     ctx.restore();
   }

--- a/src/games/archer/types.ts
+++ b/src/games/archer/types.ts
@@ -3,7 +3,7 @@ export interface Vec2 {
   y: number;
 }
 
-export type GameState = "loading" | "menu" | "playing" | "level_complete" | "gameover" | "victory";
+export type GameState = "loading" | "menu" | "level_intro" | "playing" | "level_complete" | "gameover" | "victory";
 
 export interface EntityBase {
   pos: Vec2;


### PR DESCRIPTION
## PR: Add level intro screen announcing the landmark to liberate (Issue #507, Epic #464)

### Summary (what changed + why)
This PR adds a new **`"level_intro"`** game state that shows a short interstitial overlay at the start of every level, introducing the **landmark to liberate** (label + flavor description) and prompting the player to click/tap to begin.

**Why:** Previously, starting a level transitioned directly into `"playing"` with no narrative beat. This intro screen provides context, makes levels feel more purposeful, and leverages existing `LevelConfig.landmark` metadata.

### Behavior / flow changes
- **Menu →** now transitions to **`level_intro`** (instead of immediately `"playing"`).
- **Level complete →** clicking continue transitions to **`level_intro`** for the next level (instead of immediately `"playing"`).
- **Intro → Playing:** gameplay begins only after the player clicks/taps the intro screen.
- **Music timing:** level music **does not** start during the intro; it starts when transitioning from **`level_intro` → `playing`**.
- **Rendering:** during `level_intro`, the level scene (including the landmark in siege state) renders behind a semi-transparent overlay so players can preview what they’re about to liberate.

### Key files modified
- **`src/games/archer/types.ts`**
  - Added **`"level_intro"`** to the `GameState` union.
- **`src/games/archer/rendering/HUD.ts`**
  - Added `renderLevelIntro()` to draw a centered overlay containing:
    - `Level {n} — {name}`
    - Landmark label + description
    - “Click to Begin” / “Tap to Begin” prompt
  - Updated `HUD.render()` to handle the new state and accept landmark label/description inputs.
- **`src/games/archer/ArcherGame.ts`**
  - Updated state machine to enter `level_intro` when starting a level and between levels.
  - Added `level_intro` handling in `update()` (click transitions to `playing` and starts music).
  - Ensured intro renders the level scene behind the overlay.
  - Passed landmark label/description from level config into HUD rendering.

### Testing notes
Manual QA recommended:
1. Start game from menu:
   - Verify **intro overlay appears** (Level number/name + landmark label/description).
   - Verify prompt text matches device type (**Click** vs **Tap**).
   - Verify **music is not playing** until the intro is dismissed.
2. Click/tap to begin:
   - Verify transition to **`playing`** and **music starts**.
3. Complete a level:
   - From **`level_complete`**, click continue and verify it shows the **next level’s intro** before gameplay starts.
4. While on intro:
   - Verify the **mute button works** and does not dismiss the intro.

Build/typecheck:
- Run `tsc --noEmit` to ensure new `GameState` usage is handled without TypeScript errors.

Closes: #507

Ref: https://github.com/asgardtech/archer/issues/507