### PR TITLE
Jardinains: Add flower pot deflection mechanic

### DIFF
--- a/src/games/jardinains/JardinainsGame.ts
+++ b/src/games/jardinains/JardinainsGame.ts
@@ -20,6 +20,7 @@ const SCORE_BRICK_STANDARD = 1;
 const SCORE_BRICK_TOUGH = 3;
 const SCORE_GNOME_CATCH = 5;
 const SCORE_LEVEL_CLEAR = 10;
+const SCORE_DEFLECT_GNOME = 10;
 const POWER_UP_TYPES: PowerUpType[] = ["wide-paddle", "multi-ball", "sticky", "extra-life", "shield"];
 
 export class JardinainsGame implements IGame {
@@ -211,6 +212,11 @@ export class JardinainsGame implements IGame {
     const config = this.currentLevelConfig;
 
     this.paddle.update(dt, this.input.mouseX, this.width);
+
+    if (this.input.deflectPressed) {
+      this.paddle.deflect();
+    }
+
     this.powerUpManager.update(dt);
 
     if (this.powerUpManager.isWidePaddleActive() && this.paddle.wideTimer <= 0) {
@@ -306,13 +312,31 @@ export class JardinainsGame implements IGame {
 
     for (const pot of this.flowerPots) {
       pot.update(dt, this.height);
-      if (pot.alive && this.collisions.checkPotPaddle(pot, this.paddle)) {
-        pot.alive = false;
-        const blocked = this.paddle.applyShrink();
-        if (blocked) {
-          this.sound.play("shield_block");
+
+      if (pot.alive && !pot.deflected && this.collisions.checkPotPaddle(pot, this.paddle)) {
+        if (this.paddle.isDeflecting) {
+          pot.deflect();
+          this.sound.play("pot_deflect");
         } else {
-          this.sound.play("pot_hit");
+          pot.alive = false;
+          const blocked = this.paddle.applyShrink();
+          if (blocked) {
+            this.sound.play("shield_block");
+          } else {
+            this.sound.play("pot_hit");
+          }
+        }
+      }
+
+      if (pot.alive && pot.deflected) {
+        for (const gnome of this.gnomes) {
+          if (this.collisions.checkPotGnome(pot, gnome)) {
+            pot.alive = false;
+            gnome.startFalling();
+            this.score += SCORE_DEFLECT_GNOME;
+            this.sound.play("pot_hit_gnome");
+            break;
+          }
         }
       }
     }
@@ -459,7 +483,10 @@ export class JardinainsGame implements IGame {
     this.hud.render(
       this.ctx, this.state, this.score, this.lives,
       config.level, config.name,
-      this.width, this.height
+      this.width, this.height,
+      this.paddle.canDeflect,
+      this.paddle.deflectCooldownFraction,
+      this.paddle.isDeflecting
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
   }

--- a/src/games/jardinains/entities/FlowerPot.ts
+++ b/src/games/jardinains/entities/FlowerPot.ts
@@ -1,6 +1,8 @@
 import { Vec2, FlowerPotEntity } from "../types";
 
 const POT_SPEED = 180;
+const DEFLECT_RETURN_SPEED = 280;
+const DEFLECT_SPREAD = 60;
 
 export class FlowerPot {
   public pos: Vec2;
@@ -8,6 +10,8 @@ export class FlowerPot {
   public alive = true;
   public width = 12;
   public height = 14;
+  public deflected = false;
+  private rotation = 0;
 
   constructor(x: number, y: number) {
     this.pos = { x, y };
@@ -19,11 +23,27 @@ export class FlowerPot {
   get top(): number { return this.pos.y - this.height / 2; }
   get bottom(): number { return this.pos.y + this.height / 2; }
 
+  deflect(): void {
+    this.deflected = true;
+    this.vel.y = -DEFLECT_RETURN_SPEED;
+    this.vel.x = (Math.random() - 0.5) * DEFLECT_SPREAD * 2;
+    this.rotation = 0;
+  }
+
   update(dt: number, canvasHeight: number): void {
     if (!this.alive) return;
+    this.pos.x += this.vel.x * dt;
     this.pos.y += this.vel.y * dt;
-    if (this.pos.y > canvasHeight + 20) {
-      this.alive = false;
+
+    if (this.deflected) {
+      this.rotation += dt * 12;
+      if (this.pos.y < -20 || this.pos.x < -50 || this.pos.x > 850) {
+        this.alive = false;
+      }
+    } else {
+      if (this.pos.y > canvasHeight + 20) {
+        this.alive = false;
+      }
     }
   }
 
@@ -32,6 +52,7 @@ export class FlowerPot {
       pos: { ...this.pos },
       vel: { ...this.vel },
       alive: this.alive,
+      deflected: this.deflected,
     };
   }
 
@@ -41,7 +62,14 @@ export class FlowerPot {
     const x = this.pos.x;
     const y = this.pos.y;
 
-    // Terracotta pot (trapezoid)
+    ctx.save();
+
+    if (this.deflected) {
+      ctx.translate(x, y);
+      ctx.rotate(this.rotation);
+      ctx.translate(-x, -y);
+    }
+
     ctx.fillStyle = "#D2691E";
     ctx.beginPath();
     ctx.moveTo(x - 5, y - 4);
@@ -51,11 +79,9 @@ export class FlowerPot {
     ctx.closePath();
     ctx.fill();
 
-    // Pot rim
     ctx.fillStyle = "#A0522D";
     ctx.fillRect(x - 6, y - 6, 12, 3);
 
-    // Plant poking out
     ctx.fillStyle = "#4CAF50";
     ctx.beginPath();
     ctx.ellipse(x, y - 8, 4, 3, 0, 0, Math.PI * 2);
@@ -67,5 +93,12 @@ export class FlowerPot {
     ctx.beginPath();
     ctx.ellipse(x + 2, y - 10, 2, 3, 0.3, 0, Math.PI * 2);
     ctx.fill();
+
+    if (this.deflected) {
+      ctx.fillStyle = "rgba(255, 215, 0, 0.3)";
+      ctx.fillRect(x - 8, y - 11, 16, 18);
+    }
+
+    ctx.restore();
   }
 }

--- a/src/games/jardinains/entities/Paddle.ts
+++ b/src/games/jardinains/entities/Paddle.ts
@@ -5,6 +5,8 @@ const SHRINK_AMOUNT = 30;
 const WIDE_AMOUNT = 40;
 const SHIELD_DURATION = 12;
 const SHIELD_EXPIRE_WARN = 3;
+const DEFLECT_WINDOW = 0.3;
+const DEFLECT_COOLDOWN = 1.5;
 
 export class Paddle {
   public x: number;
@@ -16,12 +18,27 @@ export class Paddle {
   public wideTimer = 0;
   public shieldActive = false;
   public shieldTimer = 0;
+  public deflectTimer = 0;
+  public deflectCooldownTimer = 0;
 
   constructor(canvasWidth: number, canvasHeight: number) {
     this.baseWidth = 100;
     this.width = this.baseWidth;
     this.x = canvasWidth / 2;
     this.y = canvasHeight - 30;
+  }
+
+  get isDeflecting(): boolean {
+    return this.deflectTimer > 0;
+  }
+
+  get canDeflect(): boolean {
+    return this.deflectCooldownTimer <= 0 && this.deflectTimer <= 0;
+  }
+
+  get deflectCooldownFraction(): number {
+    if (this.deflectCooldownTimer <= 0) return 0;
+    return this.deflectCooldownTimer / DEFLECT_COOLDOWN;
   }
 
   get left(): number {
@@ -63,6 +80,21 @@ export class Paddle {
         this.shieldActive = false;
       }
     }
+
+    if (this.deflectTimer > 0) {
+      this.deflectTimer -= dt;
+      if (this.deflectTimer <= 0) {
+        this.deflectTimer = 0;
+        this.deflectCooldownTimer = DEFLECT_COOLDOWN;
+      }
+    }
+
+    if (this.deflectCooldownTimer > 0) {
+      this.deflectCooldownTimer -= dt;
+      if (this.deflectCooldownTimer <= 0) {
+        this.deflectCooldownTimer = 0;
+      }
+    }
   }
 
   applyShrink(): boolean {
@@ -72,6 +104,12 @@ export class Paddle {
     this.shrinkTimer = 5;
     this.recalcWidth();
     return false;
+  }
+
+  deflect(): boolean {
+    if (this.deflectCooldownTimer > 0 || this.deflectTimer > 0) return false;
+    this.deflectTimer = DEFLECT_WINDOW;
+    return true;
   }
 
   activateShield(): void {
@@ -98,6 +136,8 @@ export class Paddle {
     this.wideTimer = 0;
     this.shieldActive = false;
     this.shieldTimer = 0;
+    this.deflectTimer = 0;
+    this.deflectCooldownTimer = 0;
   }
 
   getState(): PaddleState {
@@ -110,6 +150,9 @@ export class Paddle {
       shrinkTimer: this.shrinkTimer,
       shieldActive: this.shieldActive,
       shieldTimer: this.shieldTimer,
+      deflectTimer: this.deflectTimer,
+      deflectCooldownTimer: this.deflectCooldownTimer,
+      isDeflecting: this.isDeflecting,
     };
   }
 
@@ -143,6 +186,10 @@ export class Paddle {
     if (this.shieldActive) {
       this.renderShield(ctx);
     }
+
+    if (this.isDeflecting) {
+      this.renderDeflect(ctx);
+    }
   }
 
   private renderShield(ctx: CanvasRenderingContext2D): void {
@@ -164,6 +211,28 @@ export class Paddle {
     ctx.fill();
 
     ctx.strokeStyle = `rgba(0, 220, 255, ${alpha + 0.2})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.ellipse(cx, cy, rx, ry, 0, Math.PI, 0);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  private renderDeflect(ctx: CanvasRenderingContext2D): void {
+    const cx = this.x;
+    const cy = this.top;
+    const rx = this.width / 2 + 4;
+    const ry = 12;
+    const progress = this.deflectTimer / DEFLECT_WINDOW;
+
+    ctx.save();
+    ctx.fillStyle = `rgba(255, 255, 100, ${0.4 * progress})`;
+    ctx.beginPath();
+    ctx.ellipse(cx, cy, rx, ry, 0, Math.PI, 0);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.strokeStyle = `rgba(255, 255, 200, ${0.7 * progress})`;
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.ellipse(cx, cy, rx, ry, 0, Math.PI, 0);

--- a/src/games/jardinains/rendering/HUD.ts
+++ b/src/games/jardinains/rendering/HUD.ts
@@ -48,17 +48,20 @@ export class HUD {
     level: number,
     levelName: string,
     width: number,
-    height: number
+    height: number,
+    deflectReady = true,
+    deflectCooldownFraction = 0,
+    isDeflecting = false,
   ): void {
     switch (state) {
       case "menu":
         this.renderMenu(ctx, width, height);
         break;
       case "playing":
-        this.renderPlayingHUD(ctx, score, lives, level, levelName, width);
+        this.renderPlayingHUD(ctx, score, lives, level, levelName, width, deflectReady, deflectCooldownFraction, isDeflecting);
         break;
       case "level_complete":
-        this.renderPlayingHUD(ctx, score, lives, level, levelName, width);
+        this.renderPlayingHUD(ctx, score, lives, level, levelName, width, deflectReady, deflectCooldownFraction, isDeflecting);
         this.renderOverlay(ctx, width, height, "Level Complete!", this.actionText("for next level"));
         break;
       case "gameover":
@@ -99,6 +102,13 @@ export class HUD {
     ctx.fillStyle = "#AAAAAA";
     ctx.fillText("Move paddle with mouse/touch \u2022 Break bricks \u2022 Catch gnomes", width / 2, height / 2 + 80);
 
+    ctx.fillText(
+      this.isTouchDevice
+        ? "Two-finger tap to deflect pots"
+        : "Space / Right-click to deflect pots",
+      width / 2, height / 2 + 100
+    );
+
     ctx.restore();
   }
 
@@ -108,7 +118,10 @@ export class HUD {
     lives: number,
     level: number,
     levelName: string,
-    width: number
+    width: number,
+    deflectReady: boolean,
+    deflectCooldownFraction: number,
+    isDeflecting: boolean,
   ): void {
     ctx.save();
 
@@ -126,11 +139,56 @@ export class HUD {
     ctx.fillStyle = "#FFD700";
     ctx.fillText(`Level ${level} \u2013 ${levelName}`, width / 2, 14);
 
+    this.renderDeflectIndicator(ctx, width, deflectReady, deflectCooldownFraction, isDeflecting);
+
     ctx.textAlign = "right";
     ctx.fillStyle = "#FF6B6B";
     let livesText = "";
     for (let i = 0; i < lives; i++) livesText += "\u2665 ";
     ctx.fillText(livesText.trim(), width - 10, 14);
+
+    ctx.restore();
+  }
+
+  private renderDeflectIndicator(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    ready: boolean,
+    cooldownFraction: number,
+    active: boolean,
+  ): void {
+    const x = canvasWidth - 160;
+    const y = 14;
+    const r = 8;
+
+    ctx.save();
+
+    if (active) {
+      ctx.fillStyle = "#FFD700";
+    } else if (ready) {
+      ctx.fillStyle = "#66BB6A";
+    } else {
+      ctx.fillStyle = "#555";
+    }
+
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+
+    if (!ready && !active && cooldownFraction > 0) {
+      ctx.fillStyle = "#66BB6A";
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.arc(x, y, r, -Math.PI / 2, -Math.PI / 2 + (1 - cooldownFraction) * Math.PI * 2);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    ctx.fillStyle = "#fff";
+    ctx.font = "bold 10px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("\u2191", x, y);
 
     ctx.restore();
   }

--- a/src/games/jardinains/systems/CollisionSystem.ts
+++ b/src/games/jardinains/systems/CollisionSystem.ts
@@ -77,6 +77,17 @@ export class CollisionSystem {
     );
   }
 
+  checkPotGnome(pot: FlowerPot, gnome: Gnome): boolean {
+    if (!pot.alive || !pot.deflected) return false;
+    if (gnome.state !== "sitting" && gnome.state !== "ducking") return false;
+    return (
+      pot.right > gnome.left &&
+      pot.left < gnome.right &&
+      pot.bottom > gnome.top &&
+      pot.top < gnome.bottom
+    );
+  }
+
   checkPowerUpPaddle(powerUp: PowerUp, paddle: Paddle): boolean {
     if (!powerUp.alive) return false;
     return (

--- a/src/games/jardinains/systems/InputManager.ts
+++ b/src/games/jardinains/systems/InputManager.ts
@@ -2,6 +2,7 @@ export class InputManager {
   public mouseX = 400;
   public mouseY = 0;
   public wasClicked = false;
+  public deflectPressed = false;
   public readonly isTouchDevice: boolean;
 
   private canvas: HTMLCanvasElement;
@@ -12,6 +13,8 @@ export class InputManager {
   private boundTouchStart: (e: TouchEvent) => void;
   private boundTouchMove: (e: TouchEvent) => void;
   private boundTouchEnd: (e: TouchEvent) => void;
+  private boundKeyDown: (e: KeyboardEvent) => void;
+  private boundContextMenu: (e: Event) => void;
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
@@ -25,16 +28,21 @@ export class InputManager {
     this.boundTouchStart = (e) => this.onTouchStart(e);
     this.boundTouchMove = (e) => this.onTouchMove(e);
     this.boundTouchEnd = (e) => this.onTouchEnd(e);
+    this.boundKeyDown = (e) => this.onKeyDown(e);
+    this.boundContextMenu = (e) => e.preventDefault();
 
     canvas.addEventListener("mousemove", this.boundMouseMove);
     canvas.addEventListener("mousedown", this.boundMouseDown);
     canvas.addEventListener("touchstart", this.boundTouchStart, { passive: false });
     canvas.addEventListener("touchmove", this.boundTouchMove, { passive: false });
     canvas.addEventListener("touchend", this.boundTouchEnd, { passive: false });
+    document.addEventListener("keydown", this.boundKeyDown);
+    canvas.addEventListener("contextmenu", this.boundContextMenu);
   }
 
   consume(): void {
     this.wasClicked = false;
+    this.deflectPressed = false;
   }
 
   destroy(): void {
@@ -43,6 +51,8 @@ export class InputManager {
     this.canvas.removeEventListener("touchstart", this.boundTouchStart);
     this.canvas.removeEventListener("touchmove", this.boundTouchMove);
     this.canvas.removeEventListener("touchend", this.boundTouchEnd);
+    document.removeEventListener("keydown", this.boundKeyDown);
+    this.canvas.removeEventListener("contextmenu", this.boundContextMenu);
   }
 
   private toCanvasX(clientX: number): number {
@@ -63,14 +73,23 @@ export class InputManager {
   }
 
   private onMouseDown(e: MouseEvent): void {
-    this.wasClicked = true;
-    this.mouseX = this.toCanvasX(e.clientX);
-    this.mouseY = this.toCanvasY(e.clientY);
+    if (e.button === 0) {
+      this.wasClicked = true;
+      this.mouseX = this.toCanvasX(e.clientX);
+      this.mouseY = this.toCanvasY(e.clientY);
+    } else if (e.button === 2) {
+      this.deflectPressed = true;
+    }
   }
 
   private onTouchStart(e: TouchEvent): void {
     e.preventDefault();
-    if (this.activeTouchId !== null) return;
+    if (this.activeTouchId !== null) {
+      if (e.touches.length >= 2) {
+        this.deflectPressed = true;
+      }
+      return;
+    }
     const touch = e.changedTouches[0];
     this.activeTouchId = touch.identifier;
     this.mouseX = this.toCanvasX(touch.clientX);
@@ -91,6 +110,13 @@ export class InputManager {
     const touch = this.getActiveTouch(e.changedTouches);
     if (!touch) return;
     this.activeTouchId = null;
+  }
+
+  private onKeyDown(e: KeyboardEvent): void {
+    if (e.code === "Space" || e.key === " ") {
+      e.preventDefault();
+      this.deflectPressed = true;
+    }
   }
 
   private getActiveTouch(touches: TouchList): Touch | null {

--- a/src/games/jardinains/systems/SoundSystem.ts
+++ b/src/games/jardinains/systems/SoundSystem.ts
@@ -69,6 +69,12 @@ export class SoundSystem {
       case "shield_block":
         this.playShieldBlock();
         break;
+      case "pot_deflect":
+        this.playPotDeflect();
+        break;
+      case "pot_hit_gnome":
+        this.playPotHitGnome();
+        break;
     }
   }
 
@@ -234,6 +240,33 @@ export class SoundSystem {
       release: 0.03,
     });
     this.audio.playNoise(0.06, 4000);
+  }
+
+  private playPotDeflect(): void {
+    this.audio.playToneSwept(800, 1400, 0.12, "sine", {
+      attack: 0.005,
+      decay: 0.02,
+      sustain: 0.4,
+      release: 0.04,
+    });
+    this.audio.playNoise(0.06, 5000);
+  }
+
+  private playPotHitGnome(): void {
+    this.audio.playTone(200, 0.08, "triangle", {
+      attack: 0.005,
+      decay: 0.02,
+      sustain: 0.4,
+      release: 0.03,
+    });
+    this.audio.playSequence(
+      [
+        { frequency: 660, duration: 0.15, type: "sine" },
+        { frequency: 880, duration: 0.15, type: "sine" },
+        { frequency: 1100, duration: 0.2, type: "sine" },
+      ],
+      280
+    );
   }
 
   private playMenuStart(): void {

--- a/src/games/jardinains/types.ts
+++ b/src/games/jardinains/types.ts
@@ -23,6 +23,9 @@ export interface PaddleState {
   shrinkTimer: number;
   shieldActive: boolean;
   shieldTimer: number;
+  deflectTimer: number;
+  deflectCooldownTimer: number;
+  isDeflecting: boolean;
 }
 
 export interface BallState {
@@ -63,6 +66,7 @@ export interface FlowerPotEntity {
   pos: Vec2;
   vel: Vec2;
   alive: boolean;
+  deflected: boolean;
 }
 
 export interface PowerUpEntity {
@@ -88,7 +92,9 @@ export type JardinainsSoundEvent =
   | "victory"
   | "menu_start"
   | "shield_activate"
-  | "shield_block";
+  | "shield_block"
+  | "pot_deflect"
+  | "pot_hit_gnome";
 
 export interface JardinainsLevelConfig {
   level: number;


### PR DESCRIPTION
## PR: Jardinains — Add flower pot deflection mechanic (Issue #561, part of epic #542)

### Summary (what changed & why)
Flower pots are no longer a purely unavoidable/punishing hazard. This PR adds a **skill-based “deflect” mechanic**: pressing **Space** or **right-click** (or **two-finger tap** on touch) activates a short **deflect window (~0.3s)** on the paddle. If a pot hits the paddle during that window, it’s **sent back upward** instead of shrinking the paddle. Deflected pots can **hit gnomes** to knock them off their bricks and award **+10 bonus points**, adding counterplay and rewarding timing.

Key gameplay notes:
- Deflect has a **cooldown (~1.5s)** to prevent spamming.
- **Deflect takes priority over shield** (shield is not consumed when a pot is deflected).
- Right-click no longer triggers “click” actions (fixes an input regression where right-click previously launched the ball / advanced menus).

---

### Key files modified
- `src/games/jardinains/systems/InputManager.ts`
  - Adds `deflectPressed` (edge-triggered) for Space/right-click/two-finger tap
  - Fixes mouse button discrimination so right-click doesn’t set `wasClicked`
  - Suppresses canvas context menu for right-click deflect
- `src/games/jardinains/entities/Paddle.ts`
  - Deflect window + cooldown timers, `isDeflecting`/`canDeflect` helpers
  - Yellow arc glow visual feedback while deflecting
  - Resets deflect state on paddle reset
- `src/games/jardinains/entities/FlowerPot.ts`
  - Adds `deflected` state + `deflect()` behavior (reverse to -280px/s + horizontal spread)
  - Spinning/tint feedback for deflected pots
  - Off-screen cleanup (including top/side for deflected pots)
- `src/games/jardinains/systems/CollisionSystem.ts`
  - Adds `checkPotGnome()` (AABB) for **deflected** pots vs gnomes
- `src/games/jardinains/JardinainsGame.ts`
  - Wires deflect input into paddle
  - Branches pot-paddle collision: deflect vs shrink/shield handling
  - Adds deflected pot → gnome hit logic (+10 score, SFX)
  - Passes deflect state into HUD
- `src/games/jardinains/rendering/HUD.ts`
  - Adds deflect cooldown/ready/active indicator (radial fill)
  - Adds menu hint: “Space / Right-click to deflect pots”
- `src/games/jardinains/systems/SoundSystem.ts`
  - Adds `pot_deflect` and `pot_hit_gnome` sound events
- `src/games/jardinains/types.ts`
  - Extends sound event union + adds paddle/pot state fields (`deflect*`, `deflected`)

---

### Testing notes
Manual verification checklist:
- **Input**
  - Space triggers deflect window; right-click triggers deflect and **does not** launch stuck ball / click UI.
  - Two-finger tap triggers deflect while primary finger continues controlling paddle.
- **Gameplay**
  - Pot hitting paddle during deflect window bounces upward, no shrink applied, plays `pot_deflect`.
  - Deflect cooldown prevents reactivation until elapsed; HUD indicator reflects ready/cooldown/active.
  - Deflected pot can hit a sitting/ducking gnome → gnome falls, pot destroyed, **+10 score**, plays `pot_hit_gnome`.
  - With shield active + deflect active, **deflect wins** and shield charge is not consumed.
  - Deflected pots are cleaned up when leaving screen (top/side), and on level transitions.

Build/TS:
- `npm run typecheck` (per acceptance criteria) should pass with no TypeScript errors.

Ref: https://github.com/asgardtech/archer/issues/561