### PR TITLE
Add in-game story text messages during gameplay

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -115,6 +115,8 @@ export class RaptorGame implements IGame {
   private resizeTimer: ReturnType<typeof setTimeout> | undefined;
   private dpr = 1;
   private enemyLaserHitSoundCooldown = 0;
+  private levelElapsed = 0;
+  private nextStoryMessageIndex = 0;
 
   public onExit: (() => void) | null = null;
 
@@ -519,6 +521,7 @@ export class RaptorGame implements IGame {
   }
 
   private updatePlaying(dt: number): void {
+    this.levelElapsed += dt;
     this.input.updateFromKeyboard(dt, this.width, this.height);
     this.player.update(dt, this.input.targetX, this.input.targetY, this.width, this.height);
     this.updateBackground(dt);
@@ -528,6 +531,8 @@ export class RaptorGame implements IGame {
 
     if (this.input.wasClicked && this.hud.isBombButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
       this.input.wasBombPressed = true;
+    } else if (this.input.wasClicked && this.storyRenderer.isActive) {
+      this.storyRenderer.advance();
     }
 
     if (this.input.wasBombPressed && this.player.bombs > 0) {
@@ -591,6 +596,17 @@ export class RaptorGame implements IGame {
         this.enemies.push(boss);
       }
     }
+
+    const storyMessages = config.story?.inGameMessages;
+    if (storyMessages && this.nextStoryMessageIndex < storyMessages.length) {
+      const msg = storyMessages[this.nextStoryMessageIndex];
+      if (this.levelElapsed >= msg.triggerTime) {
+        this.storyRenderer.showQuick(msg.text, msg.duration, "bottom");
+        this.nextStoryMessageIndex++;
+      }
+    }
+
+    this.storyRenderer.update(dt);
 
     for (const enemy of this.enemies) {
       enemy.update(dt, this.height, this.player.pos.x);
@@ -1128,6 +1144,9 @@ export class RaptorGame implements IGame {
     if (playerSprite) this.player.setSprite(playerSprite);
     if (this.thrustSheet) this.player.setThrustSheet(this.thrustSheet);
 
+    this.levelElapsed = 0;
+    this.nextStoryMessageIndex = 0;
+
     this.spawner.configure(this.currentLevelConfig);
     this.vfx.reset();
 
@@ -1329,6 +1348,10 @@ export class RaptorGame implements IGame {
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
     this.hud.renderSettingsButton(this.ctx, this.width);
+
+    if (this.state === "playing") {
+      this.storyRenderer.render(this.ctx, this.width, this.height);
+    }
 
     if (this.settingsOpen) {
       this.hud.renderSettingsPanel(

--- a/src/games/raptor/rendering/StoryRenderer.ts
+++ b/src/games/raptor/rendering/StoryRenderer.ts
@@ -61,12 +61,16 @@ export class StoryRenderer {
     this.beginMessage(this.messages[0]);
   }
 
-  showQuick(message: string, duration: number = DEFAULT_QUICK_DURATION): void {
+  showQuick(
+    message: string,
+    duration: number = DEFAULT_QUICK_DURATION,
+    position: StoryPosition = "top"
+  ): void {
     if (this.state !== "idle" && !this.isQuickMessage) return;
 
     this.messages = [message];
     this.currentIndex = 0;
-    this.position = "top";
+    this.position = position;
     this.isQuickMessage = true;
     this.quickTimer = duration;
     this.completed = false;


### PR DESCRIPTION
## PR: Add in-game story text messages during gameplay (Issue #520, part of Epic #465)

### Summary / Why
This PR wires up level-configured `story.inGameMessages` to display short, non-blocking story text overlays during active gameplay. Messages trigger at specific elapsed times, appear in the bottom portion of the screen to avoid covering the HUD, auto-dismiss after a configurable duration (default 3s), and can be dismissed early via click—without pausing gameplay.

### What changed
- **Added a level elapsed timer owned by `RaptorGame`**
  - Introduced `levelElapsed` to track time since the level started (accumulates `dt` only in the `"playing"` state).
  - Reset timer on `startLevel()` for correct behavior on restart/level transitions.

- **Triggered in-game messages as the level progresses**
  - Added `nextStoryMessageIndex` pointer (index-based, O(1) checks) to ensure each message fires once per playthrough.
  - On reaching `triggerTime`, calls `StoryRenderer.showQuick(...)` with **bottom positioning**.

- **Enabled overlay rendering and lifecycle during gameplay**
  - `StoryRenderer.update(dt)` now runs during `"playing"` so timers/animations progress.
  - `StoryRenderer.render(...)` is invoked during gameplay (as an overlay).

- **Click-to-dismiss support**
  - During `"playing"`, if a message is active and the player clicks, `storyRenderer.advance()` is called to reveal/dismiss per existing StoryRenderer behavior (typing → waiting → fade).

- **Extended `StoryRenderer.showQuick()`**
  - Added an optional `position` parameter (defaults to `"top"`) for backward compatibility.
  - In-game messages pass `"bottom"` to avoid occluding the top HUD.

### Key files modified
- `src/games/raptor/RaptorGame.ts`
  - Added `levelElapsed` + `nextStoryMessageIndex`
  - Reset fields in `startLevel()`
  - Trigger logic in `updatePlaying()`
  - `StoryRenderer` update + render integration for `"playing"`
  - Click-to-dismiss wiring

- `src/games/raptor/rendering/StoryRenderer.ts`
  - Updated `showQuick(message, duration?, position?)` to support bottom positioning (default remains `"top"`)

### Testing notes
- **Typecheck:** `npm run typecheck` (expected: no errors; `showQuick()` change is backward compatible due to optional param/default).
- **Manual verification:**
  - Play Level 1 (“Coastal Patrol”): confirm messages appear around their configured trigger times (e.g., ~2s, ~9s, ~16s), render in the bottom area, and do not interrupt gameplay.
  - Confirm messages auto-dismiss after their configured duration and can be dismissed early via click.
  - Restart level / advance levels: confirm message index and timer reset and messages re-trigger correctly.
  - Regression check: existing story/briefing flows remain unaffected (they use other StoryRenderer paths; `showQuick()` defaults to `"top"`).

Ref: https://github.com/asgardtech/archer/issues/520