### PR TITLE
enemy lasers don't match properly, the enemy moves one way, and the laser in another way

### DIFF
--- a/src/games/raptor/entities/EnemyLaserBeam.ts
+++ b/src/games/raptor/entities/EnemyLaserBeam.ts
@@ -12,6 +12,7 @@ export interface EnemyLaserBeamConfig {
 export class EnemyLaserBeam {
   phase: EnemyLaserPhase = "idle";
   beamX = 0;
+  originX = 0;
   originY = 0;
   beamWidth: number;
   damage: number;
@@ -33,6 +34,7 @@ export class EnemyLaserBeam {
     this.phase = "warmup";
     this.phaseTimer = this.config.warmupDuration;
     this.beamX = enemyX;
+    this.originX = enemyX;
     this.originY = enemyBottomY;
     this.targetX = playerX;
     this.time = 0;
@@ -45,6 +47,7 @@ export class EnemyLaserBeam {
     if (this.phase === "idle") return;
 
     this.time += dt;
+    this.originX = enemyX;
     this.originY = enemyBottomY;
     this.phaseTimer -= dt;
 
@@ -96,7 +99,7 @@ export class EnemyLaserBeam {
     ctx.strokeStyle = `rgba(255, 204, 0, ${pulse})`;
     ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.moveTo(this.beamX, this.originY);
+    ctx.moveTo(this.originX, this.originY);
     ctx.lineTo(this.beamX, canvasHeight);
     ctx.stroke();
     ctx.restore();
@@ -104,32 +107,39 @@ export class EnemyLaserBeam {
 
   private renderBeam(ctx: CanvasRenderingContext2D, canvasHeight: number): void {
     const halfWidth = this.beamWidth / 2;
-    const beamTop = this.originY;
-    const beamHeight = canvasHeight - beamTop;
 
     ctx.save();
 
     const pulse = 0.6 + Math.sin(this.time * 20) * 0.15;
 
-    const outerGlow = ctx.createLinearGradient(
-      this.beamX - halfWidth * 4, 0, this.beamX + halfWidth * 4, 0
-    );
-    outerGlow.addColorStop(0, "rgba(255, 80, 0, 0)");
-    outerGlow.addColorStop(0.3, `rgba(255, 80, 0, ${0.15 * pulse})`);
-    outerGlow.addColorStop(0.5, `rgba(255, 120, 20, ${0.3 * pulse})`);
-    outerGlow.addColorStop(0.7, `rgba(255, 80, 0, ${0.15 * pulse})`);
-    outerGlow.addColorStop(1, "rgba(255, 80, 0, 0)");
-    ctx.fillStyle = outerGlow;
-    ctx.fillRect(this.beamX - halfWidth * 4, beamTop, halfWidth * 8, beamHeight);
+    this.fillTrapezoid(ctx, this.originX, this.originY, this.beamX, canvasHeight, halfWidth * 4);
+    ctx.fillStyle = `rgba(255, 120, 20, ${0.3 * pulse})`;
+    ctx.fill();
 
+    this.fillTrapezoid(ctx, this.originX, this.originY, this.beamX, canvasHeight, halfWidth);
     ctx.fillStyle = `rgba(255, 120, 20, ${0.5 * pulse})`;
-    ctx.fillRect(this.beamX - halfWidth, beamTop, this.beamWidth, beamHeight);
+    ctx.fill();
 
     const coreWidth = halfWidth * 0.5;
+    this.fillTrapezoid(ctx, this.originX, this.originY, this.beamX, canvasHeight, coreWidth);
     ctx.fillStyle = `rgba(255, 220, 150, ${0.8 * pulse})`;
-    ctx.fillRect(this.beamX - coreWidth, beamTop, coreWidth * 2, beamHeight);
+    ctx.fill();
 
     ctx.restore();
+  }
+
+  private fillTrapezoid(
+    ctx: CanvasRenderingContext2D,
+    topX: number, topY: number,
+    bottomX: number, bottomY: number,
+    halfWidth: number,
+  ): void {
+    ctx.beginPath();
+    ctx.moveTo(topX - halfWidth, topY);
+    ctx.lineTo(topX + halfWidth, topY);
+    ctx.lineTo(bottomX + halfWidth, bottomY);
+    ctx.lineTo(bottomX - halfWidth, bottomY);
+    ctx.closePath();
   }
 
   get isActive(): boolean {
@@ -153,6 +163,7 @@ export class EnemyLaserBeam {
     this.phaseTimer = 0;
     this.time = 0;
     this.beamX = 0;
+    this.originX = 0;
     this.originY = 0;
     this.justActivated = false;
   }

--- a/src/games/raptor/systems/CollisionSystem.ts
+++ b/src/games/raptor/systems/CollisionSystem.ts
@@ -225,14 +225,19 @@ export class CollisionSystem {
     if (!player.alive || player.isInvincible) return [];
 
     const hits: EnemyBeamPlayerHit[] = [];
+    const playerCenterY = (player.top + player.bottom) / 2;
+
     for (const beam of beams) {
       if (!beam.isActive) continue;
 
       const halfWidth = beam.beamWidth / 2;
-      const beamLeft = beam.beamX - halfWidth;
-      const beamRight = beam.beamX + halfWidth;
       const beamTop = beam.originY;
       const beamBottom = canvasHeight;
+      const totalHeight = beamBottom - beamTop;
+      const t = totalHeight > 0 ? (playerCenterY - beamTop) / totalHeight : 0;
+      const beamXAtPlayerY = beam.originX + (beam.beamX - beam.originX) * t;
+      const beamLeft = beamXAtPlayerY - halfWidth;
+      const beamRight = beamXAtPlayerY + halfWidth;
 
       if (this.aabb(beamLeft, beamTop, beamRight, beamBottom,
                     player.left, player.top, player.right, player.bottom)) {

--- a/tests/raptor-enemy-laser-beam.test.ts
+++ b/tests/raptor-enemy-laser-beam.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for Issue #524: Enemy laser beam origin tracking and angled beam
+ */
+
+import { EnemyLaserBeam, EnemyLaserBeamConfig } from "../src/games/raptor/entities/EnemyLaserBeam";
+
+const DEFAULT_CONFIG: EnemyLaserBeamConfig = {
+  warmupDuration: 1.0,
+  activeDuration: 2.0,
+  cooldownDuration: 0.5,
+  beamWidth: 12,
+  trackingSpeed: 40,
+  damage: 10,
+};
+
+function createBeam(config?: Partial<EnemyLaserBeamConfig>): EnemyLaserBeam {
+  return new EnemyLaserBeam({ ...DEFAULT_CONFIG, ...config });
+}
+
+describe("EnemyLaserBeam originX tracking", () => {
+  test("originX is set on activate", () => {
+    const beam = createBeam();
+    beam.activate(200, 50, 300);
+    expect(beam.originX).toBe(200);
+  });
+
+  test("originX tracks enemyX during warmup phase", () => {
+    const beam = createBeam();
+    beam.activate(200, 50, 300);
+
+    beam.update(0.1, 210, 55, 300);
+    expect(beam.originX).toBe(210);
+
+    beam.update(0.1, 220, 55, 300);
+    expect(beam.originX).toBe(220);
+  });
+
+  test("originX tracks enemyX during active phase", () => {
+    const beam = createBeam({ warmupDuration: 0.1 });
+    beam.activate(200, 50, 300);
+
+    beam.update(0.15, 200, 50, 300);
+    expect(beam.phase).toBe("active");
+
+    beam.update(0.1, 250, 50, 300);
+    expect(beam.originX).toBe(250);
+  });
+
+  test("originX and beamX can differ during active phase when enemy moves", () => {
+    const beam = createBeam({ warmupDuration: 0.1, trackingSpeed: 40 });
+    beam.activate(200, 50, 400);
+
+    beam.update(0.15, 200, 50, 400);
+    expect(beam.phase).toBe("active");
+
+    beam.update(0.5, 300, 50, 400);
+    expect(beam.originX).toBe(300);
+    expect(beam.beamX).not.toBe(beam.originX);
+  });
+
+  test("beamX equals originX during warmup (both track enemyX)", () => {
+    const beam = createBeam();
+    beam.activate(200, 50, 300);
+
+    beam.update(0.1, 210, 55, 300);
+    expect(beam.beamX).toBe(210);
+    expect(beam.originX).toBe(210);
+  });
+
+  test("originX is reset to 0 on reset()", () => {
+    const beam = createBeam();
+    beam.activate(200, 50, 300);
+    expect(beam.originX).toBe(200);
+
+    beam.reset();
+    expect(beam.originX).toBe(0);
+  });
+});
+
+describe("EnemyLaserBeam collision interpolation", () => {
+  test("interpolated beam X at player Y accounts for angled beam", () => {
+    const beam = createBeam({ warmupDuration: 0.1, trackingSpeed: 40 });
+    beam.activate(200, 0, 400);
+
+    beam.update(0.15, 200, 0, 400);
+    expect(beam.phase).toBe("active");
+
+    beam.update(1.0, 100, 0, 400);
+
+    const canvasHeight = 600;
+    const playerCenterY = 300;
+
+    const originX = beam.originX;
+    const beamX = beam.beamX;
+    const t = (playerCenterY - beam.originY) / (canvasHeight - beam.originY);
+    const beamXAtPlayerY = originX + (beamX - originX) * t;
+
+    expect(beamXAtPlayerY).not.toBe(beamX);
+    expect(t).toBeCloseTo(0.5);
+    expect(beamXAtPlayerY).toBeCloseTo((originX + beamX) / 2);
+  });
+
+  test("interpolation returns originX at the top of the beam", () => {
+    const beam = createBeam({ warmupDuration: 0.1 });
+    beam.activate(100, 50, 400);
+    beam.update(0.15, 100, 50, 400);
+    beam.update(0.5, 150, 50, 400);
+
+    const canvasHeight = 600;
+    const t = (50 - beam.originY) / (canvasHeight - beam.originY);
+    const beamXAtTop = beam.originX + (beam.beamX - beam.originX) * t;
+
+    expect(t).toBeCloseTo(0);
+    expect(beamXAtTop).toBeCloseTo(beam.originX);
+  });
+
+  test("interpolation returns beamX at the bottom of the beam", () => {
+    const beam = createBeam({ warmupDuration: 0.1 });
+    beam.activate(100, 50, 400);
+    beam.update(0.15, 100, 50, 400);
+    beam.update(0.5, 150, 50, 400);
+
+    const canvasHeight = 600;
+    const t = (canvasHeight - beam.originY) / (canvasHeight - beam.originY);
+    const beamXAtBottom = beam.originX + (beam.beamX - beam.originX) * t;
+
+    expect(t).toBeCloseTo(1);
+    expect(beamXAtBottom).toBeCloseTo(beam.beamX);
+  });
+});
+
+describe("EnemyLaserBeam vertical beam when aligned", () => {
+  test("beam is vertical when enemy is aligned with target (originX === beamX)", () => {
+    const beam = createBeam({ warmupDuration: 0.1, trackingSpeed: 1000 });
+    beam.activate(200, 50, 200);
+
+    beam.update(0.15, 200, 50, 200);
+    expect(beam.phase).toBe("active");
+
+    beam.update(0.1, 200, 50, 200);
+    expect(beam.originX).toBe(200);
+    expect(beam.beamX).toBe(200);
+  });
+});
+
+describe("EnemyLaserBeam reset on enemy destruction", () => {
+  test("beam resets cleanly mid-fire", () => {
+    const beam = createBeam({ warmupDuration: 0.1 });
+    beam.activate(200, 50, 300);
+    beam.update(0.15, 200, 50, 300);
+    expect(beam.phase).toBe("active");
+
+    beam.reset();
+    expect(beam.phase).toBe("idle");
+    expect(beam.originX).toBe(0);
+    expect(beam.originY).toBe(0);
+    expect(beam.beamX).toBe(0);
+  });
+});


### PR DESCRIPTION
## PR: Fix enemy laser desync by anchoring beam to enemy and rendering angled beam (Issue #524)

### Summary / Why
Enemy laser beams were visually and logically disconnected from the ship firing them: the enemy could oscillate horizontally while the laser remained a vertical column tracking independently on X, making it appear to fire from empty space and causing collision checks to be inaccurate.

This change anchors the beam’s **origin** to the enemy’s current X position every frame and renders the laser as an **angled beam** from the enemy to the tracked target point, matching expected shoot-’em-up behavior.

### What changed
- **EnemyLaserBeam**
  - Added `originX` to track the enemy ship’s current X position (mirrors existing `originY` behavior).
  - Updated warmup warning rendering to draw from `(originX, originY)` to `(beamX, canvasHeight)` rather than a detached vertical indicator.
  - Refactored active beam rendering from a vertical rectangle to an angled trapezoid (polygon) from the enemy origin to the tracked target end (with glow/core layers matching the same shape).

- **CollisionSystem**
  - Updated `checkEnemyBeamPlayer()` to handle angled beams by interpolating the beam’s X position at the player’s Y (instead of assuming a constant `beamX` for the full height).
  - Collision AABB is now centered around `beamXAtPlayerY` (interpolated) for correct hit detection.

### Key files modified
- `src/games/raptor/entities/EnemyLaserBeam.ts`
  - Add `originX`
  - Update `activate()` / `update()` to keep origin in sync with enemy
  - Angled warning + angled beam polygon rendering
- `src/games/raptor/systems/CollisionSystem.ts`
  - Angled-beam-aware collision via X interpolation at player Y

### Testing notes
- **Manual**
  - Spawn a laser-equipped enemy (e.g., destroyer) and let it oscillate: beam should remain visually connected to the ship at the top while sweeping toward the player.
  - During warmup, warning line should originate at the enemy.
  - Verify player damage occurs when intersecting the beam at the player’s Y position and does not occur when outside the interpolated beam width.

- **Automated**
  - No new tests included in this PR. Recommended follow-up unit coverage:
    - `originX` tracks `enemyX` each frame
    - collision interpolation (`beamXAtPlayerY`) correctness for angled beams

Closes: Issue #524 (“Enemy lasers don't match properly, the enemy moves one way, and the laser in another way”).

Ref: https://github.com/asgardtech/archer/issues/524