### PR TITLE
player missiles exhaust doesn't line up properly when turning

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -679,13 +679,15 @@ export class RaptorGame implements IGame {
     for (const proj of this.projectiles) {
       if (proj instanceof TrackingBullet) {
         proj.update(dt, this.width, this.height, this.enemies);
-        this.vfx.addTrail(proj.pos.x, proj.pos.y + 3, "rgba(168, 224, 108, 0.4)", 1.5);
+        const exhaust = proj.getExhaustPosition();
+        this.vfx.addTrail(exhaust.x, exhaust.y, "rgba(168, 224, 108, 0.4)", 1.5);
       } else if (proj instanceof Bullet) {
         proj.update(dt, this.width);
         this.vfx.addTrail(proj.pos.x, proj.pos.y + 4, "rgba(255, 220, 0, 0.4)", 1.5);
       } else if (proj instanceof Missile) {
         proj.update(dt, this.width, this.height, this.enemies);
-        this.vfx.addMissileTrail(proj.pos.x, proj.pos.y + 6);
+        const exhaust = proj.getExhaustPosition();
+        this.vfx.addMissileTrail(exhaust.x, exhaust.y, proj.heading);
       } else if (proj instanceof PlasmaBolt) {
         proj.update(dt, this.width);
         this.vfx.addPlasmaTrail(proj.pos.x, proj.pos.y + 3);
@@ -694,13 +696,14 @@ export class RaptorGame implements IGame {
         this.vfx.addTrail(proj.pos.x, proj.pos.y + 4, "rgba(0, 188, 212, 0.5)", 2);
       } else if (proj instanceof Rocket) {
         proj.update(dt, this.width, this.height);
-        this.vfx.addRocketTrail(proj.pos.x, proj.pos.y + 8);
+        const exhaust = proj.getExhaustPosition();
+        this.vfx.addRocketTrail(exhaust.x, exhaust.y, proj.heading);
       }
     }
     for (const eb of this.enemyBullets) {
       eb.update(dt, this.width, this.height, this.player.pos);
       if (eb instanceof EnemyMissile) {
-        this.vfx.addMissileTrail(eb.pos.x, eb.pos.y);
+        this.vfx.addMissileTrail(eb.pos.x, eb.pos.y, eb.heading);
       }
     }
     for (const exp of this.explosions) {

--- a/src/games/raptor/entities/EnemyBullet.ts
+++ b/src/games/raptor/entities/EnemyBullet.ts
@@ -63,6 +63,8 @@ export class EnemyBullet {
     this.sprite = sprite;
   }
 
+  public get heading(): number { return this.angle; }
+
   get left(): number { return this.pos.x - this.radius; }
   get right(): number { return this.pos.x + this.radius; }
   get top(): number { return this.pos.y - this.radius; }

--- a/src/games/raptor/entities/Missile.ts
+++ b/src/games/raptor/entities/Missile.ts
@@ -30,10 +30,20 @@ export class Missile implements Projectile {
     this.sprite = sprite;
   }
 
+  public get heading(): number { return this.angle; }
+
   get left(): number { return this.pos.x - this.width / 2; }
   get right(): number { return this.pos.x + this.width / 2; }
   get top(): number { return this.pos.y - this.height / 2; }
   get bottom(): number { return this.pos.y + this.height / 2; }
+
+  getExhaustPosition(): Vec2 {
+    const tailOffset = this.height / 2 + 2;
+    return {
+      x: this.pos.x - Math.sin(this.angle) * tailOffset,
+      y: this.pos.y + Math.cos(this.angle) * tailOffset,
+    };
+  }
 
   update(dt: number, canvasWidth = 800, canvasHeight = 600, enemies?: Enemy[]): void {
     if (!this.alive) return;

--- a/src/games/raptor/entities/Rocket.ts
+++ b/src/games/raptor/entities/Rocket.ts
@@ -27,10 +27,20 @@ export class Rocket implements Projectile {
     this.sprite = sprite;
   }
 
+  public get heading(): number { return this.angle; }
+
   get left(): number { return this.pos.x - this.width / 2; }
   get right(): number { return this.pos.x + this.width / 2; }
   get top(): number { return this.pos.y - this.height / 2; }
   get bottom(): number { return this.pos.y + this.height / 2; }
+
+  getExhaustPosition(): Vec2 {
+    const tailOffset = this.height / 2 + 2;
+    return {
+      x: this.pos.x - Math.sin(this.angle) * tailOffset,
+      y: this.pos.y + Math.cos(this.angle) * tailOffset,
+    };
+  }
 
   update(dt: number, canvasWidth = 800, canvasHeight = 600): void {
     if (!this.alive) return;

--- a/src/games/raptor/entities/TrackingBullet.ts
+++ b/src/games/raptor/entities/TrackingBullet.ts
@@ -30,10 +30,20 @@ export class TrackingBullet implements Projectile {
     this.sprite = sprite;
   }
 
+  public get heading(): number { return this.angle; }
+
   get left(): number { return this.pos.x - this.width / 2; }
   get right(): number { return this.pos.x + this.width / 2; }
   get top(): number { return this.pos.y - this.height / 2; }
   get bottom(): number { return this.pos.y + this.height / 2; }
+
+  getExhaustPosition(): Vec2 {
+    const tailOffset = this.height / 2 + 1;
+    return {
+      x: this.pos.x - Math.sin(this.angle) * tailOffset,
+      y: this.pos.y + Math.cos(this.angle) * tailOffset,
+    };
+  }
 
   update(dt: number, canvasWidth = 800, canvasHeight = 600, enemies?: Enemy[]): void {
     if (!this.alive) return;

--- a/src/games/raptor/rendering/VFXManager.ts
+++ b/src/games/raptor/rendering/VFXManager.ts
@@ -181,22 +181,28 @@ export class VFXManager {
     ctx.restore();
   }
 
-  addMissileTrail(x: number, y: number): void {
+  addMissileTrail(x: number, y: number, angle = 0): void {
     if (this.trails.length > 300) return;
+    const perpX = Math.cos(angle);
+    const perpY = Math.sin(angle);
+    const spread = (Math.random() - 0.5) * 4;
     this.trails.push({
-      x: x + (Math.random() - 0.5) * 4,
-      y: y + (Math.random() - 0.5) * 2,
+      x: x + perpX * spread,
+      y: y + perpY * spread,
       alpha: 0.5,
       size: 1.5 + Math.random() * 1.5,
       color: `rgba(${180 + Math.random() * 40}, ${180 + Math.random() * 40}, ${180 + Math.random() * 40}, 0.6)`,
     });
   }
 
-  addRocketTrail(x: number, y: number): void {
+  addRocketTrail(x: number, y: number, angle = 0): void {
     if (this.trails.length > 300) return;
+    const perpX = Math.cos(angle);
+    const perpY = Math.sin(angle);
+    const spread = (Math.random() - 0.5) * 6;
     this.trails.push({
-      x: x + (Math.random() - 0.5) * 6,
-      y: y + (Math.random() - 0.5) * 3,
+      x: x + perpX * spread,
+      y: y + perpY * spread,
       alpha: 0.6,
       size: 2.0 + Math.random() * 2.0,
       color: `rgba(${140 + Math.random() * 40}, ${130 + Math.random() * 30}, ${100 + Math.random() * 30}, 0.7)`,

--- a/tests/raptor-issue-522-exhaust-alignment.test.ts
+++ b/tests/raptor-issue-522-exhaust-alignment.test.ts
@@ -1,0 +1,185 @@
+import { Missile } from "../src/games/raptor/entities/Missile";
+import { Rocket } from "../src/games/raptor/entities/Rocket";
+import { TrackingBullet } from "../src/games/raptor/entities/TrackingBullet";
+import { EnemyBullet } from "../src/games/raptor/entities/EnemyBullet";
+import { EnemyMissile } from "../src/games/raptor/entities/EnemyMissile";
+import { VFXManager } from "../src/games/raptor/rendering/VFXManager";
+
+// ─── Missile exhaust position tests ─────────────────────────────
+
+describe("Missile.getExhaustPosition", () => {
+  const cx = 100;
+  const cy = 200;
+
+  it("returns position directly behind missile when heading is 0 (straight up)", () => {
+    const missile = new Missile(cx, cy, 0);
+    const exhaust = missile.getExhaustPosition();
+    const tailOffset = missile.height / 2 + 2;
+
+    expect(exhaust.x).toBeCloseTo(cx, 5);
+    expect(exhaust.y).toBeCloseTo(cy + tailOffset, 5);
+  });
+
+  it("returns position to the left when heading is π/2 (pointing right)", () => {
+    const missile = new Missile(cx, cy, Math.PI / 2);
+    const exhaust = missile.getExhaustPosition();
+    const tailOffset = missile.height / 2 + 2;
+
+    expect(exhaust.x).toBeCloseTo(cx - tailOffset, 5);
+    expect(exhaust.y).toBeCloseTo(cy, 5);
+  });
+
+  it("returns position to the right when heading is -π/2 (pointing left)", () => {
+    const missile = new Missile(cx, cy, -Math.PI / 2);
+    const exhaust = missile.getExhaustPosition();
+    const tailOffset = missile.height / 2 + 2;
+
+    expect(exhaust.x).toBeCloseTo(cx + tailOffset, 5);
+    expect(exhaust.y).toBeCloseTo(cy, 5);
+  });
+
+  it("returns position above missile when heading is π (pointing down)", () => {
+    const missile = new Missile(cx, cy, Math.PI);
+    const exhaust = missile.getExhaustPosition();
+    const tailOffset = missile.height / 2 + 2;
+
+    expect(exhaust.x).toBeCloseTo(cx, 4);
+    expect(exhaust.y).toBeCloseTo(cy - tailOffset, 4);
+  });
+
+  it("exposes heading getter matching internal angle", () => {
+    const angle = 1.23;
+    const missile = new Missile(cx, cy, angle);
+    expect(missile.heading).toBeCloseTo(angle, 10);
+  });
+});
+
+// ─── Rocket exhaust position tests ──────────────────────────────
+
+describe("Rocket.getExhaustPosition", () => {
+  const cx = 150;
+  const cy = 250;
+
+  it("returns position directly behind rocket when heading is 0", () => {
+    const rocket = new Rocket(cx, cy, 0);
+    const exhaust = rocket.getExhaustPosition();
+    const tailOffset = rocket.height / 2 + 2;
+
+    expect(exhaust.x).toBeCloseTo(cx, 5);
+    expect(exhaust.y).toBeCloseTo(cy + tailOffset, 5);
+  });
+
+  it("returns rotated position when heading is π/2", () => {
+    const rocket = new Rocket(cx, cy, Math.PI / 2);
+    const exhaust = rocket.getExhaustPosition();
+    const tailOffset = rocket.height / 2 + 2;
+
+    expect(exhaust.x).toBeCloseTo(cx - tailOffset, 5);
+    expect(exhaust.y).toBeCloseTo(cy, 5);
+  });
+
+  it("exposes heading getter", () => {
+    const rocket = new Rocket(cx, cy, 0.5);
+    expect(rocket.heading).toBeCloseTo(0.5, 10);
+  });
+});
+
+// ─── TrackingBullet exhaust position tests ──────────────────────
+
+describe("TrackingBullet.getExhaustPosition", () => {
+  const cx = 100;
+  const cy = 300;
+
+  it("returns position directly behind bullet when heading is 0", () => {
+    const bullet = new TrackingBullet(cx, cy, 0);
+    const exhaust = bullet.getExhaustPosition();
+    const tailOffset = bullet.height / 2 + 1;
+
+    expect(exhaust.x).toBeCloseTo(cx, 5);
+    expect(exhaust.y).toBeCloseTo(cy + tailOffset, 5);
+  });
+
+  it("returns rotated position for non-zero heading", () => {
+    const bullet = new TrackingBullet(cx, cy, -Math.PI / 2);
+    const exhaust = bullet.getExhaustPosition();
+    const tailOffset = bullet.height / 2 + 1;
+
+    expect(exhaust.x).toBeCloseTo(cx + tailOffset, 5);
+    expect(exhaust.y).toBeCloseTo(cy, 5);
+  });
+
+  it("uses smaller tail offset than Missile", () => {
+    const missile = new Missile(cx, cy, 0);
+    const bullet = new TrackingBullet(cx, cy, 0);
+    const missileOffset = missile.height / 2 + 2;
+    const bulletOffset = bullet.height / 2 + 1;
+
+    expect(bulletOffset).toBeLessThan(missileOffset);
+  });
+});
+
+// ─── EnemyBullet heading getter tests ───────────────────────────
+
+describe("EnemyBullet.heading", () => {
+  it("exposes the computed angle from constructor", () => {
+    const eb = new EnemyBullet(100, 100, 200, 100);
+    expect(typeof eb.heading).toBe("number");
+  });
+
+  it("EnemyMissile inherits heading getter", () => {
+    const em = new EnemyMissile(100, 100, 200, 200);
+    expect(typeof em.heading).toBe("number");
+  });
+});
+
+// ─── VFXManager angle-aware trail tests ─────────────────────────
+
+describe("VFXManager angle-aware trails", () => {
+  let vfx: VFXManager;
+
+  beforeEach(() => {
+    vfx = new VFXManager();
+  });
+
+  it("addMissileTrail with angle=0 scatters along X axis (perpendicular to up)", () => {
+    const samples: number[] = [];
+    for (let i = 0; i < 100; i++) {
+      vfx.addMissileTrail(100, 200, 0);
+    }
+    const trails = (vfx as any).trails as Array<{ x: number; y: number }>;
+    const xSpread = trails.some((t) => Math.abs(t.x - 100) > 0.01);
+    expect(xSpread).toBe(true);
+  });
+
+  it("addMissileTrail with angle=π/2 scatters along Y axis (perpendicular to right)", () => {
+    for (let i = 0; i < 100; i++) {
+      vfx.addMissileTrail(100, 200, Math.PI / 2);
+    }
+    const trails = (vfx as any).trails as Array<{ x: number; y: number }>;
+    const ySpread = trails.some((t) => Math.abs(t.y - 200) > 0.5);
+    expect(ySpread).toBe(true);
+  });
+
+  it("addRocketTrail accepts angle parameter without error", () => {
+    expect(() => {
+      vfx.addRocketTrail(100, 200, Math.PI / 4);
+    }).not.toThrow();
+  });
+
+  it("addRocketTrail with angle=π/2 scatters perpendicular to heading", () => {
+    for (let i = 0; i < 100; i++) {
+      vfx.addRocketTrail(100, 200, Math.PI / 2);
+    }
+    const trails = (vfx as any).trails as Array<{ x: number; y: number }>;
+    const ySpread = trails.some((t) => Math.abs(t.y - 200) > 0.5);
+    expect(ySpread).toBe(true);
+  });
+
+  it("trail count respects the 300 cap", () => {
+    for (let i = 0; i < 350; i++) {
+      vfx.addMissileTrail(100, 200, 0);
+    }
+    const trails = (vfx as any).trails as Array<{ x: number; y: number }>;
+    expect(trails.length).toBeLessThanOrEqual(301);
+  });
+});


### PR DESCRIPTION
## Fix #522: Align missile/rocket/tracking-bullet exhaust trails with projectile heading

### Summary (what changed & why)
Homing/angled projectiles were spawning exhaust trail particles using a fixed, screen-axis offset (e.g., `pos.y + 6`), which assumes the projectile is always pointing “up.” When missiles turned to track targets, the smoke/flame trail visually drifted away from the rear of the projectile.

This PR fixes the artifact by:
- Exposing a projectile **heading** (angle) via getters.
- Computing the **exhaust origin at the rear of the projectile** using a rotated offset based on the current heading.
- Making VFX trail particle scatter **angle-aware**, so random spread is applied perpendicular to the projectile’s heading (instead of along screen X/Y).

### Key changes
- **Angle/heading exposed on relevant projectiles**
  - Added `heading` getters (and `getExhaustPosition()` helpers where applicable) so the game loop can spawn trails at the correct, rotated tail location.
- **VFX trail placement and scatter made heading-aware**
  - `VFXManager.addMissileTrail()` / `addRocketTrail()` now accept an optional `angle` and scatter particles perpendicular to travel direction.
- **Game loop updated to use rotated exhaust positions**
  - `RaptorGame.updatePlaying()` now calls `getExhaustPosition()` and passes `heading` into VFX methods for missiles/rockets/tracking bullets (and enemy missiles via inherited heading).

### Files modified
- `src/games/raptor/RaptorGame.ts`
  - Updated projectile trail spawn logic to use rotated exhaust positions and pass heading into VFX.
- `src/games/raptor/rendering/VFXManager.ts`
  - Updated `addMissileTrail(x, y, angle?)` and `addRocketTrail(x, y, angle?)` for angle-aware particle scatter.
- `src/games/raptor/entities/Missile.ts`
  - Added `heading` getter + `getExhaustPosition()` (rotated tail offset).
- `src/games/raptor/entities/Rocket.ts`
  - Added `heading` getter + `getExhaustPosition()`.
- `src/games/raptor/entities/TrackingBullet.ts`
  - Added `heading` getter + `getExhaustPosition()`.
- `src/games/raptor/entities/EnemyBullet.ts`
  - Added `heading` getter on base class (benefits `EnemyMissile`).
- **Tests** (new/updated)
  - Unit tests for `getExhaustPosition()` at multiple angles and for angle-aware VFX scatter behavior.

### Testing notes
- **Unit tests**
  - Verify `getExhaustPosition()` for angles `0`, `π/2`, `-π/2`, and `π`.
  - Verify `VFXManager.addMissileTrail()` produces angle-dependent placement/scatter when a non-zero angle is provided.
- **Manual QA**
  - In-game: equip missiles and fire near enemies so missiles perform strong homing turns; confirm the exhaust stays anchored to the missile’s rear throughout turns.
  - Check rockets fired at angled trajectories (e.g., spread shot) to ensure trails start correctly aligned from the first frame.
  - Verify no visual regression for straight-flying projectiles (angle = 0 should match prior behavior).

Ref: https://github.com/asgardtech/archer/issues/522