### PR TITLE
Add story text to level-complete and victory screens

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -497,12 +497,26 @@ export class RaptorGame implements IGame {
 
       case "victory":
         this.updateBackground(dt);
-        if (this.input.wasClicked) {
-          this.sound.stopMusic();
-          if (this.onExit) {
-            this.onExit();
-          } else {
-            this.state = "menu";
+        this.storyRenderer.update(dt);
+
+        if (this.storyRenderer.isActive) {
+          if (this.input.wasEscPressed) {
+            this.storyRenderer = new StoryRenderer();
+            this.hud.setVictoryStoryActive(false);
+          } else if (this.input.wasClicked) {
+            this.storyRenderer.advance();
+          }
+        } else {
+          if (this.hud.victoryStoryActive) {
+            this.hud.setVictoryStoryActive(false);
+          }
+          if (this.input.wasClicked) {
+            this.sound.stopMusic();
+            if (this.onExit) {
+              this.onExit();
+            } else {
+              this.state = "menu";
+            }
           }
         }
         break;
@@ -874,9 +888,12 @@ export class RaptorGame implements IGame {
         this.state = "victory";
         this.sound.play("victory");
         SaveSystem.clear();
+        this.storyRenderer.show(GAME_STORY.ending, "center");
+        this.hud.setVictoryStoryActive(true);
       } else {
         this.state = "level_complete";
         this.sound.play("level_complete");
+        this.hud.setCompletionText(this.currentLevelConfig.story?.completionText ?? null);
         SaveSystem.save({
           version: 1,
           levelReached: this.currentLevel + 1,
@@ -1013,6 +1030,8 @@ export class RaptorGame implements IGame {
   private resetGame(): void {
     this.totalScore = 0;
     this.vfx.reset();
+    this.hud.setCompletionText(null);
+    this.hud.setVictoryStoryActive(false);
     this.startLevel(0, true);
   }
 
@@ -1146,6 +1165,8 @@ export class RaptorGame implements IGame {
 
     this.levelElapsed = 0;
     this.nextStoryMessageIndex = 0;
+    this.hud.setCompletionText(null);
+    this.hud.setVictoryStoryActive(false);
 
     this.spawner.configure(this.currentLevelConfig);
     this.vfx.reset();
@@ -1349,7 +1370,7 @@ export class RaptorGame implements IGame {
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
     this.hud.renderSettingsButton(this.ctx, this.width);
 
-    if (this.state === "playing") {
+    if (this.state === "playing" || (this.state === "victory" && this.storyRenderer.isActive)) {
       this.storyRenderer.render(this.ctx, this.width, this.height);
     }
 

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -70,9 +70,56 @@ export class HUD {
   private isTouchDevice: boolean;
   private assets: AssetLoader | null = null;
   private tierFlashTimer = 0;
+  private completionLines: string[] = [];
+  private _victoryStoryActive = false;
+  private measureCtx: CanvasRenderingContext2D;
 
   constructor(isTouchDevice: boolean) {
     this.isTouchDevice = isTouchDevice;
+    const offscreen = document.createElement("canvas");
+    this.measureCtx = offscreen.getContext("2d")!;
+  }
+
+  get victoryStoryActive(): boolean {
+    return this._victoryStoryActive;
+  }
+
+  setCompletionText(text: string | null): void {
+    if (!text) {
+      this.completionLines = [];
+      return;
+    }
+    this.completionLines = this.wrapText(text, 340);
+  }
+
+  setVictoryStoryActive(active: boolean): void {
+    this._victoryStoryActive = active;
+  }
+
+  private wrapText(text: string, maxWidth: number): string[] {
+    this.measureCtx.font = `8px ${RETRO_FONT}`;
+    const words = text.split(" ");
+    const lines: string[] = [];
+    let currentLine = "";
+
+    for (const word of words) {
+      if (currentLine === "") {
+        currentLine = word;
+        continue;
+      }
+      const testLine = currentLine + " " + word;
+      const measured = this.measureCtx.measureText(testLine).width;
+      if (measured > maxWidth) {
+        lines.push(currentLine);
+        currentLine = word;
+      } else {
+        currentLine = testLine;
+      }
+    }
+    if (currentLine !== "") {
+      lines.push(currentLine);
+    }
+    return lines;
   }
 
   setAssets(assets: AssetLoader): void {
@@ -378,15 +425,21 @@ export class HUD {
       case "level_complete":
         this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier);
         this.renderOverlay(ctx, width, height, "Level Complete!",
+          this.completionLines,
+          `Score: ${score}`,
           this.actionText("for next level"));
         break;
       case "gameover":
         this.renderOverlay(ctx, width, height, "Game Over",
+          [],
           `Final Score: ${score}`, this.actionText("to return"));
         break;
       case "victory":
-        this.renderOverlay(ctx, width, height, "Victory!",
-          `Final Score: ${score}`, this.actionText("to return"));
+        if (!this._victoryStoryActive) {
+          this.renderOverlay(ctx, width, height, "Victory!",
+            [],
+            `Final Score: ${score}`, this.actionText("to return"));
+        }
         break;
     }
   }
@@ -852,6 +905,7 @@ export class HUD {
     width: number,
     height: number,
     title: string,
+    storyLines: string[],
     ...lines: string[]
   ): void {
     ctx.save();
@@ -860,7 +914,8 @@ export class HUD {
     ctx.fillRect(0, 0, width, height);
 
     const panelW = 380;
-    const panelH = 160 + lines.length * 30;
+    const storyBlockH = storyLines.length * 18;
+    const panelH = 160 + storyBlockH + lines.length * 30;
     const px = (width - panelW) / 2;
     const py = (height - panelH) / 2;
 
@@ -883,10 +938,22 @@ export class HUD {
     ctx.font = `20px ${RETRO_FONT}`;
     ctx.fillText(title, width / 2, py + 55);
 
+    if (storyLines.length > 0) {
+      ctx.font = `8px ${RETRO_FONT}`;
+      ctx.fillStyle = "#A0B0C8";
+      ctx.textAlign = "left";
+      const textX = px + 20;
+      for (let i = 0; i < storyLines.length; i++) {
+        ctx.fillText(storyLines[i], textX, py + 90 + i * 18);
+      }
+      ctx.textAlign = "center";
+    }
+
     ctx.font = `9px ${RETRO_FONT}`;
     ctx.fillStyle = "#D0D8E8";
+    const linesStartY = py + 100 + storyBlockH;
     for (let i = 0; i < lines.length; i++) {
-      ctx.fillText(lines[i], width / 2, py + 100 + i * 30);
+      ctx.fillText(lines[i], width / 2, linesStartY + i * 30);
     }
 
     ctx.restore();


### PR DESCRIPTION
## PR: Add story text to level-complete and victory screens (Issue #521, epic #465)

### Summary (what changed + why)
This PR enhances the **Level Complete** and **Victory** overlays with narrative story text to better communicate progression and provide a more satisfying conclusion.

- **Level Complete (`"level_complete"`)** now displays the current level’s `story.completionText`, word-wrapped and shown under the title and above the score/prompt.  
  *Why:* The level configs already contain completion narrative, and showing it reinforces story continuity between levels.

- **Victory (`"victory"`)** now plays the full ending narrative from `GAME_STORY.ending` using `StoryRenderer` (typewriter/cinematic effect). After the narrative finishes (or is skipped), the UI transitions to the standard victory overlay showing the **final score** and the **return prompt**.  
  *Why:* The ending text is longer and benefits from a paced, readable presentation rather than being squeezed into a static overlay.

- Overlay panel sizing was adjusted to accommodate additional story lines without overflow.

### Key files modified
- **`src/games/raptor/rendering/HUD.ts`**
  - Added word-wrapping support for completion text and rendered it on the `"level_complete"` overlay.
  - Updated `renderOverlay()` to support a story/narrative block and to size the panel based on added lines.
  - Added HUD-level flags/state to support the two-phase victory flow (story phase vs score overlay phase).

- **`src/games/raptor/RaptorGame.ts`**
  - Wires level completion text into the HUD on transition to `"level_complete"`.
  - On transition to `"victory"`, starts `StoryRenderer` with `GAME_STORY.ending` and coordinates input handling:
    - Click advances story pages during the ending.
    - **ESC** skips the ending narrative and jumps to the final score overlay.
  - Ensures HUD story-related state is cleared/reset appropriately on restarts/transitions.

### Behavior notes
- **Level Complete:** story text appears below “Level Complete!” and above score + “click to continue”.
- **Victory:** narrative ending plays first; then a standard victory overlay appears with **Final Score** and “click to return”.
- **ESC during victory story** skips directly to the score overlay.
- Click-to-continue/click-to-return behavior remains intact.

### Testing notes
- `npm run typecheck` (expected: pass)

**Manual verification checklist**
1. Finish a non-final level (e.g., Level 1): confirm completion text appears, is wrapped, and the overlay resizes without clipping.
2. Confirm score is still visible and clicking advances to the next level as before.
3. Complete Level 10: confirm ending narrative renders via `StoryRenderer` with typewriter effect.
4. Click through all ending pages: confirm transition to the standard victory overlay with **Final Score**.
5. Press **ESC** during the victory narrative: confirm it skips to the score overlay immediately.
6. From the final victory overlay: click to return exits as expected.

Closes: #521

Ref: https://github.com/asgardtech/archer/issues/521