### PR TITLE
Jardinains: Add paddle shield power-up to block flower pot damage

### DIFF
--- a/src/games/jardinains/JardinainsGame.ts
+++ b/src/games/jardinains/JardinainsGame.ts
@@ -20,7 +20,7 @@ const SCORE_BRICK_STANDARD = 1;
 const SCORE_BRICK_TOUGH = 3;
 const SCORE_GNOME_CATCH = 5;
 const SCORE_LEVEL_CLEAR = 10;
-const POWER_UP_TYPES: PowerUpType[] = ["wide-paddle", "multi-ball", "sticky", "extra-life"];
+const POWER_UP_TYPES: PowerUpType[] = ["wide-paddle", "multi-ball", "sticky", "extra-life", "shield"];
 
 export class JardinainsGame implements IGame {
   private canvas: HTMLCanvasElement;
@@ -308,8 +308,12 @@ export class JardinainsGame implements IGame {
       pot.update(dt, this.height);
       if (pot.alive && this.collisions.checkPotPaddle(pot, this.paddle)) {
         pot.alive = false;
-        this.paddle.applyShrink();
-        this.sound.play("pot_hit");
+        const blocked = this.paddle.applyShrink();
+        if (blocked) {
+          this.sound.play("shield_block");
+        } else {
+          this.sound.play("pot_hit");
+        }
       }
     }
     this.flowerPots = this.flowerPots.filter((p) => p.alive);
@@ -328,6 +332,10 @@ export class JardinainsGame implements IGame {
         }
         if (pu.type === "wide-paddle") {
           this.paddle.applyWide();
+        }
+        if (pu.type === "shield") {
+          this.paddle.activateShield();
+          this.sound.play("shield_activate");
         }
       }
     }

--- a/src/games/jardinains/entities/Paddle.ts
+++ b/src/games/jardinains/entities/Paddle.ts
@@ -3,6 +3,8 @@ import { PaddleState } from "../types";
 const MIN_WIDTH = 40;
 const SHRINK_AMOUNT = 30;
 const WIDE_AMOUNT = 40;
