### PR TITLE
Raptor: Add dodge/dash ability with brief invincibility

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -555,6 +555,18 @@ export class RaptorGame implements IGame {
       this.storyRenderer.advance();
     }
 
+    if (this.input.wasClicked
+        && this.hud.isDodgeButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+      this.input.wasDodgePressed = true;
+    }
+
+    if (this.input.wasDodgePressed) {
+      const dodged = this.player.dodge();
+      if (dodged) {
+        this.sound.play("dodge");
+      }
+    }
+
     if (this.input.wasBombPressed && this.player.bombs > 0) {
       this.player.bombs--;
       this.sound.play("mega_bomb_fire");
@@ -877,6 +889,7 @@ export class RaptorGame implements IGame {
     this.powerUps = this.powerUps.filter((p) => p.alive);
 
     this.player.updateShieldRegen(dt);
+    this.player.updateDodge(dt);
 
     if (!this.player.alive) {
       this.totalScore += this.score;
@@ -1378,7 +1391,8 @@ export class RaptorGame implements IGame {
       this.weaponSystem.chargeLevel,
       this.player.bombs,
       this.powerUpManager.weaponTier,
-      this.player.isShieldRegenerating
+      this.player.isShieldRegenerating,
+      this.player.dodgeCooldownFraction
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
     this.hud.renderSettingsButton(this.ctx, this.width);

--- a/src/games/raptor/entities/Player.ts
+++ b/src/games/raptor/entities/Player.ts
@@ -13,6 +13,8 @@ const PANEL_LIGHT_BASE_INTERVAL = 0.5;
 const SHIELD_REGEN_RATE = 2.5;
 const SHIELD_REGEN_DELAY = 4.0;
 const MAX_SHIELD = 100;
+const DODGE_DURATION = 0.3;
+const DODGE_COOLDOWN = 3.0;
 
 export class Player {
   public pos: Vec2;
@@ -26,6 +28,8 @@ export class Player {
   public invincibilityTimer = 0;
   public godMode = false;
   public dpr = 1;
+  public dodgeTimer = 0;
+  public dodgeCooldown = 0;
 
   private flashTimer = 0;
   /** @deprecated Retained for backward compatibility; procedural rendering is used instead. */
@@ -63,7 +67,12 @@ export class Player {
   get right(): number { return this.pos.x + this.width / 2 - HITBOX_INSET_X; }
   get top(): number { return this.pos.y - this.height / 2 + HITBOX_INSET_Y; }
   get bottom(): number { return this.pos.y + this.height / 2 - HITBOX_INSET_Y; }
-  get isInvincible(): boolean { return this.invincibilityTimer > 0; }
+  get isDodging(): boolean { return this.dodgeTimer > 0; }
+  get isInvincible(): boolean { return this.invincibilityTimer > 0 || this.dodgeTimer > 0; }
+
+  get dodgeCooldownFraction(): number {
+    return this.dodgeCooldown / DODGE_COOLDOWN;
+  }
 
   get isShieldRegenerating(): boolean {
     return this.alive
@@ -131,6 +140,26 @@ export class Player {
     }
   }
 
+  dodge(): boolean {
+    if (!this.alive) return false;
+    if (this.dodgeCooldown > 0) return false;
+    if (this.dodgeTimer > 0) return false;
+    if (this.invincibilityTimer > 0) return false;
+
+    this.dodgeTimer = DODGE_DURATION;
+    this.dodgeCooldown = DODGE_COOLDOWN;
+    return true;
+  }
+
+  updateDodge(dt: number): void {
+    if (this.dodgeTimer > 0) {
+      this.dodgeTimer = Math.max(0, this.dodgeTimer - dt);
+    }
+    if (this.dodgeCooldown > 0) {
+      this.dodgeCooldown = Math.max(0, this.dodgeCooldown - dt);
+    }
+  }
+
   takeDamage(amount: number): boolean {
     if (this.godMode) return false;
     if (this.isInvincible || !this.alive) return false;
@@ -161,6 +190,8 @@ export class Player {
     this.invincibilityTimer = 0;
     this.flashTimer = 0;
     this.shieldRegenTimer = 0;
+    this.dodgeTimer = 0;
+    this.dodgeCooldown = 0;
     this.bankAngle = 0;
     this.runningLightPhase = 0;
     this.lastDx = 0;
@@ -177,8 +208,14 @@ export class Player {
   render(ctx: CanvasRenderingContext2D): void {
     if (!this.alive) return;
 
-    if (this.isInvincible && Math.floor(this.flashTimer * 10) % 2 === 0) {
+    if (this.invincibilityTimer > 0 && !this.isDodging
+        && Math.floor(this.flashTimer * 10) % 2 === 0) {
       return;
+    }
+
+    if (this.isDodging) {
+      ctx.save();
+      ctx.globalAlpha = 0.3 + 0.15 * Math.sin(this.dodgeTimer * 40);
     }
 
     if (this.godMode) {
@@ -209,5 +246,9 @@ export class Player {
       state,
       this.dpr
     );
+
+    if (this.isDodging) {
+      ctx.restore();
+    }
   }
 }

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -411,7 +411,8 @@ export class HUD {
     chargeLevel?: number,
     bombs?: number,
     weaponTier?: number,
-    isShieldRegenerating?: boolean
+    isShieldRegenerating?: boolean,
+    dodgeCooldownFraction?: number
   ): void {
     switch (state) {
       case "loading":
@@ -423,10 +424,10 @@ export class HUD {
       case "briefing":
         break;
       case "playing":
-        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating);
+        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating, dodgeCooldownFraction);
         break;
       case "level_complete":
-        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating);
+        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating, dodgeCooldownFraction);
         this.renderOverlay(ctx, width, height, "Level Complete!",
           this.completionLines,
           `Score: ${score}`,
@@ -627,7 +628,8 @@ export class HUD {
     chargeLevel?: number,
     bombs?: number,
     weaponTier?: number,
-    isShieldRegenerating?: boolean
+    isShieldRegenerating?: boolean,
+    dodgeCooldownFraction?: number
   ): void {
     ctx.save();
 
@@ -670,7 +672,9 @@ export class HUD {
     ctx.restore();
 
     this.renderShieldBar(ctx, shield, height, isShieldRegenerating);
+    this.renderDodgeCooldown(ctx, dodgeCooldownFraction ?? 0, 10, 52);
     this.renderTouchBombButton(ctx, bombs ?? 0, width, height);
+    this.renderTouchDodgeButton(ctx, dodgeCooldownFraction ?? 0, width, height);
   }
 
   private renderShieldBar(ctx: CanvasRenderingContext2D, shield: number, canvasHeight: number, isRegenerating?: boolean): void {
@@ -840,6 +844,90 @@ export class HUD {
 
     ctx.font = `8px ${RETRO_FONT}`;
     ctx.fillText(`${bombs}`, btn.x + btn.w / 2, btn.y + btn.h / 2 + 8);
+    ctx.restore();
+  }
+
+  private renderDodgeCooldown(
+    ctx: CanvasRenderingContext2D,
+    cooldownFraction: number,
+    startX: number,
+    y: number
+  ): void {
+    ctx.save();
+    ctx.font = `7px ${RETRO_FONT}`;
+    ctx.textAlign = "left";
+    ctx.textBaseline = "middle";
+
+    const ready = cooldownFraction <= 0;
+    ctx.fillStyle = ready ? "#2ecc71" : "#95a5a6";
+    ctx.fillText("DODGE", startX, y);
+
+    const labelW = ctx.measureText("DODGE").width;
+    const barX = startX + labelW + 6;
+    const barW = 40;
+    const barH = 5;
+    const barY = y - barH / 2;
+
+    ctx.fillStyle = "rgba(255, 255, 255, 0.1)";
+    ctx.fillRect(barX, barY, barW, barH);
+
+    const fillFrac = 1 - cooldownFraction;
+    if (fillFrac > 0) {
+      ctx.fillStyle = ready ? "#2ecc71" : "#3498db";
+      ctx.fillRect(barX, barY, barW * fillFrac, barH);
+    }
+
+    if (ready) {
+      ctx.fillStyle = "rgba(255, 255, 255, 0.4)";
+      ctx.font = `5px ${RETRO_FONT}`;
+      ctx.fillText("[SHIFT]", barX + barW + 4, y);
+    }
+
+    ctx.restore();
+  }
+
+  private getDodgeButtonRect(width: number, height: number) {
+    const size = 44;
+    const bombBtn = this.getBombButtonRect(width, height);
+    return { x: bombBtn.x - size - 8, y: bombBtn.y, w: size, h: size };
+  }
+
+  isDodgeButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    if (!this.isTouchDevice) return false;
+    const btn = this.getDodgeButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w
+        && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  private renderTouchDodgeButton(
+    ctx: CanvasRenderingContext2D,
+    cooldownFraction: number,
+    width: number,
+    height: number
+  ): void {
+    if (!this.isTouchDevice) return;
+    const btn = this.getDodgeButtonRect(width, height);
+    const ready = cooldownFraction <= 0;
+
+    ctx.save();
+    ctx.globalAlpha = ready ? 0.7 : 0.3;
+    ctx.fillStyle = ready ? "#3498db" : "#555555";
+    ctx.beginPath();
+    ctx.roundRect(btn.x, btn.y, btn.w, btn.h, 8);
+    ctx.fill();
+
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.3)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.roundRect(btn.x, btn.y, btn.w, btn.h, 8);
+    ctx.stroke();
+
+    ctx.globalAlpha = 1;
+    ctx.font = `9px ${RETRO_FONT}`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = "#FFFFFF";
+    ctx.fillText("DASH", btn.x + btn.w / 2, btn.y + btn.h / 2);
     ctx.restore();
   }
 

--- a/src/games/raptor/systems/InputManager.ts
+++ b/src/games/raptor/systems/InputManager.ts
@@ -5,6 +5,7 @@ export class InputManager {
   public wasClicked = false;
   public wasEscPressed = false;
   public wasBombPressed = false;
+  public wasDodgePressed = false;
   public wasConsoleToggled = false;
   public isMouseDown = false;
   public mouseX = 0;
@@ -70,6 +71,7 @@ export class InputManager {
     this.wasClicked = false;
     this.wasEscPressed = false;
     this.wasBombPressed = false;
+    this.wasDodgePressed = false;
     this.wasConsoleToggled = false;
   }
 
@@ -160,6 +162,10 @@ export class InputManager {
     }
     if (e.key === "b") {
       this.wasBombPressed = true;
+    }
+    if (e.key === "Shift") {
+      this.wasDodgePressed = true;
+      e.preventDefault();
     }
     if (e.key === "`") {
       this.wasConsoleToggled = true;

--- a/src/games/raptor/systems/SoundSystem.ts
+++ b/src/games/raptor/systems/SoundSystem.ts
@@ -50,6 +50,7 @@ export class SoundSystem {
       case "plasma_fire": this.playPlasmaFire(); break;
       case "plasma_hit": this.playPlasmaHit(); break;
       case "mega_bomb_fire": this.playMegaBombFire(); break;
+      case "dodge": this.playDodge(); break;
     }
   }
 
@@ -242,6 +243,13 @@ export class SoundSystem {
       attack: 0.01, decay: 0.05, sustain: 0.6, release: 0.2,
     }, this.sfxNode);
     this.audio.playNoise(0.4, 4000, this.sfxNode);
+  }
+
+  private playDodge(): void {
+    this.audio.playToneSwept(1400, 600, 0.12, "sine", {
+      attack: 0.005, decay: 0.02, sustain: 0.3, release: 0.04,
+    }, this.sfxNode);
+    this.audio.playNoise(0.06, 5000, this.sfxNode);
   }
 
   private get musicNode(): AudioNode | undefined {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -145,7 +145,8 @@ export type RaptorSoundEvent =
   | "ion_fire"
   | "ion_hit"
   | "rocket_fire"
-  | "mega_bomb_fire";
+  | "mega_bomb_fire"
+  | "dodge";
 
 export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon" | "auto-gun" | "rocket";
 


### PR DESCRIPTION
## PR: Raptor — Add dodge/dash ability with brief invincibility (Shift / Mobile DASH)

### Summary (what changed & why)
This PR adds a **player-initiated dodge/dash** to Raptor, giving the player a **~0.3s invincibility window** on a **~3s cooldown**. The goal is to introduce a **skill-based defensive option** beyond basic movement and the existing post-hit invincibility frames.

Key behaviors:
- **Keyboard:** press **Shift** to dodge (Space is reserved for firing).
- **Mobile:** tap a new **DASH** HUD button.
- Dodge grants brief invulnerability against all existing enemy damage sources because it’s integrated into `player.isInvincible`.
- Visual feedback: the ship renders with a **distinct translucent/pulsing alpha** while dodging.
- HUD shows a **dodge cooldown bar** + keybind hint.

### Implementation notes (high level)
- Dodge state is tracked separately from post-death i-frames via `dodgeTimer` / `dodgeCooldown`, and `Player.isInvincible` now covers both states.
- Collision logic required **no direct changes** because all player-damage checks already guard on `player.isInvincible`.

---

### Key files modified
- `src/games/raptor/entities/Player.ts`
  - Adds `dodgeTimer`, `dodgeCooldown`, `isDodging`
  - Adds `dodge()` and `updateDodge(dt)`
  - Updates `isInvincible` to include dodge timer
  - Adds dodge-specific render effect (translucent/pulsing alpha)
- `src/games/raptor/systems/InputManager.ts`
  - Adds `wasDodgePressed` edge-triggered input flag
  - Binds **Shift** to dodge, resets in `consume()`
- `src/games/raptor/RaptorGame.ts`
  - Triggers `player.dodge()` when dodge input is pressed (including touch button hit)
  - Calls `player.updateDodge(dt)` each frame during `playing`
  - Passes cooldown fraction into HUD rendering
  - Plays dodge SFX on successful dodge
- `src/games/raptor/rendering/HUD.ts`
  - Adds **DODGE cooldown bar** (top-left HUD area)
  - Adds mobile **DASH** button + hit testing + disabled state during cooldown
- `src/games/raptor/systems/SoundSystem.ts`
  - Adds synthesized **dodge** sound effect
- `src/games/raptor/types.ts`
  - Extends sound event union with `"dodge"`

---

### Testing notes
Manual verification:
- **Keyboard:** Press **Shift** in `playing` state → dodge triggers, ship becomes translucent, invincibility applies for ~0.3s, cooldown starts (~3s).
- **Cooldown enforcement:** pressing Shift during cooldown does nothing; pressing during dodge does nothing.
- **Guards:** dodge cannot be triggered while dead or during post-death invincibility frames (does not consume cooldown).
- **Damage checks:** bullets / beams / collisions do not damage the player while dodging (covered via updated `isInvincible`).
- **HUD:** cooldown bar fills over time; ready state is clearly indicated; keybind hint shows when ready.
- **Mobile:** DASH button appears on touch devices, triggers dodge when tapped, visually disabled during cooldown.

Commands:
- `npm run typecheck` (per acceptance criteria)

---

### Related
- Implements: **Raptor: Add dodge/dash ability with brief invincibility**
- Part of epic: **#542**

Ref: https://github.com/asgardtech/archer/issues/556