### PR TITLE
Add pre-level mission briefing screen between levels

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -445,7 +445,22 @@ export class RaptorGame implements IGame {
         this.storyRenderer.update(dt);
 
         if (this.input.wasEscPressed || this.storyRenderer.isComplete || !this.storyRenderer.isActive) {
+          this.enterBriefing();
+          break;
+        }
+
+        if (this.input.wasClicked) {
+          this.storyRenderer.advance();
+        }
+        break;
+
+      case "briefing":
+        this.updateBackground(dt);
+        this.storyRenderer.update(dt);
+
+        if (this.input.wasEscPressed || this.storyRenderer.isComplete || !this.storyRenderer.isActive) {
           this.state = "playing";
+          this.sound.startMusic("playing", this.currentLevel);
           break;
         }
 
@@ -462,8 +477,7 @@ export class RaptorGame implements IGame {
         this.updateBackground(dt);
         if (this.input.wasClicked) {
           this.startLevel(this.currentLevel + 1);
-          this.state = "playing";
-          this.sound.startMusic("playing", this.currentLevel);
+          this.enterBriefing();
         }
         break;
 
@@ -1004,6 +1018,34 @@ export class RaptorGame implements IGame {
     this.powerUpManager.setTier(data.weaponTier ?? 1);
   }
 
+  private enterBriefing(): void {
+    const config = this.currentLevelConfig;
+    const briefingText = config.story?.briefing;
+
+    if (!briefingText) {
+      this.state = "playing";
+      this.sound.startMusic("playing", this.currentLevel);
+      return;
+    }
+
+    this.storyRenderer.show([briefingText], "center");
+    this.state = "briefing";
+  }
+
+  private renderBriefingHeader(): void {
+    const config = this.currentLevelConfig;
+    const ctx = this.ctx;
+    const headerText = `LEVEL ${config.level} \u2014 ${config.name.toUpperCase()}`;
+
+    ctx.save();
+    ctx.font = "14px 'Press Start 2P', monospace";
+    ctx.fillStyle = "#8EAADC";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    ctx.fillText(headerText, this.width / 2, this.height / 2 - 50);
+    ctx.restore();
+  }
+
   private buildCommandContext(): CommandContext {
     return {
       currentLevel: this.currentLevel,
@@ -1224,6 +1266,11 @@ export class RaptorGame implements IGame {
     this.renderBackground();
 
     if (this.state === "story_intro") {
+      this.storyRenderer.render(this.ctx, this.width, this.height);
+    }
+
+    if (this.state === "briefing") {
+      this.renderBriefingHeader();
       this.storyRenderer.render(this.ctx, this.width, this.height);
     }
 

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -369,6 +369,9 @@ export class HUD {
       case "menu":
         this.renderMenu(ctx, width, height, hasSave);
         break;
+      case "story_intro":
+      case "briefing":
+        break;
       case "playing":
         this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier);
         break;

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -7,6 +7,7 @@ export type RaptorGameState =
   | "loading"
   | "menu"
   | "story_intro"
+  | "briefing"
   | "playing"
   | "level_complete"
   | "gameover"


### PR DESCRIPTION
## PR: Add pre-level mission briefing screen between levels (Issue #519, part of Epic #465)

### Summary (what changed + why)
This PR introduces a new **`"briefing"`** game state to show a short **mission briefing screen before each level begins**. The goal is to provide narrative context using the already-authored `story.briefing` text in each level config, instead of jumping directly from `"level_complete"` to `"playing"`.

Key flow changes:
- **`story_intro → briefing (Level 1) → playing`** for new games (so the opening crawl leads into the first mission briefing).
- **`level_complete → briefing (next level) → playing`** between levels.
- Briefing supports **typewriter text** (via `StoryRenderer`), **click to advance/finish**, and **Escape to skip straight into gameplay**.
- If a level has **no `story.briefing`**, the game **skips the briefing** and goes directly to `"playing"` (backwards compatible).

### Key files modified
- **`src/games/raptor/types.ts`**
  - Added `"briefing"` to the `RaptorGameState` union.

- **`src/games/raptor/RaptorGame.ts`**
  - Added `enterBriefing()` helper to centralize briefing entry + fallback when no text exists.
  - Inserted the `"briefing"` state into the state machine transitions:
    - `story_intro → briefing` (instead of `→ playing`)
    - `level_complete → briefing` (instead of `→ playing`)
  - Implemented `"briefing"` handling in `update()`:
    - Updates background + `StoryRenderer`
    - Click advances text; once finished/inactive, transitions to `"playing"` and starts level music
    - Escape skips briefing and starts `"playing"` immediately
  - Implemented `"briefing"` rendering in `render()`:
    - Renders background behind the panel
    - Renders a level header via `renderBriefingHeader()`
    - Renders briefing text using `StoryRenderer`

- **`src/games/raptor/rendering/HUD.ts`**
  - Added a `"briefing"` case to the HUD render switch (no HUD elements during briefing; keeps state handling complete).

### Testing notes
- **Typecheck:** Run `npm run typecheck` (should pass with the new `RaptorGameState` variant handled).
- **Manual QA checklist:**
  - Start a new game: confirm **story crawl → Level 1 briefing → gameplay**.
  - Finish a level: confirm click on level complete goes to **next level briefing**, then click begins gameplay.
  - During briefing:
    - Click advances typewriter text / proceeds once complete
    - **Escape** skips immediately to gameplay (and music starts)
  - Validate background renders behind the briefing panel.
  - Verify behavior when `story.briefing` is missing/empty: **briefing is skipped** and gameplay starts normally.
  - Confirm “Continue” path still enters **`playing` directly** (no briefing for resumed games).

Ref: https://github.com/asgardtech/archer/issues/519