### PR TITLE
the beginning and end of the game stories should be in one screen; right now the user has to go through many clicks, each displaying one sentence

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -430,7 +430,7 @@ export class RaptorGame implements IGame {
               this.sound.play("menu_start");
               SaveSystem.clear();
               this.resetGame();
-              this.storyRenderer.show(GAME_STORY.opening, "center", "pilot");
+              this.storyRenderer.show([GAME_STORY.opening.join(" ")], "center", "pilot");
               this.state = "story_intro";
               this.sound.startMusic("playing", 0);
             }
@@ -438,7 +438,7 @@ export class RaptorGame implements IGame {
             this.audio.ensureContext();
             this.sound.play("menu_start");
             this.resetGame();
-            this.storyRenderer.show(GAME_STORY.opening, "center", "pilot");
+            this.storyRenderer.show([GAME_STORY.opening.join(" ")], "center", "pilot");
             this.state = "story_intro";
             this.sound.startMusic("playing", 0);
           }
@@ -917,7 +917,7 @@ export class RaptorGame implements IGame {
         this.state = "victory";
         this.sound.play("victory");
         SaveSystem.clear();
-        this.storyRenderer.show(GAME_STORY.ending, "center", "pilot");
+        this.storyRenderer.show([GAME_STORY.ending.join(" ")], "center", "pilot");
         this.hud.setVictoryStoryActive(true);
       } else {
         this.state = "level_complete";

--- a/tests/raptor-qa.test.ts
+++ b/tests/raptor-qa.test.ts
@@ -23,6 +23,7 @@ import {
   Vec2,
 } from "../src/games/raptor/types";
 import { AUDIO_MANIFEST } from "../src/games/raptor/rendering/audioAssets";
+import { GAME_STORY } from "../src/games/raptor/story";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -333,6 +334,57 @@ describe("Scenario: Clicking on the menu starts the game", () => {
     (game as any).update(0.016);
 
     expect(game.player.lives).toBe(3);
+  });
+});
+
+describe("Scenario: Opening story displays all text in one panel", () => {
+  test("storyRenderer.show is called with a single joined string for opening", () => {
+    const { game } = createPlayingGame();
+    const showSpy = jest.spyOn(game.storyRenderer, "show");
+    game.state = "menu";
+    game.input.wasClicked = true;
+
+    (game as any).update(0.016);
+
+    expect(showSpy).toHaveBeenCalledTimes(1);
+    const messages = showSpy.mock.calls[0][0] as string[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toBe(GAME_STORY.opening.join(" "));
+    showSpy.mockRestore();
+  });
+
+  test("opening story is a single message, not one per sentence", () => {
+    const joined = GAME_STORY.opening.join(" ");
+    expect(GAME_STORY.opening.length).toBeGreaterThan(1);
+    for (const sentence of GAME_STORY.opening) {
+      expect(joined).toContain(sentence);
+    }
+  });
+});
+
+describe("Scenario: Ending story displays all text in one panel", () => {
+  test("storyRenderer.show is called with a single joined string for ending", () => {
+    const { game } = createPlayingGame();
+    const showSpy = jest.spyOn(game.storyRenderer, "show");
+    game.currentLevel = LEVELS.length - 1;
+    game.spawner.configure(LEVELS[LEVELS.length - 1]);
+
+    for (let t = 0; t < 200; t += 0.1) {
+      game.spawner.update(0.1, 800);
+    }
+    game.spawner.spawnBoss(800);
+    game.spawner.markBossDefeated();
+    game.enemies = [];
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("victory");
+    expect(showSpy).toHaveBeenCalled();
+    const lastCall = showSpy.mock.calls[showSpy.mock.calls.length - 1];
+    const messages = lastCall[0] as string[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toBe(GAME_STORY.ending.join(" "));
+    showSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## PR: Consolidate game story intro/ending into single screens (Issue #577)

### Summary / Why
The opening (9 sentences) and ending (10 sentences) story sequences were previously rendered as **one sentence per screen**, forcing players to click through ~9 clicks at the start and ~10 clicks after victory. This PR consolidates each sequence into **a single story panel** by joining the sentence arrays into one string at the call sites.  
Result: each sequence now takes **2 clicks** (one to instantly reveal remaining typed text, one to dismiss), while **ESC still skips** the entire story.

### What changed
- Updated the three story `show()` call sites to pass a single combined message:
  - `GAME_STORY.opening` → `[GAME_STORY.opening.join(" ")]`
  - `GAME_STORY.ending` → `[GAME_STORY.ending.join(" ")]`
- No changes were made to `StoryRenderer` or the `GAME_STORY` data format; wrapping/typewriter behavior remains handled by existing renderer logic.

### Key files modified
- **`src/games/raptor/RaptorGame.ts`**
  - Updated three call sites:
    - New game start (no save data)
    - New game start via “New Game” when save data exists
    - Victory ending sequence

### Testing notes
- **Manual QA**
  - Start a new game → opening story displays as a single panel with typewriter animation.
  - Click once during typing → remaining text reveals instantly.
  - Click again after fully revealed → story dismisses and game proceeds.
  - Press **ESC** during story → skips story immediately.
  - Win final level → ending story behaves the same (single panel, reveal/dismiss, ESC skip).
- **Automated tests**
  - If present, update `tests/raptor-qa.test.ts` `story_intro` expectations to reflect single-panel behavior (2 clicks to pass instead of multiple sentence-by-sentence clicks).

Ref: https://github.com/asgardtech/archer/issues/577