### PR TITLE
the icons for the weapons should look like the weapon, and be larger

### DIFF
--- a/src/games/archer/ArcherGame.ts
+++ b/src/games/archer/ArcherGame.ts
@@ -158,6 +158,13 @@ export class ArcherGame implements IGame {
       if (img) bowSprites.set(key, img);
     }
     this.bow.setSprites(bowSprites);
+
+    const upgradeIcons = new Map<string, HTMLImageElement>();
+    for (const [upgradeType, assetKey] of Object.entries(UPGRADE_ICON_KEYS)) {
+      const img = this.assetLoader.getOptional(assetKey);
+      if (img) upgradeIcons.set(upgradeType, img);
+    }
+    this.hud.setUpgradeIcons(upgradeIcons);
   }
 
   private getArrowSprite(piercing: boolean): HTMLImageElement | null {

--- a/src/games/archer/entities/Balloon.ts
+++ b/src/games/archer/entities/Balloon.ts
@@ -211,7 +211,7 @@ export class Balloon {
 
     if (this.upgradeType) {
       if (this.upgradeIcon) {
-        const iconSize = r * 0.8;
+        const iconSize = r * 1.1;
         ctx.drawImage(this.upgradeIcon, -iconSize / 2, -iconSize / 2, iconSize, iconSize);
       } else {
         ctx.fillStyle = "#333";

--- a/src/games/archer/rendering/HUD.ts
+++ b/src/games/archer/rendering/HUD.ts
@@ -30,9 +30,14 @@ const MUTE_BTN_MARGIN = 12;
 export class HUD {
   private ammoGainTexts: AmmoGainText[] = [];
   private penaltyTexts: PenaltyText[] = [];
+  private upgradeIcons: Map<string, HTMLImageElement> = new Map();
   public loadingProgress = 0;
 
   constructor(private isTouchDevice = false) {}
+
+  setUpgradeIcons(icons: Map<string, HTMLImageElement>): void {
+    this.upgradeIcons = icons;
+  }
 
   showAmmoGain(amount: number): void {
     this.ammoGainTexts.push({
@@ -217,21 +222,43 @@ export class HUD {
 
     ctx.textAlign = "left";
     let yOffset = 55;
+    const iconSize = 28;
+    const rowHeight = 36;
     for (const upgrade of activeUpgrades) {
       const info = UPGRADE_DISPLAY[upgrade.type];
       if (!info) continue;
 
       const isPerm = permanentUpgrades.has(upgrade.type);
-      const prefix = isPerm ? "★ " : "";
+      let xCursor = 16;
 
-      ctx.font = "bold 15px sans-serif";
+      if (isPerm) {
+        ctx.font = "bold 18px sans-serif";
+        ctx.fillStyle = "#FFD700";
+        ctx.textBaseline = "middle";
+        ctx.fillText("★", xCursor, yOffset + iconSize / 2);
+        xCursor += 18;
+      }
+
+      const iconImg = this.upgradeIcons.get(upgrade.type);
+      if (iconImg) {
+        ctx.drawImage(iconImg, xCursor, yOffset, iconSize, iconSize);
+      } else {
+        ctx.font = "bold 20px sans-serif";
+        ctx.fillStyle = info.color;
+        ctx.textBaseline = "middle";
+        ctx.fillText(info.icon, xCursor, yOffset + iconSize / 2);
+      }
+      xCursor += iconSize + 6;
+
+      ctx.font = "bold 14px sans-serif";
       ctx.fillStyle = info.color;
-      ctx.fillText(`${prefix}${info.icon} ${info.label} ${upgrade.remainingTime.toFixed(1)}s`, 16, yOffset);
+      ctx.textBaseline = "middle";
+      ctx.fillText(`${info.label} ${upgrade.remainingTime.toFixed(1)}s`, xCursor, yOffset + iconSize / 2);
 
       const barX = 16;
-      const barW = 120;
+      const barW = 140;
       const barH = 4;
-      const barY = yOffset + 5;
+      const barY = yOffset + iconSize + 2;
 
       if (isPerm) {
         ctx.strokeStyle = "#FFD700";
@@ -247,7 +274,7 @@ export class HUD {
       ctx.fillStyle = info.color;
       ctx.fillRect(barX, barY, barW * fillRatio, barH);
 
-      yOffset += 26;
+      yOffset += rowHeight;
     }
 
     ctx.textAlign = "right";
@@ -318,6 +345,7 @@ export class HUD {
 
     let progressY = h / 2 + 80;
     let hasProgress = false;
+    const lcIconSize = 20;
     for (const { type, label } of upgradeTypes) {
       const count = collectionCounts.get(type) ?? 0;
       if (count === 0) continue;
@@ -327,10 +355,24 @@ export class HUD {
         i < count ? "●" : "○"
       ).join("");
 
+      const text = `${label} ${dots}`;
       ctx.font = "16px sans-serif";
+      const textWidth = ctx.measureText(text).width;
+
+      const iconImg = this.upgradeIcons.get(type);
+      const totalWidth = iconImg ? lcIconSize + 6 + textWidth : textWidth;
+      const startX = w / 2 - totalWidth / 2;
+
+      if (iconImg) {
+        ctx.drawImage(iconImg, startX, progressY - lcIconSize / 2, lcIconSize, lcIconSize);
+      }
+
+      ctx.textAlign = "left";
       ctx.fillStyle = "rgba(255,255,255,0.8)";
-      ctx.fillText(`${label} ${dots}`, w / 2, progressY);
-      progressY += 22;
+      ctx.fillText(text, iconImg ? startX + lcIconSize + 6 : startX, progressY);
+      ctx.textAlign = "center";
+
+      progressY += 26;
     }
 
     ctx.fillStyle = "rgba(255,255,255,0.7)";


### PR DESCRIPTION
## PR: Use weapon PNG sprites for upgrade icons + increase icon sizes (Fixes #539)

### Summary / Why
Weapon/upgrade indicators in the Balloon Archer HUD were using small Unicode glyphs (`⫸`, `➤`, `⚡`) at ~15px, which were hard to recognize quickly during play. This PR switches those HUD indicators to the existing weapon-specific PNG assets and increases icon sizing across the HUD and upgrade balloons so players can identify upgrades at a glance. It also enhances the level-complete screen by showing the same icons alongside upgrade collection progress.

### What changed
- **HUD active upgrades**
  - Replaced Unicode text glyphs with existing **powerup PNG sprites** for:
    - multi-shot (`powerup_multishot.png`)
    - piercing (`powerup_piercing.png`)
    - rapid-fire (`powerup_rapidfire.png`)
  - Increased icon size to **28×28px**
  - Increased HUD upgrade row height from **26px → 36px** to prevent crowding and improve readability
  - Preserved a **fallback to Unicode icons** if images are unavailable
  - Ensured the **permanent upgrade star (★)** renders to the left of the icon without overlapping

- **Upgrade balloons**
  - Increased the rendered powerup icon size on upgrade balloons from **`r * 0.8` → `r * 1.1`** to make the upgrade type clearer before popping

- **Level complete screen**
  - Added **20×20px** powerup icons inline next to the collection progress dots for each upgrade type

### Key files modified
- `src/games/archer/rendering/HUD.ts`
  - Added `setUpgradeIcons()` and updated HUD rendering to use `ctx.drawImage()` for upgrade indicators
  - Updated layout/sizing for larger icons and added icons to the level-complete progress rows
- `src/games/archer/ArcherGame.ts`
  - Wires loaded powerup images from the asset pipeline into the HUD via `setUpgradeIcons()`
- `src/games/archer/entities/Balloon.ts`
  - Increased upgrade icon rendering size on upgrade balloons (`r * 1.1`)

### Testing notes
- Manual verification:
  - Collect each upgrade (multi-shot, piercing, rapid-fire) and confirm the HUD shows the correct **PNG icon**, label, timer, and progress bar
  - Activate multiple upgrades simultaneously and confirm rows **stack without overlap**
  - Make an upgrade permanent and confirm **★** appears to the left of the icon cleanly
  - Confirm upgrade balloons show a **larger, clearly visible** upgrade icon
  - Complete a level and verify the level-complete screen displays **20×20px icons** next to upgrade collection dots
  - (Optional) simulate missing/failed asset loads and confirm HUD falls back to the prior Unicode glyphs without breaking rendering

Ref: https://github.com/asgardtech/archer/issues/539