### PR TITLE
let's have a character face for the wingman as well as us

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,4 +1,5 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType } from "./types";
+import { detectSpeaker } from "./rendering/StoryRenderer";
 import { InputManager } from "./systems/InputManager";
 import { DevConsole } from "./systems/DevConsole";
 import { CollisionSystem } from "./systems/CollisionSystem";
@@ -427,7 +428,7 @@ export class RaptorGame implements IGame {
               this.sound.play("menu_start");
               SaveSystem.clear();
               this.resetGame();
-              this.storyRenderer.show(GAME_STORY.opening, "center");
+              this.storyRenderer.show(GAME_STORY.opening, "center", "pilot");
               this.state = "story_intro";
               this.sound.startMusic("playing", 0);
             }
@@ -435,7 +436,7 @@ export class RaptorGame implements IGame {
             this.audio.ensureContext();
             this.sound.play("menu_start");
             this.resetGame();
-            this.storyRenderer.show(GAME_STORY.opening, "center");
+            this.storyRenderer.show(GAME_STORY.opening, "center", "pilot");
             this.state = "story_intro";
             this.sound.startMusic("playing", 0);
           }
@@ -615,7 +616,8 @@ export class RaptorGame implements IGame {
     if (storyMessages && this.nextStoryMessageIndex < storyMessages.length) {
       const msg = storyMessages[this.nextStoryMessageIndex];
       if (this.levelElapsed >= msg.triggerTime) {
-        this.storyRenderer.showQuick(msg.text, msg.duration, "bottom");
+        const speaker: SpeakerType = msg.speaker ?? detectSpeaker(msg.text);
+        this.storyRenderer.showQuick(msg.text, msg.duration, "bottom", speaker);
         this.nextStoryMessageIndex++;
       }
     }
@@ -891,7 +893,7 @@ export class RaptorGame implements IGame {
         this.state = "victory";
         this.sound.play("victory");
         SaveSystem.clear();
-        this.storyRenderer.show(GAME_STORY.ending, "center");
+        this.storyRenderer.show(GAME_STORY.ending, "center", "pilot");
         this.hud.setVictoryStoryActive(true);
       } else {
         this.state = "level_complete";
@@ -1066,7 +1068,7 @@ export class RaptorGame implements IGame {
       return;
     }
 
-    this.storyRenderer.show([briefingText], "center");
+    this.storyRenderer.show([briefingText], "center", "pilot");
     this.state = "briefing";
   }
 

--- a/src/games/raptor/rendering/HQPortrait.ts
+++ b/src/games/raptor/rendering/HQPortrait.ts
@@ -1,0 +1,137 @@
+export class HQPortrait {
+  static render(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    size: number,
+    elapsed: number
+  ): void {
+    const s = size / 100;
+    const cx = x + size / 2;
+    const cy = y + (size * 1.2) / 2;
+
+    ctx.save();
+
+    const frameX = x - 4;
+    const frameY = y - 4;
+    const frameW = size + 8;
+    const frameH = size * 1.2 + 8;
+
+    ctx.strokeStyle = "rgba(220, 180, 60, 0.7)";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    ctx.roundRect(frameX, frameY, frameW, frameH, 6);
+    ctx.stroke();
+
+    ctx.strokeStyle = "rgba(180, 140, 40, 0.4)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.roundRect(frameX - 2, frameY - 2, frameW + 4, frameH + 4, 8);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.roundRect(x, y, size, size * 1.2, 4);
+    ctx.clip();
+
+    // Dark screen background
+    ctx.fillStyle = "#0a0e14";
+    ctx.fillRect(x, y, size, size * 1.2);
+
+    // Subtle scan-line effect
+    ctx.fillStyle = "rgba(40, 60, 30, 0.08)";
+    for (let ly = 0; ly < size * 1.2; ly += 3 * s) {
+      ctx.fillRect(x, y + ly, size, 1 * s);
+    }
+
+    // Radar sweep glow
+    const sweepAngle = (elapsed * 1.2) % (Math.PI * 2);
+    const radarR = 30 * s;
+
+    const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, radarR);
+    grad.addColorStop(0, "rgba(80, 200, 60, 0.15)");
+    grad.addColorStop(1, "rgba(80, 200, 60, 0)");
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(cx, cy, radarR, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Radar rings
+    ctx.strokeStyle = "rgba(80, 200, 60, 0.25)";
+    ctx.lineWidth = 1 * s;
+    for (let r = 10; r <= 30; r += 10) {
+      ctx.beginPath();
+      ctx.arc(cx, cy, r * s, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    // Cross-hairs
+    ctx.strokeStyle = "rgba(80, 200, 60, 0.2)";
+    ctx.lineWidth = 0.5 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx - 32 * s, cy);
+    ctx.lineTo(cx + 32 * s, cy);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - 38 * s);
+    ctx.lineTo(cx, cy + 38 * s);
+    ctx.stroke();
+
+    // Sweep line
+    const sweepEndX = cx + Math.cos(sweepAngle) * radarR;
+    const sweepEndY = cy + Math.sin(sweepAngle) * radarR;
+    ctx.strokeStyle = "rgba(100, 255, 80, 0.6)";
+    ctx.lineWidth = 1.5 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(sweepEndX, sweepEndY);
+    ctx.stroke();
+
+    // Sweep fade trail
+    ctx.fillStyle = "rgba(80, 200, 60, 0.12)";
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.arc(cx, cy, radarR, sweepAngle - 0.5, sweepAngle);
+    ctx.closePath();
+    ctx.fill();
+
+    // Blip dots (pulse with elapsed)
+    const blipPulse = Math.sin(elapsed * 3) * 0.3 + 0.7;
+    ctx.fillStyle = `rgba(100, 255, 80, ${blipPulse * 0.8})`;
+    ctx.beginPath();
+    ctx.arc(cx + 12 * s, cy - 8 * s, 2 * s, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(cx - 16 * s, cy + 5 * s, 1.5 * s, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(cx + 5 * s, cy + 18 * s, 1.8 * s, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Center dot (own position)
+    ctx.fillStyle = "rgba(220, 180, 60, 0.9)";
+    ctx.beginPath();
+    ctx.arc(cx, cy, 2.5 * s, 0, Math.PI * 2);
+    ctx.fill();
+
+    // "HQ" label at top of screen
+    ctx.fillStyle = "rgba(220, 180, 60, 0.7)";
+    ctx.font = `bold ${8 * s}px monospace`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.fillText("HQ-COMM", cx, y + 6 * s);
+
+    // Signal bars bottom-right
+    const barX = x + size - 18 * s;
+    const barBaseY = y + size * 1.2 - 10 * s;
+    const barBlink = elapsed % 2 < 1.7;
+    ctx.fillStyle = barBlink
+      ? "rgba(100, 255, 80, 0.6)"
+      : "rgba(100, 255, 80, 0.3)";
+    for (let i = 0; i < 4; i++) {
+      const bh = (i + 1) * 3 * s;
+      ctx.fillRect(barX + i * 3.5 * s, barBaseY - bh, 2 * s, bh);
+    }
+
+    ctx.restore();
+  }
+}

--- a/src/games/raptor/rendering/PilotPortrait.ts
+++ b/src/games/raptor/rendering/PilotPortrait.ts
@@ -1,0 +1,203 @@
+export class PilotPortrait {
+  static render(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    size: number,
+    elapsed: number
+  ): void {
+    const s = size / 100;
+    const cx = x + size / 2;
+
+    ctx.save();
+
+    const frameX = x - 4;
+    const frameY = y - 4;
+    const frameW = size + 8;
+    const frameH = size * 1.2 + 8;
+
+    ctx.strokeStyle = "rgba(80, 130, 220, 0.7)";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    ctx.roundRect(frameX, frameY, frameW, frameH, 6);
+    ctx.stroke();
+
+    ctx.strokeStyle = "rgba(60, 100, 180, 0.4)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.roundRect(frameX - 2, frameY - 2, frameW + 4, frameH + 4, 8);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.roundRect(x, y, size, size * 1.2, 4);
+    ctx.clip();
+
+    ctx.fillStyle = "#0f1a2e";
+    ctx.fillRect(x, y, size, size * 1.2);
+
+    // Shoulders / flight suit
+    const shoulderY = y + 85 * s;
+    ctx.fillStyle = "#1a2a4a";
+    ctx.beginPath();
+    ctx.ellipse(cx, shoulderY + 20 * s, 45 * s, 25 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Collar / suit neckline
+    ctx.fillStyle = "#152240";
+    ctx.beginPath();
+    ctx.moveTo(cx - 15 * s, shoulderY);
+    ctx.lineTo(cx + 15 * s, shoulderY);
+    ctx.lineTo(cx + 10 * s, shoulderY + 15 * s);
+    ctx.lineTo(cx - 10 * s, shoulderY + 15 * s);
+    ctx.closePath();
+    ctx.fill();
+
+    // Suit shoulder patches
+    ctx.fillStyle = "#b89a4a";
+    ctx.beginPath();
+    ctx.roundRect(x + 5 * s, shoulderY + 2 * s, 14 * s, 6 * s, 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.roundRect(x + 81 * s, shoulderY + 2 * s, 14 * s, 6 * s, 2);
+    ctx.fill();
+
+    // Neck
+    ctx.fillStyle = "#d4a574";
+    ctx.beginPath();
+    ctx.ellipse(cx, shoulderY - 2 * s, 10 * s, 12 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Face
+    const faceY = y + 42 * s;
+    ctx.fillStyle = "#d4a574";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY, 28 * s, 32 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Jaw
+    ctx.fillStyle = "#c89a68";
+    ctx.beginPath();
+    ctx.moveTo(cx - 22 * s, faceY + 10 * s);
+    ctx.lineTo(cx, faceY + 32 * s);
+    ctx.lineTo(cx + 22 * s, faceY + 10 * s);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = "#d4a574";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY + 5 * s, 26 * s, 22 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Helmet shell
+    ctx.fillStyle = "#1a2a4a";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY - 20 * s, 34 * s, 22 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = "#132040";
+    ctx.beginPath();
+    ctx.arc(cx, faceY - 24 * s, 26 * s, Math.PI, 0);
+    ctx.fill();
+
+    // Helmet rim
+    ctx.fillStyle = "#0e1830";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY - 14 * s, 32 * s, 6 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Visor (gold-tinted)
+    ctx.fillStyle = "rgba(200, 170, 60, 0.35)";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY - 4 * s, 24 * s, 10 * s, 0, 0, Math.PI);
+    ctx.fill();
+    ctx.strokeStyle = "rgba(200, 170, 60, 0.5)";
+    ctx.lineWidth = 1 * s;
+    ctx.stroke();
+
+    // Eyes (visible through visor) - blinking
+    const blinkCycle = elapsed % 4;
+    const isBlinking = blinkCycle > 3.8;
+    const eyeY = faceY - 2 * s;
+    const eyeSpacing = 12 * s;
+
+    if (isBlinking) {
+      ctx.strokeStyle = "#3a2a1a";
+      ctx.lineWidth = 2 * s;
+      ctx.beginPath();
+      ctx.moveTo(cx - eyeSpacing - 5 * s, eyeY);
+      ctx.lineTo(cx - eyeSpacing + 5 * s, eyeY);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(cx + eyeSpacing - 5 * s, eyeY);
+      ctx.lineTo(cx + eyeSpacing + 5 * s, eyeY);
+      ctx.stroke();
+    } else {
+      ctx.fillStyle = "#f0e8d8";
+      ctx.beginPath();
+      ctx.ellipse(cx - eyeSpacing, eyeY, 5 * s, 4 * s, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.ellipse(cx + eyeSpacing, eyeY, 5 * s, 4 * s, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = "#1a3a6a";
+      ctx.beginPath();
+      ctx.arc(cx - eyeSpacing + 1 * s, eyeY, 2.5 * s, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(cx + eyeSpacing + 1 * s, eyeY, 2.5 * s, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Eyebrows
+    ctx.strokeStyle = "#4a3a2a";
+    ctx.lineWidth = 2 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx - eyeSpacing - 6 * s, eyeY - 7 * s);
+    ctx.lineTo(cx - eyeSpacing + 4 * s, eyeY - 5.5 * s);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(cx + eyeSpacing + 6 * s, eyeY - 7 * s);
+    ctx.lineTo(cx + eyeSpacing - 4 * s, eyeY - 5.5 * s);
+    ctx.stroke();
+
+    // Oxygen mask outline
+    ctx.strokeStyle = "#0e1830";
+    ctx.lineWidth = 2 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx - 10 * s, faceY + 8 * s);
+    ctx.quadraticCurveTo(cx, faceY + 26 * s, cx + 10 * s, faceY + 8 * s);
+    ctx.stroke();
+
+    // Nose
+    ctx.strokeStyle = "#b88a5a";
+    ctx.lineWidth = 1.5 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx, eyeY + 4 * s);
+    ctx.lineTo(cx - 2 * s, eyeY + 12 * s);
+    ctx.lineTo(cx + 2 * s, eyeY + 12 * s);
+    ctx.stroke();
+
+    // Mouth
+    ctx.strokeStyle = "#8a5a3a";
+    ctx.lineWidth = 1.5 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx - 8 * s, faceY + 17 * s);
+    ctx.quadraticCurveTo(cx, faceY + 15 * s, cx + 8 * s, faceY + 17 * s);
+    ctx.stroke();
+
+    // R-1 badge on chest
+    const badgeY = shoulderY + 8 * s;
+    ctx.fillStyle = "#b89a4a";
+    ctx.beginPath();
+    ctx.roundRect(cx - 10 * s, badgeY, 20 * s, 10 * s, 2);
+    ctx.fill();
+    ctx.fillStyle = "#0e1830";
+    ctx.font = `bold ${6 * s}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("R-1", cx, badgeY + 5 * s);
+
+    ctx.restore();
+  }
+}

--- a/src/games/raptor/rendering/StoryRenderer.ts
+++ b/src/games/raptor/rendering/StoryRenderer.ts
@@ -1,3 +1,8 @@
+import { SpeakerType } from "../types";
+import { PilotPortrait } from "./PilotPortrait";
+import { WingmanPortrait } from "./WingmanPortrait";
+import { HQPortrait } from "./HQPortrait";
+
 type StoryPosition = "top" | "center" | "bottom";
 
 type StoryRendererState =
@@ -27,6 +32,48 @@ const TOP_POSITION_Y = 52;
 const BOTTOM_POSITION_MARGIN = 16;
 const QUICK_PADDING_Y = 10;
 
+const PORTRAIT_SIZE_FULL = 100;
+const PORTRAIT_SIZE_QUICK = 48;
+const PORTRAIT_MARGIN = 14;
+const SMALL_CANVAS_THRESHOLD = 500;
+
+const SPEAKER_LABELS: Record<SpeakerType, string> = {
+  pilot: "RAPTOR-1",
+  wingman: "WINGMAN",
+  hq: "HQ COMMAND",
+  sensor: "HQ COMMAND",
+};
+
+export function detectSpeaker(text: string): SpeakerType {
+  if (text.startsWith("Wingman:")) return "wingman";
+  if (text.startsWith("HQ:")) return "hq";
+  if (text.startsWith("Sensor:")) return "sensor";
+  return "pilot";
+}
+
+function renderPortraitForSpeaker(
+  ctx: CanvasRenderingContext2D,
+  speaker: SpeakerType,
+  x: number,
+  y: number,
+  size: number,
+  elapsed: number
+): void {
+  switch (speaker) {
+    case "wingman":
+      WingmanPortrait.render(ctx, x, y, size, elapsed);
+      break;
+    case "hq":
+    case "sensor":
+      HQPortrait.render(ctx, x, y, size, elapsed);
+      break;
+    case "pilot":
+    default:
+      PilotPortrait.render(ctx, x, y, size, elapsed);
+      break;
+  }
+}
+
 export class StoryRenderer {
   private state: StoryRendererState = "idle";
   private messages: string[] = [];
@@ -42,6 +89,8 @@ export class StoryRenderer {
   private quickTimer = 0;
   private completed = false;
   private blinkTimer = 0;
+  private elapsed = 0;
+  private speaker: SpeakerType = "pilot";
 
   private measureCtx: CanvasRenderingContext2D;
 
@@ -50,7 +99,7 @@ export class StoryRenderer {
     this.measureCtx = canvas.getContext("2d")!;
   }
 
-  show(messages: string[], position: StoryPosition = "center"): void {
+  show(messages: string[], position: StoryPosition = "center", speaker?: SpeakerType): void {
     if (messages.length === 0) return;
 
     this.messages = [...messages];
@@ -58,13 +107,16 @@ export class StoryRenderer {
     this.position = position;
     this.isQuickMessage = false;
     this.completed = false;
+    this.speaker = speaker ?? "pilot";
+    this.elapsed = 0;
     this.beginMessage(this.messages[0]);
   }
 
   showQuick(
     message: string,
     duration: number = DEFAULT_QUICK_DURATION,
-    position: StoryPosition = "top"
+    position: StoryPosition = "top",
+    speaker?: SpeakerType
   ): void {
     if (this.state !== "idle" && !this.isQuickMessage) return;
 
@@ -74,6 +126,8 @@ export class StoryRenderer {
     this.isQuickMessage = true;
     this.quickTimer = duration;
     this.completed = false;
+    this.speaker = speaker ?? detectSpeaker(message);
+    this.elapsed = 0;
     this.beginMessage(message);
   }
 
@@ -81,9 +135,6 @@ export class StoryRenderer {
     if (this.state === "typing") {
       this.revealedChars = this.totalChars;
       this.state = "waiting";
-      if (this.isQuickMessage) {
-        // quick messages don't wait — timer handles dismissal
-      }
       return true;
     }
 
@@ -97,6 +148,10 @@ export class StoryRenderer {
   }
 
   update(dt: number): void {
+    if (this.state !== "idle") {
+      this.elapsed += dt;
+    }
+
     switch (this.state) {
       case "fade_in":
         this.fadeProgress += dt / this.fadeDuration;
@@ -110,11 +165,7 @@ export class StoryRenderer {
         this.revealedChars += this.charsPerSecond * dt;
         if (this.revealedChars >= this.totalChars) {
           this.revealedChars = this.totalChars;
-          if (this.isQuickMessage) {
-            this.state = "waiting";
-          } else {
-            this.state = "waiting";
-          }
+          this.state = "waiting";
         }
         break;
 
@@ -149,20 +200,48 @@ export class StoryRenderer {
     ctx.save();
     ctx.globalAlpha = Math.max(0, Math.min(1, this.fadeProgress));
 
+    const isSmall = width < SMALL_CANVAS_THRESHOLD;
+    const portraitVisible = !isSmall;
+    const portraitSize = this.isQuickMessage ? PORTRAIT_SIZE_QUICK : PORTRAIT_SIZE_FULL;
+    const portraitAreaW = portraitVisible ? portraitSize + PORTRAIT_MARGIN * 2 : 0;
+
     const paddingY = this.isQuickMessage ? QUICK_PADDING_Y : PANEL_PADDING_Y;
-    const panelW = Math.min(width - PANEL_MARGIN * 2, PANEL_MAX_WIDTH);
-    const panelH = paddingY * 2 + this.wrappedLines.length * LINE_HEIGHT;
-    const panelX = (width - panelW) / 2;
+    const textPanelW = Math.min(width - PANEL_MARGIN * 2, PANEL_MAX_WIDTH);
+    const totalPanelW = textPanelW + portraitAreaW;
+    const textContentH = paddingY * 2 + this.wrappedLines.length * LINE_HEIGHT;
+
+    let minPortraitH = 0;
+    if (portraitVisible) {
+      const portraitContentH = portraitSize * 1.2 + (this.isQuickMessage ? 0 : 22);
+      minPortraitH = portraitContentH + paddingY * 2;
+    }
+    const panelH = Math.max(textContentH, minPortraitH);
+
+    const panelX = (width - totalPanelW) / 2;
     const panelY = this.computePanelY(height, panelH);
 
-    this.renderPanel(ctx, panelX, panelY, panelW, panelH);
-    this.renderText(ctx, panelX, panelY, paddingY);
+    this.renderPanel(ctx, panelX, panelY, totalPanelW, panelH);
 
-    if (
-      this.state === "waiting" &&
-      !this.isQuickMessage
-    ) {
-      this.renderPromptIndicator(ctx, panelX, panelY, panelW, panelH);
+    if (portraitVisible) {
+      const portraitX = panelX + PORTRAIT_MARGIN;
+      const portraitY = panelY + paddingY;
+      renderPortraitForSpeaker(ctx, this.speaker, portraitX, portraitY, portraitSize, this.elapsed);
+
+      if (!this.isQuickMessage) {
+        const label = SPEAKER_LABELS[this.speaker] || "RAPTOR-1";
+        ctx.font = `bold ${7}px ${RETRO_FONT}`;
+        ctx.fillStyle = this.getSpeakerLabelColor();
+        ctx.textAlign = "center";
+        ctx.textBaseline = "top";
+        ctx.fillText(label, portraitX + portraitSize / 2, portraitY + portraitSize * 1.2 + 10);
+      }
+    }
+
+    const textX = panelX + portraitAreaW;
+    this.renderText(ctx, textX, panelY, paddingY);
+
+    if (this.state === "waiting" && !this.isQuickMessage) {
+      this.renderPromptIndicator(ctx, panelX, panelY, totalPanelW, panelH);
     }
 
     ctx.restore();
@@ -174,6 +253,19 @@ export class StoryRenderer {
 
   get isComplete(): boolean {
     return this.completed;
+  }
+
+  private getSpeakerLabelColor(): string {
+    switch (this.speaker) {
+      case "wingman":
+        return "rgba(80, 180, 100, 0.8)";
+      case "hq":
+      case "sensor":
+        return "rgba(220, 180, 60, 0.8)";
+      case "pilot":
+      default:
+        return "rgba(80, 130, 220, 0.8)";
+    }
   }
 
   private beginMessage(message: string): void {

--- a/src/games/raptor/rendering/WingmanPortrait.ts
+++ b/src/games/raptor/rendering/WingmanPortrait.ts
@@ -1,0 +1,203 @@
+export class WingmanPortrait {
+  static render(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    size: number,
+    elapsed: number
+  ): void {
+    const s = size / 100;
+    const cx = x + size / 2;
+
+    ctx.save();
+
+    const frameX = x - 4;
+    const frameY = y - 4;
+    const frameW = size + 8;
+    const frameH = size * 1.2 + 8;
+
+    ctx.strokeStyle = "rgba(80, 180, 100, 0.7)";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    ctx.roundRect(frameX, frameY, frameW, frameH, 6);
+    ctx.stroke();
+
+    ctx.strokeStyle = "rgba(50, 140, 70, 0.4)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.roundRect(frameX - 2, frameY - 2, frameW + 4, frameH + 4, 8);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.roundRect(x, y, size, size * 1.2, 4);
+    ctx.clip();
+
+    ctx.fillStyle = "#121e12";
+    ctx.fillRect(x, y, size, size * 1.2);
+
+    // Shoulders / flight suit
+    const shoulderY = y + 85 * s;
+    ctx.fillStyle = "#2a3a2a";
+    ctx.beginPath();
+    ctx.ellipse(cx, shoulderY + 20 * s, 45 * s, 25 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Collar
+    ctx.fillStyle = "#223022";
+    ctx.beginPath();
+    ctx.moveTo(cx - 15 * s, shoulderY);
+    ctx.lineTo(cx + 15 * s, shoulderY);
+    ctx.lineTo(cx + 10 * s, shoulderY + 15 * s);
+    ctx.lineTo(cx - 10 * s, shoulderY + 15 * s);
+    ctx.closePath();
+    ctx.fill();
+
+    // Shoulder patches
+    ctx.fillStyle = "#7a9a5a";
+    ctx.beginPath();
+    ctx.roundRect(x + 5 * s, shoulderY + 2 * s, 14 * s, 6 * s, 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.roundRect(x + 81 * s, shoulderY + 2 * s, 14 * s, 6 * s, 2);
+    ctx.fill();
+
+    // Neck
+    ctx.fillStyle = "#c49464";
+    ctx.beginPath();
+    ctx.ellipse(cx, shoulderY - 2 * s, 10 * s, 12 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Face
+    const faceY = y + 42 * s;
+    ctx.fillStyle = "#c49464";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY, 28 * s, 32 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Jaw (slightly wider/rounder than pilot)
+    ctx.fillStyle = "#b08454";
+    ctx.beginPath();
+    ctx.moveTo(cx - 24 * s, faceY + 8 * s);
+    ctx.lineTo(cx, faceY + 30 * s);
+    ctx.lineTo(cx + 24 * s, faceY + 8 * s);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = "#c49464";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY + 5 * s, 26 * s, 22 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Helmet shell (dark green)
+    ctx.fillStyle = "#2a3a2a";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY - 20 * s, 34 * s, 22 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = "#223022";
+    ctx.beginPath();
+    ctx.arc(cx, faceY - 24 * s, 26 * s, Math.PI, 0);
+    ctx.fill();
+
+    // Helmet rim
+    ctx.fillStyle = "#1a281a";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY - 14 * s, 32 * s, 6 * s, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Visor (green-tinted)
+    ctx.fillStyle = "rgba(80, 200, 100, 0.3)";
+    ctx.beginPath();
+    ctx.ellipse(cx, faceY - 4 * s, 24 * s, 10 * s, 0, 0, Math.PI);
+    ctx.fill();
+    ctx.strokeStyle = "rgba(80, 200, 100, 0.45)";
+    ctx.lineWidth = 1 * s;
+    ctx.stroke();
+
+    // Eyes - blinking
+    const blinkCycle = elapsed % 4;
+    const isBlinking = blinkCycle > 3.8;
+    const eyeY = faceY - 2 * s;
+    const eyeSpacing = 12 * s;
+
+    if (isBlinking) {
+      ctx.strokeStyle = "#3a2a1a";
+      ctx.lineWidth = 2 * s;
+      ctx.beginPath();
+      ctx.moveTo(cx - eyeSpacing - 5 * s, eyeY);
+      ctx.lineTo(cx - eyeSpacing + 5 * s, eyeY);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(cx + eyeSpacing - 5 * s, eyeY);
+      ctx.lineTo(cx + eyeSpacing + 5 * s, eyeY);
+      ctx.stroke();
+    } else {
+      ctx.fillStyle = "#f0e8d8";
+      ctx.beginPath();
+      ctx.ellipse(cx - eyeSpacing, eyeY, 5 * s, 4 * s, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.ellipse(cx + eyeSpacing, eyeY, 5 * s, 4 * s, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = "#2a4a1a";
+      ctx.beginPath();
+      ctx.arc(cx - eyeSpacing + 1 * s, eyeY, 2.5 * s, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(cx + eyeSpacing + 1 * s, eyeY, 2.5 * s, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Eyebrows (slightly more relaxed than pilot)
+    ctx.strokeStyle = "#3a2a1a";
+    ctx.lineWidth = 2.2 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx - eyeSpacing - 6 * s, eyeY - 6.5 * s);
+    ctx.lineTo(cx - eyeSpacing + 4 * s, eyeY - 5.5 * s);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(cx + eyeSpacing + 6 * s, eyeY - 6.5 * s);
+    ctx.lineTo(cx + eyeSpacing - 4 * s, eyeY - 5.5 * s);
+    ctx.stroke();
+
+    // Oxygen mask outline
+    ctx.strokeStyle = "#1a281a";
+    ctx.lineWidth = 2 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx - 10 * s, faceY + 8 * s);
+    ctx.quadraticCurveTo(cx, faceY + 26 * s, cx + 10 * s, faceY + 8 * s);
+    ctx.stroke();
+
+    // Nose
+    ctx.strokeStyle = "#a07a4a";
+    ctx.lineWidth = 1.5 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx, eyeY + 4 * s);
+    ctx.lineTo(cx - 3 * s, eyeY + 12 * s);
+    ctx.lineTo(cx + 3 * s, eyeY + 12 * s);
+    ctx.stroke();
+
+    // Mouth (slight grin)
+    ctx.strokeStyle = "#7a4a2a";
+    ctx.lineWidth = 1.5 * s;
+    ctx.beginPath();
+    ctx.moveTo(cx - 9 * s, faceY + 16 * s);
+    ctx.quadraticCurveTo(cx, faceY + 19 * s, cx + 9 * s, faceY + 16 * s);
+    ctx.stroke();
+
+    // W-2 badge on chest
+    const badgeY = shoulderY + 8 * s;
+    ctx.fillStyle = "#7a9a5a";
+    ctx.beginPath();
+    ctx.roundRect(cx - 10 * s, badgeY, 20 * s, 10 * s, 2);
+    ctx.fill();
+    ctx.fillStyle = "#1a281a";
+    ctx.font = `bold ${6 * s}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("W-2", cx, badgeY + 5 * s);
+
+    ctx.restore();
+  }
+}

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -384,6 +384,8 @@ export interface TerrainLayerConfig {
   litStructures?: string[];
 }
 
+export type SpeakerType = "pilot" | "wingman" | "hq" | "sensor";
+
 export interface InGameStoryMessage {
   /** When to show this message (in seconds from level start) */
   triggerTime: number;
@@ -391,6 +393,8 @@ export interface InGameStoryMessage {
   text: string;
   /** How long to display the message in seconds (default: 3) */
   duration?: number;
+  /** Which character portrait to show (auto-detected from text prefix if omitted) */
+  speaker?: SpeakerType;
 }
 
 export interface LevelStoryConfig {


### PR DESCRIPTION
## PR: Add character face portraits for Wingman + Player in Raptor dialogue (Issue #537)

### Summary / Why
Raptor’s story + in-game dialogue previously rendered as text-only, which made it harder to quickly identify who’s speaking and gave the UI a flatter feel. This PR adds **procedurally-rendered** character portraits (no new image assets) so both the **player pilot (Raptor‑1)** and **wingman** have a visible “face” in dialogue, following the proven portrait pattern used in Archer.

### What changed
- Added **three new procedural canvas portraits**:
  - **PilotPortrait**: helmeted pilot w/ gold visor, blue frame, “R-1” badge
  - **WingmanPortrait**: visually distinct pilot gear w/ green tint, green frame, “W-2” badge
  - **HQPortrait**: comms/radar-style portrait/icon with animated sweep, amber frame
- Introduced a `SpeakerType` and optional `speaker` field on `InGameStoryMessage`.
- Implemented **speaker auto-detection** from message prefixes as a backward-compatible fallback:
  - `"Wingman:"` → wingman
  - `"HQ:"` → hq
  - `"Sensor:"` → sensor
  - default → pilot
- Updated Raptor `StoryRenderer` to:
  - Render portraits alongside dialogue panels
  - Show **large portraits** for full story sequences (~100px)
  - Show **compact portraits** for quick in-game messages (~48px)
  - Include **name plates** and subtle **blink/idle animation**
  - **Hide portraits on small screens** (< 500px width) and revert to text-only layout

### Key files modified / added
**New**
- `src/games/raptor/rendering/PilotPortrait.ts`
- `src/games/raptor/rendering/WingmanPortrait.ts`
- `src/games/raptor/rendering/HQPortrait.ts`

**Modified**
- `src/games/raptor/rendering/StoryRenderer.ts`  
  Portrait selection + rendering, layout changes, name plates, small-screen fallback
- `src/games/raptor/types.ts`  
  Adds `SpeakerType` + `speaker?: SpeakerType` on `InGameStoryMessage`
- `src/games/raptor/RaptorGame.ts`  
  Passes speaker info into story/quick message rendering where available
- `src/games/raptor/levels.ts`  
  Optional speaker annotations (auto-detection remains the default/back-compat path)

### Testing notes
- **Unit:** Speaker detection logic (prefix-based fallback) and portrait render callability/signature.
- **Integration:** Verified `StoryRenderer` chooses the correct portrait for:
  - Full story sequences (defaults to pilot)
  - Quick messages based on explicit `speaker` and/or prefix detection
- **Visual QA (manual):**
  - Checked portrait placement, sizing (story vs quick), name plates, and blink/idle animation
  - Confirmed **portraits are hidden under 500px width** and text panel expands as expected

Closes: **#537**

Ref: https://github.com/asgardtech/archer/issues/537