### PR TITLE
Raptor: Add temporary armor/damage-reduction power-up

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -546,6 +546,7 @@ export class RaptorGame implements IGame {
     }
     this.updateBackground(dt);
     this.powerUpManager.update(dt);
+    this.player.armorActive = this.powerUpManager.hasUpgrade("armor");
 
     const config = this.currentLevelConfig;
 
@@ -850,6 +851,9 @@ export class RaptorGame implements IGame {
         case "rapid-fire":
           this.powerUpManager.activate(hit.powerUp.type);
           break;
+        case "armor":
+          this.powerUpManager.activate("armor");
+          break;
         case "shield-restore":
           this.player.shield = 100;
           break;
@@ -1018,6 +1022,9 @@ export class RaptorGame implements IGame {
     }
 
     const pu = new PowerUp(x, y, type);
+    if (pu.type === "armor" && config.level < 4) {
+      pu.type = "shield-restore";
+    }
     const spriteKey = POWERUP_SPRITE_KEYS[pu.type];
     const sprite = this.assets.getOptional(spriteKey);
     if (sprite) pu.setSprite(sprite);

--- a/src/games/raptor/entities/Player.ts
+++ b/src/games/raptor/entities/Player.ts
@@ -30,6 +30,7 @@ export class Player {
   public dpr = 1;
   public dodgeTimer = 0;
   public dodgeCooldown = 0;
+  public armorActive = false;
 
   private flashTimer = 0;
   /** @deprecated Retained for backward compatibility; procedural rendering is used instead. */
@@ -164,6 +165,10 @@ export class Player {
     if (this.godMode) return false;
     if (this.isInvincible || !this.alive) return false;
 
+    if (this.armorActive) {
+      amount = Math.max(1, Math.floor(amount * 0.5));
+    }
+
     this.shieldRegenTimer = 0;
 
     if (this.shield > 0) {
@@ -192,6 +197,7 @@ export class Player {
     this.shieldRegenTimer = 0;
     this.dodgeTimer = 0;
     this.dodgeCooldown = 0;
+    this.armorActive = false;
     this.bankAngle = 0;
     this.runningLightPhase = 0;
     this.lastDx = 0;
@@ -224,6 +230,16 @@ export class Player {
       ctx.fillStyle = "#ffd700";
       ctx.beginPath();
       ctx.ellipse(this.pos.x, this.pos.y, this.width * 0.7, this.height * 0.7, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    if (this.armorActive) {
+      ctx.save();
+      ctx.globalAlpha = 0.12 + 0.06 * Math.sin(Date.now() / 400);
+      ctx.fillStyle = "#00bcd4";
+      ctx.beginPath();
+      ctx.ellipse(this.pos.x, this.pos.y, this.width * 0.65, this.height * 0.65, 0, 0, Math.PI * 2);
       ctx.fill();
       ctx.restore();
     }

--- a/src/games/raptor/entities/PowerUp.ts
+++ b/src/games/raptor/entities/PowerUp.ts
@@ -1,7 +1,7 @@
 import { Vec2, RaptorPowerUpType } from "../types";
 
 const FALL_SPEED = 100;
-const POWER_UP_TYPES: RaptorPowerUpType[] = ["spread-shot", "rapid-fire", "shield-restore", "bonus-life", "mega-bomb"];
+const POWER_UP_TYPES: RaptorPowerUpType[] = ["spread-shot", "rapid-fire", "shield-restore", "bonus-life", "mega-bomb", "armor"];
 
 const COLORS: Record<RaptorPowerUpType, string> = {
   "spread-shot": "#3498db",
@@ -15,6 +15,7 @@ const COLORS: Record<RaptorPowerUpType, string> = {
   "weapon-autogun": "#27ae60",
   "weapon-rocket": "#2c3e50",
   "mega-bomb": "#e74c3c",
+  "armor": "#00bcd4",
 };
 
 const ICONS: Record<RaptorPowerUpType, string> = {
@@ -29,6 +30,7 @@ const ICONS: Record<RaptorPowerUpType, string> = {
   "weapon-autogun": "A",
   "weapon-rocket": "R",
   "mega-bomb": "B",
+  "armor": "A",
 };
 
 const SPRITE_KEYS: Record<RaptorPowerUpType, string> = {
@@ -43,6 +45,7 @@ const SPRITE_KEYS: Record<RaptorPowerUpType, string> = {
   "weapon-autogun": "powerup_autogun",
   "weapon-rocket": "powerup_rocket",
   "mega-bomb": "powerup_bomb",
+  "armor": "powerup_armor",
 };
 
 export { SPRITE_KEYS as POWERUP_SPRITE_KEYS };

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -25,6 +25,7 @@ const EFFECT_COLORS: Partial<Record<RaptorPowerUpType, string>> = {
   "weapon-laser": "#9b59b6",
   "weapon-plasma": "#8e44ad",
   "weapon-ion": "#00bcd4",
+  "armor": "#00bcd4",
 };
 
 const EFFECT_LABELS: Partial<Record<RaptorPowerUpType, string>> = {
@@ -34,6 +35,7 @@ const EFFECT_LABELS: Partial<Record<RaptorPowerUpType, string>> = {
   "weapon-laser": "LSR",
   "weapon-plasma": "PLS",
   "weapon-ion": "ION",
+  "armor": "ARM",
 };
 
 const WEAPON_LABELS: Record<WeaponType, string> = {
@@ -963,9 +965,12 @@ export class HUD {
       const color = EFFECT_COLORS[eff.type] ?? "#888";
       const label = EFFECT_LABELS[eff.type] ?? "?";
 
-      const sprite = this.assets?.getOptional(
-        eff.type === "spread-shot" ? "powerup_spread" : "powerup_rapid"
-      );
+      const spriteKeyMap: Partial<Record<RaptorPowerUpType, string>> = {
+        "spread-shot": "powerup_spread",
+        "rapid-fire": "powerup_rapid",
+        "armor": "powerup_armor",
+      };
+      const sprite = this.assets?.getOptional(spriteKeyMap[eff.type] ?? "");
 
       if (sprite) {
         ctx.drawImage(sprite, startX - 18, y, 14, 14);

--- a/src/games/raptor/systems/PowerUpManager.ts
+++ b/src/games/raptor/systems/PowerUpManager.ts
@@ -8,6 +8,7 @@ export interface ActiveEffect {
 export const EFFECT_DURATIONS: Partial<Record<RaptorPowerUpType, number>> = {
   "spread-shot": 8,
   "rapid-fire": 6,
+  "armor": 10,
 };
 
 export type WeaponSetResult = "switched" | "upgraded" | "maxed";

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -107,6 +107,7 @@ export type RaptorPowerUpType =
   | "rapid-fire"
   | "shield-restore"
   | "bonus-life"
+  | "armor"
   | "weapon-missile"
   | "weapon-laser"
   | "weapon-plasma"


### PR DESCRIPTION
## PR: Raptor — Add temporary armor / damage-reduction power-up (Issue #557, part of epic #542)

### Summary (what + why)
This PR introduces a new **`armor`** power-up for Raptor that **reduces all incoming damage by 50% for 10 seconds** (with a minimum of 1 damage). The game previously offered survivability via **shield restore** and **bonus life**, but lacked a **temporary defensive buff** that rewards aggressive positioning. Armor fills that gap while integrating with the existing timed-effect architecture used by `spread-shot` and `rapid-fire`.

Key behaviors:
- Collecting `armor` activates a **10s** timed effect; collecting again **refreshes** the duration.
- Damage reduction is applied **inside `Player.takeDamage()`**, ensuring bullets, lasers, and collision damage are all uniformly affected.
- Armor is **gated to levels 4+** (early levels downgrade any rolled armor drop to `shield-restore`).
- Adds distinct visuals (drop + HUD + player glow) and reuses the existing power-up collect sound.

---

### Key files modified
- **`src/games/raptor/types.ts`**
  - Added `'armor'` to `RaptorPowerUpType`.

- **`src/games/raptor/entities/Player.ts`**
  - Added `armorActive` flag.
  - Updated `takeDamage(amount)` to apply `Math.max(1, Math.floor(amount * 0.5))` when armor is active (before shield/life logic).
  - Reset `armorActive` during player reset/death flow.
  - Added a subtle cyan glow while armor is active.

- **`src/games/raptor/systems/PowerUpManager.ts`**
  - Added `"armor": 10` to `EFFECT_DURATIONS` so it’s managed like other timed effects.

- **`src/games/raptor/entities/PowerUp.ts`**
  - Added armor to the power-up drop pool and visual mappings:
    - Color: `#00bcd4`
    - Icon: `A`
    - Sprite key: `powerup_armor`

- **`src/games/raptor/rendering/HUD.ts`**
  - Displays armor as an active effect with label **`ARM`** and color `#00bcd4`.
  - Updated sprite key lookup to support armor alongside existing effects.

- **`src/games/raptor/RaptorGame.ts`**
  - Handles armor pickup via `powerUpManager.activate("armor")`.
  - Syncs `player.armorActive` each frame from `powerUpManager.hasUpgrade("armor")`.
  - Gates armor drops to **levels 4+** (downgrades to `shield-restore` in levels 1–3).

---

### Testing notes
Manual verification recommended:
- **Pickup + timer**
  - Collect armor → HUD shows **ARM** with countdown; player has cyan glow.
  - Collect armor again while active → timer refreshes back to 10s.

- **Damage reduction correctness**
  - With armor active:
    - Bullet/laser/collision damage is halved (rounded down) with **minimum 1**.
    - Reduction occurs **before** shield/life application (shield depletion and life loss behave as expected).

- **Drop gating**
  - Levels **1–3**: armor should not appear (any roll is downgraded to `shield-restore`).
  - Levels **4+**: armor can appear in the generic power-up pool.

- **Resets**
  - Armor clears on death/respawn and level transitions (no carryover).

Build/type safety:
- Run **`npm run typecheck`** (acceptance requires zero TS errors).

---

Ref: https://github.com/asgardtech/archer/issues/557