+const SHIELD_DURATION = 12;
+const SHIELD_EXPIRE_WARN = 3;
 
 export class Paddle {
   public x: number;
@@ -12,6 +14,8 @@ export class Paddle {
   public baseWidth: number;
   public shrinkTimer = 0;
   public wideTimer = 0;
+  public shieldActive = false;
+  public shieldTimer = 0;
 
   constructor(canvasWidth: number, canvasHeight: number) {
     this.baseWidth = 100;
@@ -51,11 +55,28 @@ export class Paddle {
         this.recalcWidth();
       }
     }
+
+    if (this.shieldTimer > 0) {
+      this.shieldTimer -= dt;
+      if (this.shieldTimer <= 0) {
+        this.shieldTimer = 0;
+        this.shieldActive = false;
+      }
+    }
   }
 
-  applyShrink(): void {
+  applyShrink(): boolean {
+    if (this.shieldActive) {
+      return true;
+    }
     this.shrinkTimer = 5;
     this.recalcWidth();
+    return false;
+  }
+
+  activateShield(): void {
+    this.shieldActive = true;
+    this.shieldTimer = SHIELD_DURATION;
   }
 
   applyWide(): void {
@@ -75,6 +96,8 @@ export class Paddle {
     this.x = canvasWidth / 2;
     this.shrinkTimer = 0;
     this.wideTimer = 0;
+    this.shieldActive = false;
+    this.shieldTimer = 0;
   }
 
   getState(): PaddleState {
@@ -85,6 +108,8 @@ export class Paddle {
       height: this.height,
       baseWidth: this.baseWidth,
       shrinkTimer: this.shrinkTimer,
+      shieldActive: this.shieldActive,
+      shieldTimer: this.shieldTimer,
     };
   }
 
@@ -114,5 +139,35 @@ export class Paddle {
 
     ctx.fillStyle = "#A0522D";
     ctx.fillRect(x + 2, y + h - 4, w - 4, 3);
+
+    if (this.shieldActive) {
+      this.renderShield(ctx);
+    }
+  }
+
+  private renderShield(ctx: CanvasRenderingContext2D): void {
+    const cx = this.x;
+    const cy = this.top;
+    const rx = this.width / 2 + 6;
+    const ry = 18;
+
+    let alpha = 0.3;
+    if (this.shieldTimer <= SHIELD_EXPIRE_WARN) {
+      alpha = 0.15 + 0.15 * Math.abs(Math.sin(this.shieldTimer * 4));
+    }
+
+    ctx.save();
+    ctx.fillStyle = `rgba(0, 200, 255, ${alpha})`;
+    ctx.beginPath();
+    ctx.ellipse(cx, cy, rx, ry, 0, Math.PI, 0);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.strokeStyle = `rgba(0, 220, 255, ${alpha + 0.2})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.ellipse(cx, cy, rx, ry, 0, Math.PI, 0);
+    ctx.stroke();
+    ctx.restore();
   }
 }

--- a/src/games/jardinains/entities/PowerUp.ts
+++ b/src/games/jardinains/entities/PowerUp.ts
@@ -7,6 +7,7 @@ const POWERUP_COLORS: Record<PowerUpType, string> = {
   "multi-ball": "#9C27B0",
   "sticky": "#FF9800",
   "extra-life": "#F44336",
+  "shield": "#00BCD4",
 };
 
 const POWERUP_LABELS: Record<PowerUpType, string> = {
@@ -14,6 +15,7 @@ const POWERUP_LABELS: Record<PowerUpType, string> = {
   "multi-ball": "M",
   "sticky": "S",
   "extra-life": "\u2665",
+  "shield": "D",
 };
 
 export class PowerUp {

--- a/src/games/jardinains/systems/PowerUpManager.ts
+++ b/src/games/jardinains/systems/PowerUpManager.ts
@@ -27,6 +27,8 @@ export class PowerUpManager {
       case "extra-life":
         result.extraLife = true;
         break;
+      case "shield":
+        break;
     }
 
     return result;

--- a/src/games/jardinains/systems/SoundSystem.ts
+++ b/src/games/jardinains/systems/SoundSystem.ts
@@ -63,6 +63,12 @@ export class SoundSystem {
       case "menu_start":
         this.playMenuStart();
         break;
+      case "shield_activate":
+        this.playShieldActivate();
+        break;
+      case "shield_block":
+        this.playShieldBlock();
+        break;
     }
   }
 
@@ -203,6 +209,31 @@ export class SoundSystem {
       ],
       240
     );
+  }
+
+  private playShieldActivate(): void {
+    this.audio.playToneSwept(400, 1200, 0.2, "sine", {
+      attack: 0.01,
+      decay: 0.03,
+      sustain: 0.5,
+      release: 0.06,
+    });
+    this.audio.playTone(800, 0.15, "triangle", {
+      attack: 0.01,
+      decay: 0.02,
+      sustain: 0.3,
+      release: 0.04,
+    });
+  }
+
+  private playShieldBlock(): void {
+    this.audio.playTone(1800, 0.08, "square", {
+      attack: 0.002,
+      decay: 0.01,
+      sustain: 0.2,
+      release: 0.03,
+    });
+    this.audio.playNoise(0.06, 4000);
   }
 
   private playMenuStart(): void {

--- a/src/games/jardinains/types.ts
+++ b/src/games/jardinains/types.ts
@@ -10,7 +10,7 @@ export type JardinainsGameState =
   | "gameover"
   | "victory";
 
-export type PowerUpType = "wide-paddle" | "multi-ball" | "sticky" | "extra-life";
+export type PowerUpType = "wide-paddle" | "multi-ball" | "sticky" | "extra-life" | "shield";
 
 export type GnomeState = "sitting" | "ducking" | "falling" | "caught" | "gone";
 
@@ -21,6 +21,8 @@ export interface PaddleState {
   height: number;
   baseWidth: number;
   shrinkTimer: number;
+  shieldActive: boolean;
+  shieldTimer: number;
 }
 
 export interface BallState {
@@ -84,7 +86,9 @@ export type JardinainsSoundEvent =
   | "level_complete"
   | "game_over"
   | "victory"
-  | "menu_start";
+  | "menu_start"
+  | "shield_activate"
+  | "shield_block";
 
 export interface JardinainsLevelConfig {
   level: number;


### PR DESCRIPTION
## PR: Jardinains — Add paddle shield power-up to block flower pot damage (Issue #560, Epic #542)

### Summary (what changed + why)
This PR introduces a new **`shield` power-up** to Jardinains that **temporarily protects the paddle from gnome flower pot shrink effects**. Previously, any pot collision always triggered a shrink with no counterplay. With the shield active (12s duration), pots that hit the paddle are **destroyed harmlessly**, giving players a defensive option against repeated gnome harassment.

Key behavior:
- New power-up type: **`shield`**
- **12s timed shield** on the paddle; collecting again **refreshes** duration (non-stacking)
- While shielded, **flower pots do not shrink the paddle**
- Shield has **distinct visuals** (cyan dome + end-of-timer pulsing) and **new sound cues**

---

### Key files modified
- **`src/games/jardinains/types.ts`**
  - Add `shield` to `PowerUpType`
  - Extend `PaddleState` with `shieldActive` / `shieldTimer`
  - Add sound events: `shield_activate`, `shield_block`

- **`src/games/jardinains/entities/Paddle.ts`**
  - Add shield state + timer handling
  - Implement `activateShield()` (12s, refreshes if already active)
  - Change `applyShrink()` to return `boolean` (true = blocked by shield)
  - Render shield dome; pulse effect in final 3s
  - Clear shield state on `reset()`

- **`src/games/jardinains/entities/PowerUp.ts`**
  - Add shield visuals to lookup tables:
    - Color: `#00BCD4`
    - Label: `"D"` (ASCII-safe)

- **`src/games/jardinains/JardinainsGame.ts`**
  - Add `shield` to `POWER_UP_TYPES` drop pool
  - Update pot→paddle collision handling to respect shield via `applyShrink()` return value
  - Activate shield on power-up collection + play activation sound

- **`src/games/jardinains/systems/PowerUpManager.ts`**
  - Add `case "shield"` to activation switch (keeps manager compatible with new type)

- **`src/games/jardinains/systems/SoundSystem.ts`**
  - Implement playback for `shield_activate` and `shield_block`

---

### Testing notes
- **Typecheck:** `npm run typecheck` (expected clean)
- **Manual gameplay verification:**
  - Collecting shield activates dome visual and plays `shield_activate`
  - Pots hitting paddle while shielded are destroyed, paddle width unchanged, plays `shield_block` (not `pot_hit`)
  - Shield lasts ~12 seconds; dome **pulses in last 3 seconds**, then disappears on expiry
  - Shield state clears correctly on **life loss / level transition** (paddle reset)
  - Shield coexists with other paddle effects (wide/shrink timers run independently)
  - Power-up capsule appears **cyan** and labeled **“D”**, distinct from wide-paddle blue

--- 

### Notes for reviewers
- `Paddle.applyShrink()` now returns a boolean (blocked vs applied), and callers were updated accordingly.
- Shield only affects **flower pots**; ball behavior is unchanged.

Ref: https://github.com/asgardtech/archer/issues/560