### PR TITLE
Archer: Implement active landmark defense system

### DIFF
--- a/src/games/archer/ArcherGame.ts
+++ b/src/games/archer/ArcherGame.ts
@@ -25,6 +25,7 @@ const BOSS_BALLOON_SCORE = 10;
 const MILESTONE_INTERVAL = 25;
 const MILESTONE_AMMO_BONUS = 5;
 const BOSS_KILL_AMMO_BONUS = 15;
+const SIEGE_BALLOON_SCORE = 5;
 
 const SHIELD_DURATION = 5.0;
 const SHIELD_COOLDOWN = 15.0;
@@ -461,6 +462,11 @@ export class ArcherGame implements IGame {
       this.obstacles.push(o);
     }
 
+    const newSiegeBalloons = this.spawner.updateSiegeBalloons(dt, this.width);
+    for (const b of newSiegeBalloons) {
+      this.balloons.push(b);
+    }
+
     for (const balloon of this.balloons) {
       const wasAlive = balloon.alive;
       balloon.update(dt);
@@ -499,9 +505,24 @@ export class ArcherGame implements IGame {
       this.shieldCooldownTimer -= dt;
     }
 
+    if (this.landmark) {
+      const landmarkPos = this.landmark.getPosition();
+      for (const balloon of this.balloons) {
+        if (!balloon.alive || balloon.variant !== "siege") continue;
+        if (balloon.pos.y >= landmarkPos.y) {
+          balloon.alive = false;
+          this.landmark.takeDamage(this.currentLevelConfig.siegeDamage);
+          this.sound.play("landmark_damaged");
+        }
+      }
+    }
+
     const hits = this.collisions.check(this.arrows, this.balloons);
     for (const hit of hits) {
-      if (hit.isBossKill) {
+      if (hit.balloon.variant === "siege") {
+        this.score += SIEGE_BALLOON_SCORE;
+        this.sound.play("siege_hit");
+      } else if (hit.isBossKill) {
         this.score += BOSS_BALLOON_SCORE;
         this.arrowsRemaining += BOSS_KILL_AMMO_BONUS;
         this.hud.showAmmoGain(BOSS_KILL_AMMO_BONUS);
@@ -564,6 +585,19 @@ export class ArcherGame implements IGame {
         this.lowAmmoTriggered = false;
         this.sound.stopLowAmmoWarning();
       }
+    }
+
+    if (this.landmark && this.landmark.isDestroyed()) {
+      this.totalScore += this.score;
+      this.balloons = [];
+      this.arrows = [];
+      this.obstacles = [];
+      this.sound.stopLowAmmoWarning();
+      this.lowAmmoTriggered = false;
+      this.sound.stopMusic();
+      this.sound.play("game_over");
+      this.state = "gameover";
+      return;
     }
 
     if (this.score >= this.currentLevelConfig.targetScore) {
@@ -695,7 +729,10 @@ export class ArcherGame implements IGame {
       this.shieldActive,
       this.shieldCooldownTimer,
       SHIELD_COOLDOWN,
-      this.input.isTouchDevice
+      this.input.isTouchDevice,
+      this.landmark?.getHealthPercent() ?? 1,
+      this.landmark !== null && !this.landmark.isDestroyed() &&
+        this.balloons.some(b => b.variant === "siege" && b.alive)
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
   }

--- a/src/games/archer/entities/Balloon.ts
+++ b/src/games/archer/entities/Balloon.ts
@@ -28,14 +28,20 @@ export class Balloon {
   private flashTimer = 0;
   private upgradeIcon: HTMLImageElement | null = null;
 
-  constructor(x: number, y: number, speed: number, upgrade?: UpgradeType | "boss", bossHitPoints = 5) {
+  constructor(x: number, y: number, speed: number, upgrade?: UpgradeType | "boss" | "siege", bossHitPoints = 5) {
     this.radius = 20 + Math.random() * 15;
     this.pos = { x, y };
     this.vel = { x: 0, y: -speed };
     this.baseX = x;
     this.wobbleOffset = Math.random() * Math.PI * 2;
 
-    if (upgrade === "boss") {
+    if (upgrade === "siege") {
+      this.variant = "siege";
+      this.color = "#4A0E0E";
+      this.radius *= 0.85;
+      this.vel = { x: 0, y: speed };
+      this.wobbleAmplitude = 15;
+    } else if (upgrade === "boss") {
       this.variant = "boss";
       this.color = "#8B0000";
       this.radius *= 2.0;
@@ -74,7 +80,7 @@ export class Balloon {
     this.pos.y += this.vel.y * dt;
     this.pos.x = this.baseX + Math.sin(this.time * 1.5 + this.wobbleOffset) * this.wobbleAmplitude;
 
-    if (this.pos.y + this.radius < 0) {
+    if (this.variant !== "siege" && this.pos.y + this.radius < 0) {
       this.alive = false;
     }
   }
@@ -85,7 +91,9 @@ export class Balloon {
     ctx.save();
     ctx.translate(this.pos.x, this.pos.y);
 
-    if (this.variant === "boss") {
+    if (this.variant === "siege") {
+      this.renderSiegeBalloon(ctx);
+    } else if (this.variant === "boss") {
       this.renderBossBalloon(ctx);
     } else if (this.variant === "upgrade") {
       this.renderUpgradeBalloon(ctx);
@@ -110,6 +118,29 @@ export class Balloon {
     ctx.stroke();
 
     ctx.restore();
+  }
+
+  private renderSiegeBalloon(ctx: CanvasRenderingContext2D): void {
+    const r = this.radius;
+
+    ctx.beginPath();
+    ctx.ellipse(0, 0, r * 0.8, r, 0, 0, Math.PI * 2);
+    ctx.fillStyle = this.color;
+    ctx.fill();
+    ctx.strokeStyle = "rgba(0,0,0,0.5)";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.ellipse(-r * 0.25, -r * 0.35, r * 0.15, r * 0.25, -0.4, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(255,255,255,0.2)";
+    ctx.fill();
+
+    ctx.fillStyle = "rgba(255,80,50,0.9)";
+    ctx.font = `bold ${r * 0.5}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("\u{1F4A3}", 0, r * 0.1);
   }
 
   private renderStandardBalloon(ctx: CanvasRenderingContext2D): void {

--- a/src/games/archer/entities/Landmark.ts
+++ b/src/games/archer/entities/Landmark.ts
@@ -44,10 +44,36 @@ export class Landmark {
   private liberationTimer = 0;
   private sparkles: Sparkle[] = [];
 
+  private currentHitPoints: number;
+  private maxHitPoints: number;
+  private damageFlashTimer = 0;
+
   constructor(config: LandmarkConfig, canvasWidth: number, canvasHeight: number) {
     this.type = config.type;
     this.x = Math.max(0, Math.min(1, config.positionX)) * canvasWidth;
     this.groundY = canvasHeight - GROUND_HEIGHT;
+    this.maxHitPoints = config.hitPoints;
+    this.currentHitPoints = config.hitPoints;
+  }
+
+  takeDamage(amount: number): void {
+    if (this.state === "liberated" || this.currentHitPoints <= 0) return;
+    this.currentHitPoints = Math.max(0, this.currentHitPoints - amount);
+    this.damageFlashTimer = 0.3;
+  }
+
+  getHealthPercent(): number {
+    return this.maxHitPoints > 0
+      ? this.currentHitPoints / this.maxHitPoints
+      : 0;
+  }
+
+  isDestroyed(): boolean {
+    return this.currentHitPoints <= 0;
+  }
+
+  getPosition(): { x: number; y: number } {
+    return { x: this.x, y: this.groundY };
   }
 
   setSiegeProgress(progress: number): void {
@@ -69,6 +95,7 @@ export class Landmark {
     this.flagPhase += dt * 3.0;
     this.swayPhase += dt * 1.2;
     this.shakeTimer += dt;
+    if (this.damageFlashTimer > 0) this.damageFlashTimer -= dt;
 
     if (this.state === "liberated" && this.liberationTimer > 0) {
       this.liberationTimer -= dt;
@@ -88,8 +115,9 @@ export class Landmark {
 
     if (this.state === "siege") {
       const siegeIntensity = 1 - this.siegeProgress;
-      const shakeX = Math.sin(this.shakeTimer * 15) * 1.5 * siegeIntensity;
-      const shakeY = Math.cos(this.shakeTimer * 12) * 1.0 * siegeIntensity;
+      const damageShake = this.damageFlashTimer > 0 ? 3 : 0;
+      const shakeX = Math.sin(this.shakeTimer * 15) * (1.5 * siegeIntensity + damageShake);
+      const shakeY = Math.cos(this.shakeTimer * 12) * (1.0 * siegeIntensity + damageShake);
       ctx.translate(shakeX, shakeY);
     }
 
@@ -129,6 +157,18 @@ export class Landmark {
           bounds.height
         );
       }
+    }
+
+    if (this.damageFlashTimer > 0) {
+      const bounds = LANDMARK_BOUNDS[this.type];
+      const flashAlpha = 0.4 * (this.damageFlashTimer / 0.3);
+      ctx.fillStyle = `rgba(231, 76, 60, ${flashAlpha})`;
+      ctx.fillRect(
+        -bounds.width / 2,
+        bounds.offsetY - bounds.height / 2,
+        bounds.width,
+        bounds.height
+      );
     }
 
     if (this.state === "liberated" && this.liberationTimer > 0) {

--- a/src/games/archer/levels.ts
+++ b/src/games/archer/levels.ts
@@ -26,6 +26,13 @@ export interface LevelConfig {
   obstacleSpeedMax: number;
   landmark: LandmarkConfig;
   terrain: TerrainStyle;
+  siegeEnabled: boolean;
+  siegeDelay: number;
+  siegeIntervalMin: number;
+  siegeIntervalMax: number;
+  siegeSpeedMin: number;
+  siegeSpeedMax: number;
+  siegeDamage: number;
 }
 
 export const LEVELS: LevelConfig[] = [
@@ -66,6 +73,13 @@ export const LEVELS: LevelConfig[] = [
       surfaceColor: "#2d6b2e",
       accentColor: "#e8554e",
     },
+    siegeEnabled: false,
+    siegeDelay: 0,
+    siegeIntervalMin: 0,
+    siegeIntervalMax: 0,
+    siegeSpeedMin: 0,
+    siegeSpeedMax: 0,
+    siegeDamage: 0,
   },
   {
     level: 2,
@@ -104,6 +118,13 @@ export const LEVELS: LevelConfig[] = [
       surfaceColor: "#1e3a1e",
       accentColor: "#c0392b",
     },
+    siegeEnabled: false,
+    siegeDelay: 0,
+    siegeIntervalMin: 0,
+    siegeIntervalMax: 0,
+    siegeSpeedMin: 0,
+    siegeSpeedMax: 0,
+    siegeDamage: 0,
   },
   {
     level: 3,
@@ -142,6 +163,13 @@ export const LEVELS: LevelConfig[] = [
       surfaceColor: "#4a4a4a",
       accentColor: "#e8e8f0",
     },
+    siegeEnabled: true,
+    siegeDelay: 15,
+    siegeIntervalMin: 8,
+    siegeIntervalMax: 14,
+    siegeSpeedMin: 40,
+    siegeSpeedMax: 60,
+    siegeDamage: 1,
   },
   {
     level: 4,
@@ -180,6 +208,13 @@ export const LEVELS: LevelConfig[] = [
       surfaceColor: "#252220",
       accentColor: "rgba(100, 140, 180, 0.4)",
     },
+    siegeEnabled: true,
+    siegeDelay: 10,
+    siegeIntervalMin: 5,
+    siegeIntervalMax: 10,
+    siegeSpeedMin: 50,
+    siegeSpeedMax: 80,
+    siegeDamage: 1,
   },
   {
     level: 5,
@@ -218,5 +253,12 @@ export const LEVELS: LevelConfig[] = [
       surfaceColor: "#5a5552",
       accentColor: "#6B6462",
     },
+    siegeEnabled: true,
+    siegeDelay: 5,
+    siegeIntervalMin: 3,
+    siegeIntervalMax: 7,
+    siegeSpeedMin: 60,
+    siegeSpeedMax: 100,
+    siegeDamage: 2,
   },
 ];

--- a/src/games/archer/rendering/HUD.ts
+++ b/src/games/archer/rendering/HUD.ts
@@ -106,7 +106,9 @@ export class HUD {
     shieldActive = false,
     shieldCooldownTimer = 0,
     shieldCooldownMax = 15,
-    isTouchInput = false
+    isTouchInput = false,
+    landmarkHealthPercent = 1,
+    siegeActive = false
   ): void {
     for (const t of this.ammoGainTexts) {
       t.age += dt;
@@ -140,13 +142,13 @@ export class HUD {
         break;
       case "playing":
         this.renderPlaying(ctx, score, arrowsRemaining, canvasW, canvasH, currentWeapon, unlockedWeapons, level, levelName,
-          shieldCharges, shieldActive, shieldCooldownTimer, shieldCooldownMax, isTouchInput);
+          shieldCharges, shieldActive, shieldCooldownTimer, shieldCooldownMax, isTouchInput, landmarkHealthPercent, siegeActive);
         break;
       case "level_complete":
         this.renderLevelComplete(ctx, score, level, levelName, landmarkLabel, canvasW, canvasH);
         break;
       case "gameover":
-        this.renderGameOver(ctx, totalScore, canvasW, canvasH, level, levelName);
+        this.renderGameOver(ctx, totalScore, canvasW, canvasH, level, levelName, landmarkHealthPercent);
         break;
       case "victory":
         this.renderVictory(ctx, totalScore, canvasW, canvasH);
@@ -262,7 +264,9 @@ export class HUD {
     shieldActive = false,
     shieldCooldownTimer = 0,
     shieldCooldownMax = 15,
-    isTouchInput = false
+    isTouchInput = false,
+    landmarkHealthPercent = 1,
+    siegeActive = false
   ): void {
     ctx.save();
     ctx.font = "bold 20px sans-serif";
@@ -301,6 +305,9 @@ export class HUD {
     }
 
     this.renderShieldStatus(ctx, shieldCharges, shieldActive, shieldCooldownTimer, shieldCooldownMax, w);
+    if (landmarkHealthPercent < 1 || siegeActive) {
+      this.renderLandmarkHealth(ctx, landmarkHealthPercent, siegeActive, w);
+    }
     this.renderWeaponBar(ctx, w, h, currentWeapon, unlockedWeapons, isTouchInput);
 
     if (this.weaponNotification) {
@@ -453,6 +460,53 @@ export class HUD {
     return x >= r.x && x <= r.x + r.w && y >= r.y && y <= r.y + r.h;
   }
 
+  private renderLandmarkHealth(
+    ctx: CanvasRenderingContext2D,
+    healthPercent: number,
+    siegeActive: boolean,
+    w: number
+  ): void {
+    const barW = 120;
+    const barH = 8;
+    const x = (w - barW) / 2;
+    const y = 34;
+
+    ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
+    ctx.fillRect(x, y, barW, barH);
+
+    const fillColor = healthPercent > 0.5
+      ? "#2ecc71"
+      : healthPercent > 0.25
+        ? "#f1c40f"
+        : "#e74c3c";
+    ctx.fillStyle = fillColor;
+    ctx.fillRect(x, y, barW * healthPercent, barH);
+
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.3)";
+    ctx.lineWidth = 1;
+    ctx.strokeRect(x, y, barW, barH);
+
+    ctx.font = "bold 10px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillStyle = "rgba(255, 255, 255, 0.7)";
+    ctx.fillText("LANDMARK", w / 2, y + barH + 12);
+
+    if (healthPercent <= 0.25 && healthPercent > 0) {
+      const flash = Math.sin(Date.now() * 0.01) > 0;
+      if (flash) {
+        ctx.fillStyle = "rgba(231, 76, 60, 0.3)";
+        ctx.fillRect(x - 2, y - 2, barW + 4, barH + 4);
+      }
+    }
+
+    if (siegeActive) {
+      ctx.font = "bold 12px sans-serif";
+      ctx.textAlign = "center";
+      ctx.fillStyle = "rgba(231, 76, 60, 0.9)";
+      ctx.fillText("\u26A0 UNDER ATTACK", w / 2, y + barH + 26);
+    }
+  }
+
   private renderShieldStatus(
     ctx: CanvasRenderingContext2D,
     charges: number,
@@ -554,7 +608,8 @@ export class HUD {
     w: number,
     h: number,
     level: number,
-    levelName: string
+    levelName: string,
+    landmarkHealthPercent = 1
   ): void {
     ctx.save();
 
@@ -564,9 +619,10 @@ export class HUD {
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
 
+    const title = landmarkHealthPercent <= 0 ? "Landmark Destroyed!" : "Game Over";
     ctx.fillStyle = "#fff";
     ctx.font = "bold 44px sans-serif";
-    ctx.fillText("Game Over", w / 2, h / 2 - 60);
+    ctx.fillText(title, w / 2, h / 2 - 60);
 
     ctx.fillStyle = "rgba(255,255,255,0.7)";
     ctx.font = "22px sans-serif";

--- a/src/games/archer/systems/SoundSystem.ts
+++ b/src/games/archer/systems/SoundSystem.ts
@@ -74,6 +74,12 @@ export class SoundSystem {
       case "shield_block":
         this.playShieldBlock();
         break;
+      case "siege_hit":
+        this.playSiegeHit();
+        break;
+      case "landmark_damaged":
+        this.playLandmarkDamaged();
+        break;
     }
   }
 
@@ -280,6 +286,26 @@ export class SoundSystem {
       release: 0.02,
     });
     this.audio.playNoise(0.05, 5000);
+  }
+
+  private playSiegeHit(): void {
+    this.audio.playNoise(0.08, 3000);
+    this.audio.playTone(400, 0.1, "sine", {
+      attack: 0.005,
+      decay: 0.02,
+      sustain: 0.3,
+      release: 0.04,
+    });
+  }
+
+  private playLandmarkDamaged(): void {
+    this.audio.playToneSwept(200, 80, 0.3, "sawtooth", {
+      attack: 0.01,
+      decay: 0.05,
+      sustain: 0.5,
+      release: 0.1,
+    });
+    this.audio.playNoise(0.2, 1500);
   }
 
   private startLowAmmoWarning(): void {

--- a/src/games/archer/systems/Spawner.ts
+++ b/src/games/archer/systems/Spawner.ts
@@ -42,6 +42,13 @@ const DEFAULT_CONFIG: LevelConfig = {
     surfaceColor: "#2d6b2e",
     accentColor: "#e8554e",
   },
+  siegeEnabled: false,
+  siegeDelay: 0,
+  siegeIntervalMin: 0,
+  siegeIntervalMax: 0,
+  siegeSpeedMin: 0,
+  siegeSpeedMax: 0,
+  siegeDamage: 0,
 };
 
 export class Spawner {
@@ -55,6 +62,10 @@ export class Spawner {
   private bossInterval: number;
   private obstacleTimer = 0;
   private obstacleInterval: number;
+  private siegeTimer = 0;
+  private siegeDelaySatisfied = false;
+  private siegeInterval = 0;
+  private siegeElapsed = 0;
 
   private config: LevelConfig;
 
@@ -78,6 +89,10 @@ export class Spawner {
     this.bossInterval = this.randomBossInterval();
     this.obstacleTimer = 0;
     this.obstacleInterval = this.randomObstacleInterval();
+    this.siegeTimer = 0;
+    this.siegeDelaySatisfied = false;
+    this.siegeElapsed = 0;
+    this.siegeInterval = this.randomSiegeInterval();
   }
 
   reset(): void {
@@ -91,6 +106,10 @@ export class Spawner {
     this.bossInterval = this.randomBossInterval();
     this.obstacleTimer = 0;
     this.obstacleInterval = this.randomObstacleInterval();
+    this.siegeTimer = 0;
+    this.siegeDelaySatisfied = false;
+    this.siegeElapsed = 0;
+    this.siegeInterval = this.randomSiegeInterval();
   }
 
   update(dt: number, canvasW: number, canvasH: number): Balloon[] {
@@ -180,6 +199,42 @@ export class Spawner {
 
   private randomBossInterval(): number {
     return this.config.bossIntervalMin + Math.random() * (this.config.bossIntervalMax - this.config.bossIntervalMin);
+  }
+
+  updateSiegeBalloons(dt: number, canvasW: number): Balloon[] {
+    const cfg = this.config;
+    if (!cfg.siegeEnabled) return [];
+
+    const spawned: Balloon[] = [];
+    this.siegeElapsed += dt;
+
+    if (!this.siegeDelaySatisfied) {
+      if (this.siegeElapsed >= cfg.siegeDelay) {
+        this.siegeDelaySatisfied = true;
+        this.siegeTimer = this.siegeInterval;
+      }
+      return spawned;
+    }
+
+    this.siegeTimer += dt;
+    if (this.siegeTimer >= this.siegeInterval) {
+      this.siegeTimer -= this.siegeInterval;
+      this.siegeInterval = this.randomSiegeInterval();
+
+      const margin = 50;
+      const x = margin + Math.random() * (canvasW - margin * 2);
+      const speed = cfg.siegeSpeedMin +
+        Math.random() * (cfg.siegeSpeedMax - cfg.siegeSpeedMin);
+      spawned.push(new Balloon(x, -40, speed, "siege"));
+    }
+
+    return spawned;
+  }
+
+  private randomSiegeInterval(): number {
+    const cfg = this.config;
+    if (cfg.siegeIntervalMax <= cfg.siegeIntervalMin) return cfg.siegeIntervalMin || 10;
+    return cfg.siegeIntervalMin + Math.random() * (cfg.siegeIntervalMax - cfg.siegeIntervalMin);
   }
 
   private randomObstacleInterval(): number {

--- a/src/games/archer/types.ts
+++ b/src/games/archer/types.ts
@@ -12,7 +12,7 @@ export interface EntityBase {
   alive: boolean;
 }
 
-export type BalloonVariant = "standard" | "upgrade" | "boss";
+export type BalloonVariant = "standard" | "upgrade" | "boss" | "siege";
 
 export type UpgradeType = "multi-shot" | "piercing" | "rapid-fire" | "bonus-arrows" | "shield";
 
@@ -39,7 +39,9 @@ export type SoundEvent =
   | "landmark_liberated"
   | "weapon_switch"
   | "shield_activate"
-  | "shield_block";
+  | "shield_block"
+  | "siege_hit"
+  | "landmark_damaged";
 
 export type LandmarkType = "windmill" | "treehouse" | "watchtower" | "lighthouse" | "castle";
 


### PR DESCRIPTION
## PR: Archer — Implement Active Landmark Defense System (Issue #559, part of #542)

### Summary (what & why)
This PR turns landmarks into **defendable objectives** by introducing an **active landmark HP system** and a new enemy type: **siege balloons**. Previously, landmarks had `hitPoints` in config and a `siege/liberated` visual state, but no gameplay mechanic used them. With this change, siege balloons spawn from above, descend toward the landmark, and **damage it on contact**—creating a tower-defense-style pressure where players must balance scoring with defending the landmark.

Key outcomes:
- Landmarks now have **functional hit points** and can be destroyed.
- New **siege balloon** variant targets landmarks and is **visually distinct**.
- **Game over** triggers when landmark HP reaches 0 (with a specific “Landmark Destroyed!” message).
- HUD shows **landmark health**, low-health warning, and **“UNDER ATTACK”** alert.
- Siege difficulty ramps across levels 3–5 via level config.

### Key files modified
- `src/games/archer/types.ts`
  - Adds `BalloonVariant: 'siege'`
  - Adds sound events: `siege_hit`, `landmark_damaged`
- `src/games/archer/entities/Landmark.ts`
  - Implements landmark HP (`currentHitPoints`/`maxHitPoints`)
  - Adds `takeDamage()`, `getHealthPercent()`, `isDestroyed()`, `getPosition()`
  - Adds damage flash overlay + stronger shake feedback on hit
- `src/games/archer/entities/Balloon.ts`
  - Implements `'siege'` balloon behavior (downward movement, dark maroon color, bomb icon, tighter wobble)
- `src/games/archer/systems/Spawner.ts`
  - Adds siege spawning logic (delay + random interval + speed range), configurable per level
- `src/games/archer/ArcherGame.ts`
  - Integrates siege spawns into update loop
  - Applies landmark damage when siege balloons reach landmark Y
  - Adds landmark-destruction game over condition
  - Awards **+5 score** for popping siege balloons
- `src/games/archer/rendering/HUD.ts`
  - Adds landmark health bar (green/yellow/red), low-health flash, “UNDER ATTACK” alert
  - Displays “Landmark Destroyed!” when applicable
- `src/games/archer/systems/SoundSystem.ts`
  - Adds new SFX hooks for `siege_hit` and `landmark_damaged`
- `src/games/archer/levels.ts`
  - Adds per-level siege configuration and enables siege on levels 3–5 with escalating difficulty (levels 1–2 remain siege-free)

### Behavior changes / gameplay notes
- Siege balloons:
  - Spawn from above the screen and drift downward toward the landmark.
  - Can be shot like normal balloons.
  - If they reach the landmark, they are destroyed and deal configured damage.
- Landmark:
  - Takes damage only while not liberated.
  - When HP hits 0 → game transitions to `gameover`.
- Scoring:
  - Popping siege balloons grants **+5 points**.

### Testing notes
**Manual verification recommended:**
- Levels 1–2: confirm **no siege balloons** spawn and HUD does not show landmark HP.
- Levels 3–5: confirm siege balloons spawn after configured delay and at configured rate; movement is downward; bomb icon/color renders correctly.
- Confirm siege balloon reaching the landmark:
  - Removes the balloon
  - Reduces landmark HP
  - Plays `landmark_damaged`
  - Triggers game over at 0 HP (message: “Landmark Destroyed!”)
- Confirm shooting siege balloons:
  - Balloon is destroyed
  - Score increases by 5
  - Plays `siege_hit`
- HUD:
  - Health bar updates and changes color by percent
  - Low-health flash triggers at critical HP
  - “UNDER ATTACK” appears only when siege balloons are alive on-screen

**TypeScript/build:**
- Run: `npm run typecheck` (expected: clean, exit code 0)

Ref: https://github.com/asgardtech/archer/issues/559