### PR TITLE
the text at the beginning and end of the game should be displayed all at once, not in separate screens

### DIFF
--- a/src/games/archer/ArcherGame.ts
+++ b/src/games/archer/ArcherGame.ts
@@ -246,7 +246,12 @@ export class ArcherGame implements IGame {
           this.audio.ensureContext();
           this.sound.play("menu_start");
           this.resetGame();
-          this.storyRenderer.show(ARCHER_STORY.opening);
+          const menuConfig = this.currentLevelConfig;
+          this.storyRenderer.show(ARCHER_STORY.opening, {
+            heading: `Level ${menuConfig.level} \u2014 ${menuConfig.name}`,
+            subheading: menuConfig.landmark.label,
+            detail: menuConfig.landmark.description,
+          });
           this.state = "story_intro";
         }
         break;
@@ -254,9 +259,11 @@ export class ArcherGame implements IGame {
       case "story_intro":
         this.storyRenderer.update(dt);
         if (this.storyRenderer.isComplete) {
-          this.state = "level_intro";
+          this.state = "playing";
+          this.sound.startMusic("playing", this.currentLevel);
         } else if (this.input.wasEscPressed) {
-          this.state = "level_intro";
+          this.state = "playing";
+          this.sound.startMusic("playing", this.currentLevel);
         } else if (this.input.wasClicked) {
           this.storyRenderer.advance();
         }
@@ -305,6 +312,28 @@ export class ArcherGame implements IGame {
           } else {
             this.state = "menu";
           }
+        }
+        break;
+
+      case "story_ending":
+        this.storyRenderer.update(dt);
+        if (this.landmark) this.landmark.update(dt);
+        if (this.storyRenderer.isComplete) {
+          this.sound.stopMusic();
+          if (this.onExit) {
+            this.onExit();
+          } else {
+            this.state = "menu";
+          }
+        } else if (this.input.wasEscPressed) {
+          this.sound.stopMusic();
+          if (this.onExit) {
+            this.onExit();
+          } else {
+            this.state = "menu";
+          }
+        } else if (this.input.wasClicked) {
+          this.storyRenderer.advance();
         }
         break;
     }
@@ -483,8 +512,12 @@ export class ArcherGame implements IGame {
       this.sound.stopMusic();
       this.sound.play("landmark_liberated");
       if (this.currentLevel >= LEVELS.length - 1) {
-        this.state = "victory";
+        this.state = "story_ending";
         this.sound.play("victory");
+        this.storyRenderer.show(ARCHER_STORY.ending, {
+          heading: "Victory!",
+          score: this.totalScore,
+        });
       } else {
         this.state = "level_complete";
         this.sound.play("level_complete");
@@ -533,7 +566,12 @@ export class ArcherGame implements IGame {
   private render(): void {
     this.renderSky();
 
-    if (this.state === "story_intro") {
+    if (this.state === "story_intro" || this.state === "story_ending") {
+      if (this.state === "story_ending") {
+        const endConfig = this.currentLevelConfig;
+        TerrainRenderer.render(this.ctx, this.width, this.height, endConfig.terrain);
+        if (this.landmark) this.landmark.render(this.ctx);
+      }
       this.storyRenderer.render(this.ctx, this.width, this.height);
       this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
       return;

--- a/src/games/archer/rendering/HUD.ts
+++ b/src/games/archer/rendering/HUD.ts
@@ -118,6 +118,7 @@ export class HUD {
         this.renderMenu(ctx, canvasW, canvasH);
         break;
       case "story_intro":
+      case "story_ending":
         break;
       case "level_intro":
         this.renderLevelIntro(ctx, level, levelName, landmarkLabel, landmarkDescription, canvasW, canvasH);

--- a/src/games/archer/rendering/StoryRenderer.ts
+++ b/src/games/archer/rendering/StoryRenderer.ts
@@ -1,5 +1,12 @@
 import { GeneralPortrait } from "./GeneralPortrait";
 
+export interface StoryFooter {
+  heading: string;
+  subheading?: string;
+  detail?: string;
+  score?: number;
+}
+
 type StoryRendererState = "idle" | "fade_in" | "typing" | "waiting" | "fade_out";
 
 const FONT_FAMILY = "sans-serif";
@@ -23,6 +30,12 @@ const PANEL_BORDER_COLOR = "rgba(180, 150, 80, 0.4)";
 const TEXT_COLOR = "#e8dcc8";
 const TITLE_COLOR = "#b89a4a";
 
+const FOOTER_HEADING_SIZE = 24;
+const FOOTER_SUBHEADING_SIZE = 18;
+const FOOTER_DETAIL_SIZE = 16;
+const FOOTER_SCORE_SIZE = 28;
+const FOOTER_DIVIDER_GAP = 18;
+
 export class StoryRenderer {
   private state: StoryRendererState = "idle";
   private lines: string[] = [];
@@ -35,6 +48,8 @@ export class StoryRenderer {
   private completed = false;
   private isTouchDevice: boolean;
   private measureCtx: CanvasRenderingContext2D;
+  private footer: StoryFooter | undefined;
+  private footerFadeProgress = 0;
 
   constructor(isTouchDevice = false) {
     this.isTouchDevice = isTouchDevice;
@@ -42,7 +57,7 @@ export class StoryRenderer {
     this.measureCtx = canvas.getContext("2d")!;
   }
 
-  show(lines: string[]): void {
+  show(lines: string[], footer?: StoryFooter): void {
     if (lines.length === 0) return;
     this.lines = [...lines];
     this.wrappedLines = [];
@@ -52,6 +67,8 @@ export class StoryRenderer {
     this.blinkTimer = 0;
     this.elapsed = 0;
     this.completed = false;
+    this.footer = footer;
+    this.footerFadeProgress = 0;
     this.state = "fade_in";
   }
 
@@ -87,6 +104,9 @@ export class StoryRenderer {
 
       case "waiting":
         this.blinkTimer += dt;
+        if (this.footer && this.footerFadeProgress < 1) {
+          this.footerFadeProgress = Math.min(1, this.footerFadeProgress + dt / FADE_DURATION);
+        }
         break;
 
       case "fade_out":
@@ -100,17 +120,29 @@ export class StoryRenderer {
     }
   }
 
+  private computeFooterHeight(isSmall: boolean): number {
+    if (!this.footer) return 0;
+    let h = FOOTER_DIVIDER_GAP;
+    h += FOOTER_HEADING_SIZE + 8;
+    if (this.footer.subheading) h += (isSmall ? FOOTER_SUBHEADING_SIZE - 2 : FOOTER_SUBHEADING_SIZE) + 6;
+    if (this.footer.detail) h += (isSmall ? FOOTER_DETAIL_SIZE - 2 : FOOTER_DETAIL_SIZE) + 6;
+    if (this.footer.score != null) h += FOOTER_SCORE_SIZE + 6;
+    return h;
+  }
+
   render(ctx: CanvasRenderingContext2D, canvasW: number, canvasH: number): void {
     if (this.state === "idle") return;
-
-    const panelW = Math.min(canvasW * PANEL_WIDTH_RATIO, 680);
-    const panelH = Math.min(canvasH * PANEL_HEIGHT_RATIO, 420);
-    const panelX = (canvasW - panelW) / 2;
-    const panelY = (canvasH - panelH) / 2;
 
     const isSmall = canvasW < SMALL_CANVAS_THRESHOLD;
     const portraitVisible = !isSmall;
     const portraitAreaW = portraitVisible ? PORTRAIT_SIZE + PORTRAIT_MARGIN * 2 : 0;
+
+    const panelW = Math.min(canvasW * PANEL_WIDTH_RATIO, 680);
+    const footerHeight = this.computeFooterHeight(isSmall);
+    const basePanelH = Math.min(canvasH * PANEL_HEIGHT_RATIO, 420);
+    const panelH = Math.min(canvasH * PANEL_HEIGHT_RATIO, basePanelH + footerHeight);
+    const panelX = (canvasW - panelW) / 2;
+    const panelY = (canvasH - panelH) / 2;
 
     const textAreaX = panelX + PANEL_PADDING + portraitAreaW;
     const textAreaW = panelW - PANEL_PADDING * 2 - portraitAreaW;
@@ -123,11 +155,9 @@ export class StoryRenderer {
     ctx.save();
     ctx.globalAlpha = Math.max(0, Math.min(1, this.fadeProgress));
 
-    // Dim overlay
     ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
     ctx.fillRect(0, 0, canvasW, canvasH);
 
-    // Panel background
     const grad = ctx.createLinearGradient(panelX, panelY, panelX, panelY + panelH);
     grad.addColorStop(0, PANEL_BG_TOP);
     grad.addColorStop(1, PANEL_BG_BOTTOM);
@@ -136,27 +166,23 @@ export class StoryRenderer {
     ctx.roundRect(panelX, panelY, panelW, panelH, PANEL_RADIUS);
     ctx.fill();
 
-    // Panel border
     ctx.strokeStyle = PANEL_BORDER_COLOR;
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.roundRect(panelX, panelY, panelW, panelH, PANEL_RADIUS);
     ctx.stroke();
 
-    // Inner glow border
     ctx.strokeStyle = "rgba(180, 150, 80, 0.15)";
     ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.roundRect(panelX + 3, panelY + 3, panelW - 6, panelH - 6, PANEL_RADIUS - 2);
     ctx.stroke();
 
-    // Portrait
     if (portraitVisible) {
       const portraitX = panelX + PORTRAIT_MARGIN;
       const portraitY = panelY + PANEL_PADDING;
       GeneralPortrait.render(ctx, portraitX, portraitY, PORTRAIT_SIZE, this.elapsed);
 
-      // Name plate under portrait
       ctx.font = `bold 11px ${FONT_FAMILY}`;
       ctx.fillStyle = TITLE_COLOR;
       ctx.textAlign = "center";
@@ -164,7 +190,6 @@ export class StoryRenderer {
       ctx.fillText("THE GENERAL", portraitX + PORTRAIT_SIZE / 2, portraitY + PORTRAIT_SIZE * 1.2 + 12);
     }
 
-    // Text with typewriter effect
     ctx.font = `${FONT_SIZE}px ${FONT_FAMILY}`;
     ctx.fillStyle = TEXT_COLOR;
     ctx.textAlign = "left";
@@ -187,7 +212,10 @@ export class StoryRenderer {
       textY += LINE_HEIGHT;
     }
 
-    // "Click/Tap to continue" prompt
+    if (this.footer && this.state === "waiting" && this.footerFadeProgress > 0) {
+      this.renderFooter(ctx, panelX, panelY, panelW, panelH, textAreaX, textAreaW, textY, isSmall);
+    }
+
     if (this.state === "waiting") {
       const cycle = this.blinkTimer % (PROMPT_BLINK_RATE * 2);
       if (cycle < PROMPT_BLINK_RATE) {
@@ -201,6 +229,66 @@ export class StoryRenderer {
     }
 
     ctx.restore();
+  }
+
+  private renderFooter(
+    ctx: CanvasRenderingContext2D,
+    panelX: number,
+    panelY: number,
+    panelW: number,
+    _panelH: number,
+    textAreaX: number,
+    textAreaW: number,
+    textY: number,
+    isSmall: boolean
+  ): void {
+    if (!this.footer) return;
+
+    const prevAlpha = ctx.globalAlpha;
+    ctx.globalAlpha = prevAlpha * this.footerFadeProgress;
+
+    let y = textY + FOOTER_DIVIDER_GAP;
+
+    const dividerX1 = textAreaX;
+    const dividerX2 = textAreaX + textAreaW;
+    ctx.strokeStyle = "rgba(180, 150, 80, 0.3)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(dividerX1, y - FOOTER_DIVIDER_GAP / 2);
+    ctx.lineTo(dividerX2, y - FOOTER_DIVIDER_GAP / 2);
+    ctx.stroke();
+
+    const headingSize = isSmall ? FOOTER_HEADING_SIZE - 2 : FOOTER_HEADING_SIZE;
+    ctx.font = `bold ${headingSize}px ${FONT_FAMILY}`;
+    ctx.fillStyle = TITLE_COLOR;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.fillText(this.footer.heading, panelX + panelW / 2, y);
+    y += headingSize + 8;
+
+    if (this.footer.subheading) {
+      const subSize = isSmall ? FOOTER_SUBHEADING_SIZE - 2 : FOOTER_SUBHEADING_SIZE;
+      ctx.font = `bold ${subSize}px ${FONT_FAMILY}`;
+      ctx.fillStyle = "#f1c40f";
+      ctx.fillText(this.footer.subheading, panelX + panelW / 2, y);
+      y += subSize + 6;
+    }
+
+    if (this.footer.detail) {
+      const detailSize = isSmall ? FOOTER_DETAIL_SIZE - 2 : FOOTER_DETAIL_SIZE;
+      ctx.font = `italic ${detailSize}px ${FONT_FAMILY}`;
+      ctx.fillStyle = "rgba(232, 220, 200, 0.8)";
+      ctx.fillText(this.footer.detail, panelX + panelW / 2, y);
+      y += detailSize + 6;
+    }
+
+    if (this.footer.score != null) {
+      ctx.font = `bold ${FOOTER_SCORE_SIZE}px ${FONT_FAMILY}`;
+      ctx.fillStyle = "#f1c40f";
+      ctx.fillText(`Total Score: ${this.footer.score}`, panelX + panelW / 2, y);
+    }
+
+    ctx.globalAlpha = prevAlpha;
   }
 
   get isComplete(): boolean {

--- a/src/games/archer/story.ts
+++ b/src/games/archer/story.ts
@@ -7,4 +7,11 @@ export const ARCHER_STORY = {
     "The windmill, treehouse, watchtower, lighthouse, and sky castle \u2014 all depend on you.",
     "Good luck, soldier. The realm is counting on you.",
   ],
+  ending: [
+    "Commander, you've done it.",
+    "All five landmarks have been liberated from the balloon menace.",
+    "The Dark Hollows have fallen silent, and peace returns to the realm.",
+    "The people celebrate your name \u2014 the greatest archer the realm has ever known.",
+    "Well done, soldier. The realm is safe once more.",
+  ],
 };

--- a/src/games/archer/types.ts
+++ b/src/games/archer/types.ts
@@ -3,7 +3,7 @@ export interface Vec2 {
   y: number;
 }
 
-export type GameState = "loading" | "menu" | "story_intro" | "level_intro" | "playing" | "level_complete" | "gameover" | "victory";
+export type GameState = "loading" | "menu" | "story_intro" | "level_intro" | "playing" | "level_complete" | "gameover" | "victory" | "story_ending";
 
 export interface EntityBase {
   pos: Vec2;

--- a/tests/landmark-liberation-qa.test.ts
+++ b/tests/landmark-liberation-qa.test.ts
@@ -796,7 +796,7 @@ describe("Feature: Landmark liberation celebration on level complete", () => {
       (gi.input as any).wasClicked = false;
       gi.updatePlaying(0.016);
 
-      expect(gi.state).toBe("victory");
+      expect(gi.state).toBe("story_ending");
       expect(celebrateSpy).toHaveBeenCalled();
 
       randomSpy.mockRestore();

--- a/tests/levels.test.ts
+++ b/tests/levels.test.ts
@@ -508,7 +508,7 @@ describe("Scenario: Completing level 5 shows the victory screen", () => {
     internals.updatePlaying(0.016);
 
     expect(internals.score).toBe(100);
-    expect(internals.state).toBe("victory");
+    expect(internals.state).toBe("story_ending");
     randomSpy.mockRestore();
   });
 });
@@ -964,7 +964,7 @@ describe("Level complete on last level transitions to victory, not level_complet
     (internals.input as any).wasClicked = false;
     internals.updatePlaying(0.016);
 
-    expect(internals.state).toBe("victory");
+    expect(internals.state).toBe("story_ending");
     expect(internals.state).not.toBe("level_complete");
 
     randomSpy.mockRestore();


### PR DESCRIPTION
## PR: Consolidate opening and ending story screens into single panels (Archer)

### Summary (what changed + why)
This PR addresses the issue where Archer’s start/end text was split across multiple click-through screens.

- **Beginning of game:** The opening narrative and **Level 1 intro details** are now shown together on a **single StoryRenderer panel**, so players only dismiss one screen before gameplay starts.
- **End of game (victory):** Added a **closing narrative** and introduced a new **`story_ending`** flow that displays the ending story **alongside final score** on one screen (replacing the bare victory-only HUD screen).
- **Inter-level flow unchanged:** The standalone `level_intro` screen is still used for levels **2–5** (where there’s no story text to merge).

Why: reduces unnecessary clicks and provides narrative closure on victory while keeping existing inter-level UX intact.

---

### Key files modified
- **`src/games/archer/story.ts`**
  - Added `ARCHER_STORY.ending` closing narrative lines.
- **`src/games/archer/rendering/StoryRenderer.ts`**
  - Extended StoryRenderer to support optional **footer metadata** (heading/subheading/detail/score) rendered beneath the story text.
  - Footer appears **after** the typewriter completes (with a fade-in), keeping story pacing intact.
- **`src/games/archer/ArcherGame.ts`**
  - Updated state machine:
    - `menu → story_intro (includes Level 1 info) → playing` (skips `level_intro` for level 1 only)
    - On final level win: transitions to new `story_ending` state and shows ending narrative + total score.
  - Updated rendering path so `story_ending` overlays StoryRenderer on top of the victory backdrop.
- **`src/games/archer/types.ts`**
  - Added `"story_ending"` to `GameState`.
- **Tests (updated expectations)**
  - Updated integration expectations to use `story_ending` instead of `victory` on final level completion.

---

### Behavior notes / UX details
- Footer metadata is **optional**; StoryRenderer behavior is unchanged when no footer is provided.
- **Escape** handling remains consistent:
  - `story_intro`: Escape skips straight into gameplay
  - `story_ending`: Escape exits back to menu/exit (same as clicking through)
- Portrait behavior on small screens remains the same (hidden under narrow widths); footer text remains visible.

---

### Testing notes
- **Updated automated tests** to reflect the new victory flow (`story_ending` replaces `victory` at game completion).
- Manual verification recommended:
  1. Start a new game: confirm a **single** opening panel includes story + “Level 1 — …” + landmark info, then proceeds **directly** to gameplay.
  2. Complete levels 1→2 transition: confirm **Level 2 intro** still appears as a standalone inter-level screen.
  3. Win final level: confirm ending story appears with **Victory + total score** on a single panel and returns to menu on click/Escape.
  4. Check small canvas/mobile widths (<500px): confirm layout fits and footer is readable.

Ref: https://github.com/asgardtech/archer/issues/547