### PR TITLE
once a weapon has been received, the user should be able to switch to it

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,4 +1,4 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER } from "./types";
 import { detectSpeaker } from "./rendering/StoryRenderer";
 import { InputManager } from "./systems/InputManager";
 import { DevConsole } from "./systems/DevConsole";
@@ -566,7 +566,9 @@ export class RaptorGame implements IGame {
 
     const config = this.currentLevelConfig;
 
-    if (this.input.wasClicked && this.hud.isBombButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+    if (this.input.wasClicked && this.hud.isWeaponCycleButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+      this.input.wasCycleNextPressed = true;
+    } else if (this.input.wasClicked && this.hud.isBombButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
       this.input.wasBombPressed = true;
     } else if (this.input.wasClicked && this.storyRenderer.isActive) {
       this.storyRenderer.advance();
@@ -596,6 +598,30 @@ export class RaptorGame implements IGame {
             this.handleEnemyDestroyed(enemy, config);
           }
         }
+      }
+    }
+
+    if (this.input.weaponSlotPressed !== null) {
+      const type = WEAPON_SLOT_ORDER[this.input.weaponSlotPressed - 1];
+      if (type && this.powerUpManager.switchWeapon(type)) {
+        this.weaponSystem.setWeapon(this.powerUpManager.currentWeapon);
+        this.sound.play("weapon_switch");
+      }
+    }
+    if (this.input.wasCycleNextPressed) {
+      const prev = this.powerUpManager.currentWeapon;
+      this.powerUpManager.cycleWeapon(1);
+      if (this.powerUpManager.currentWeapon !== prev) {
+        this.weaponSystem.setWeapon(this.powerUpManager.currentWeapon);
+        this.sound.play("weapon_switch");
+      }
+    }
+    if (this.input.wasCyclePrevPressed) {
+      const prev = this.powerUpManager.currentWeapon;
+      this.powerUpManager.cycleWeapon(-1);
+      if (this.powerUpManager.currentWeapon !== prev) {
+        this.weaponSystem.setWeapon(this.powerUpManager.currentWeapon);
+        this.sound.play("weapon_switch");
       }
     }
 
@@ -939,6 +965,10 @@ export class RaptorGame implements IGame {
         this.state = "level_complete";
         this.sound.play("level_complete");
         this.hud.setCompletionText(this.currentLevelConfig.story?.completionText ?? null);
+        const inventoryRecord: Record<string, number> = {};
+        for (const [w, t] of this.powerUpManager.inventory) {
+          inventoryRecord[w] = t;
+        }
         SaveSystem.save({
           version: 1,
           levelReached: this.currentLevel + 1,
@@ -948,6 +978,7 @@ export class RaptorGame implements IGame {
           savedAt: new Date().toISOString(),
           bombs: this.player.bombs,
           weaponTier: this.powerUpManager.weaponTier,
+          weaponInventory: inventoryRecord,
         });
       }
     }
@@ -1094,11 +1125,29 @@ export class RaptorGame implements IGame {
     this.startLevel(data.levelReached, false);
     this.player.lives = data.lives;
     this.player.bombs = data.bombs ?? 0;
-    // Order matters: setWeapon() may transiently bump the tier (e.g. "upgraded"
-    // when restoring the default machine-gun), so setTier() must come second to
-    // overwrite with the saved value.
-    this.powerUpManager.setWeapon(data.weapon);
-    this.powerUpManager.setTier(data.weaponTier ?? 1);
+
+    if (data.weaponInventory) {
+      const inv = new Map<WeaponType, number>();
+      for (const [key, val] of Object.entries(data.weaponInventory)) {
+        inv.set(key as WeaponType, val);
+      }
+      if (!inv.has("machine-gun")) {
+        inv.set("machine-gun", 1);
+      }
+      this.powerUpManager.setInventory(inv);
+      this.powerUpManager.setActiveWeapon(data.weapon);
+    } else {
+      // Backward compat: construct inventory from single weapon + tier
+      const inv = new Map<WeaponType, number>([["machine-gun", 1]]);
+      const tier = data.weaponTier ?? 1;
+      if (data.weapon !== "machine-gun") {
+        inv.set(data.weapon, tier);
+      } else {
+        inv.set("machine-gun", tier);
+      }
+      this.powerUpManager.setInventory(inv);
+      this.powerUpManager.setActiveWeapon(data.weapon);
+    }
   }
 
   private enterBriefing(): void {
@@ -1415,7 +1464,8 @@ export class RaptorGame implements IGame {
       this.player.bombs,
       this.powerUpManager.weaponTier,
       this.player.isShieldRegenerating,
-      this.player.dodgeCooldownFraction
+      this.player.dodgeCooldownFraction,
+      this.powerUpManager.inventory
     );
     this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width);
     this.hud.renderSettingsButton(this.ctx, this.width);

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -1,4 +1,4 @@
-import { RaptorGameState, RaptorPowerUpType, WeaponType } from "../types";
+import { RaptorGameState, RaptorPowerUpType, WeaponType, WEAPON_SLOT_ORDER } from "../types";
 import { ActiveEffect, EFFECT_DURATIONS } from "../systems/PowerUpManager";
 import { AssetLoader } from "./AssetLoader";
 import { ShipRenderer } from "./ShipRenderer";
@@ -414,7 +414,8 @@ export class HUD {
     bombs?: number,
     weaponTier?: number,
     isShieldRegenerating?: boolean,
-    dodgeCooldownFraction?: number
+    dodgeCooldownFraction?: number,
+    inventory?: ReadonlyMap<WeaponType, number>
   ): void {
     switch (state) {
       case "loading":
@@ -426,10 +427,10 @@ export class HUD {
       case "briefing":
         break;
       case "playing":
-        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating, dodgeCooldownFraction);
+        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating, dodgeCooldownFraction, inventory);
         break;
       case "level_complete":
-        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating, dodgeCooldownFraction);
+        this.renderPlayingHUD(ctx, score, lives, shield, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isShieldRegenerating, dodgeCooldownFraction, inventory);
         this.renderOverlay(ctx, width, height, "Level Complete!",
           this.completionLines,
           `Score: ${score}`,
@@ -631,7 +632,8 @@ export class HUD {
     bombs?: number,
     weaponTier?: number,
     isShieldRegenerating?: boolean,
-    dodgeCooldownFraction?: number
+    dodgeCooldownFraction?: number,
+    inventory?: ReadonlyMap<WeaponType, number>
   ): void {
     ctx.save();
 
@@ -677,6 +679,11 @@ export class HUD {
     this.renderDodgeCooldown(ctx, dodgeCooldownFraction ?? 0, 10, 52);
     this.renderTouchBombButton(ctx, bombs ?? 0, width, height);
     this.renderTouchDodgeButton(ctx, dodgeCooldownFraction ?? 0, width, height);
+
+    if (inventory && inventory.size > 1) {
+      this.renderWeaponTray(ctx, inventory, currentWeapon ?? "machine-gun", width);
+    }
+    this.renderTouchWeaponCycleButton(ctx, width, height, inventory);
   }
 
   private renderShieldBar(ctx: CanvasRenderingContext2D, shield: number, canvasHeight: number, isRegenerating?: boolean): void {
@@ -930,6 +937,112 @@ export class HUD {
     ctx.textBaseline = "middle";
     ctx.fillStyle = "#FFFFFF";
     ctx.fillText("DASH", btn.x + btn.w / 2, btn.y + btn.h / 2);
+    ctx.restore();
+  }
+
+  private renderWeaponTray(
+    ctx: CanvasRenderingContext2D,
+    inventory: ReadonlyMap<WeaponType, number>,
+    activeWeapon: WeaponType,
+    canvasWidth: number
+  ): void {
+    const TIER_PIPS = ["I", "II", "III"];
+    const slotW = 38;
+    const slotH = 28;
+    const gap = 3;
+    const ownedWeapons = WEAPON_SLOT_ORDER.filter((w) => inventory.has(w));
+    const totalW = ownedWeapons.length * slotW + (ownedWeapons.length - 1) * gap;
+    const startX = (canvasWidth - totalW) / 2;
+    const trayY = 50;
+
+    ctx.save();
+
+    for (let i = 0; i < ownedWeapons.length; i++) {
+      const weapon = ownedWeapons[i];
+      const tier = inventory.get(weapon) ?? 1;
+      const isActive = weapon === activeWeapon;
+      const x = startX + i * (slotW + gap);
+
+      ctx.fillStyle = isActive
+        ? "rgba(255, 255, 255, 0.15)"
+        : "rgba(0, 0, 0, 0.3)";
+      this.roundedRect(ctx, x, trayY, slotW, slotH, 4);
+      ctx.fill();
+
+      if (isActive) {
+        ctx.strokeStyle = WEAPON_COLORS[weapon];
+        ctx.lineWidth = 1.5;
+        this.roundedRect(ctx, x, trayY, slotW, slotH, 4);
+        ctx.stroke();
+      }
+
+      ctx.globalAlpha = isActive ? 1.0 : 0.5;
+
+      ctx.font = `6px ${RETRO_FONT}`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = WEAPON_COLORS[weapon];
+      ctx.fillText(WEAPON_LABELS[weapon], x + slotW / 2, trayY + 10);
+
+      ctx.font = `5px ${RETRO_FONT}`;
+      ctx.fillStyle = isActive ? "#ffffff" : "#aaaaaa";
+      ctx.fillText(TIER_PIPS[tier - 1], x + slotW / 2, trayY + 20);
+
+      if (!this.isTouchDevice) {
+        const slotIndex = WEAPON_SLOT_ORDER.indexOf(weapon) + 1;
+        ctx.font = `5px ${RETRO_FONT}`;
+        ctx.fillStyle = "rgba(255, 255, 255, 0.3)";
+        ctx.fillText(`${slotIndex}`, x + slotW / 2, trayY + slotH + 6);
+      }
+
+      ctx.globalAlpha = 1.0;
+    }
+
+    ctx.restore();
+  }
+
+  private getWeaponCycleButtonRect(width: number, height: number) {
+    const dodgeBtn = this.getDodgeButtonRect(width, height);
+    const size = 44;
+    return { x: dodgeBtn.x - size - 8, y: dodgeBtn.y, w: size, h: size };
+  }
+
+  isWeaponCycleButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    if (!this.isTouchDevice) return false;
+    const btn = this.getWeaponCycleButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w
+        && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  private renderTouchWeaponCycleButton(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    inventory?: ReadonlyMap<WeaponType, number>
+  ): void {
+    if (!this.isTouchDevice) return;
+    if (!inventory || inventory.size <= 1) return;
+    const btn = this.getWeaponCycleButtonRect(width, height);
+
+    ctx.save();
+    ctx.globalAlpha = 0.7;
+    ctx.fillStyle = "#8e44ad";
+    ctx.beginPath();
+    ctx.roundRect(btn.x, btn.y, btn.w, btn.h, 8);
+    ctx.fill();
+
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.3)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.roundRect(btn.x, btn.y, btn.w, btn.h, 8);
+    ctx.stroke();
+
+    ctx.globalAlpha = 1;
+    ctx.font = `8px ${RETRO_FONT}`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = "#FFFFFF";
+    ctx.fillText("WPN", btn.x + btn.w / 2, btn.y + btn.h / 2);
     ctx.restore();
   }
 

--- a/src/games/raptor/systems/CommandRegistry.ts
+++ b/src/games/raptor/systems/CommandRegistry.ts
@@ -132,7 +132,7 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
     }
 
     if (args.length === 0) {
-      return "Usage: weapon <type|list>";
+      return "Usage: weapon <type|list|give>";
     }
 
     const sub = args[0].toLowerCase();
@@ -142,7 +142,7 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
       const names = Object.keys(WEAPON_CONFIGS) as WeaponType[];
       const maxLen = Math.max(...names.map((n) => n.length));
       const current = ctx.powerUpManager.currentWeapon;
-      const tier = ctx.powerUpManager.weaponTier;
+      const inventory = ctx.powerUpManager.inventory;
 
       for (const name of names) {
         const cfg = WEAPON_CONFIGS[name];
@@ -158,10 +158,36 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
         if (cfg.homing) parts.push("HOMING");
         if (cfg.piercing) parts.push("PIERCING");
 
-        const marker = name === current ? ` [ACTIVE T${tier}]` : "";
+        const invTier = inventory.get(name);
+        let marker = "";
+        if (name === current) {
+          marker = ` [ACTIVE T${invTier ?? 1}]`;
+        } else if (invTier !== undefined) {
+          marker = ` [OWNED T${invTier}]`;
+        }
         lines.push(`  ${paddedName} \u2014 ${parts.join(" ")}${marker}`);
       }
       return lines;
+    }
+
+    if (sub === "give") {
+      if (args.length < 2) {
+        return "Usage: weapon give <type> [tier]";
+      }
+      const resolved = WEAPON_ALIASES[args[1].toLowerCase()];
+      if (!resolved) {
+        return `Unknown weapon '${args[1]}'`;
+      }
+      let tier = 1;
+      if (args.length >= 3) {
+        const parsed = parseInt(args[2], 10);
+        if (isNaN(parsed) || parsed < 1 || parsed > 3) {
+          return "Tier must be between 1 and 3";
+        }
+        tier = parsed;
+      }
+      ctx.powerUpManager.addToInventory(resolved, tier);
+      return `Added ${resolved} at tier ${tier} to inventory`;
     }
 
     const resolved = WEAPON_ALIASES[sub];
@@ -169,9 +195,13 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
       return `Unknown weapon '${sub}'. Available: machine-gun (mg), missile (msl), laser (lsr), plasma (pls), ion-cannon (ion), auto-gun (atg), rocket (rkt)`;
     }
 
-    ctx.powerUpManager.setWeapon(resolved);
-    ctx.powerUpManager.setTier(1);
-    ctx.weaponSystem.setWeapon(resolved);
+    const inventory = ctx.powerUpManager.inventory;
+    if (!inventory.has(resolved)) {
+      ctx.powerUpManager.setWeapon(resolved);
+    } else {
+      ctx.powerUpManager.switchWeapon(resolved);
+    }
+    ctx.weaponSystem.setWeapon(ctx.powerUpManager.currentWeapon);
     return `Weapon switched to ${resolved}`;
   });
 
@@ -378,7 +408,7 @@ export function registerCombatCommands(registry: CommandRegistry): void {
       `Level: ${ctx.currentLevel + 1} - ${ctx.levels[ctx.currentLevel].name}`,
       `Score: ${ctx.score} (Total: ${ctx.totalScore})`,
       `Lives: ${ctx.player.lives} | Shield: ${ctx.player.shield}`,
-      `Weapon: ${ctx.weaponSystem.currentWeapon} (Tier ${ctx.powerUpManager.weaponTier})`,
+      `Weapon: ${ctx.weaponSystem.currentWeapon} (Tier ${ctx.powerUpManager.weaponTier}) | Inventory: ${Array.from(ctx.powerUpManager.inventory.entries()).map(([w, t]) => `${w}:T${t}`).join(", ")}`,
       `Enemies: ${ctx.enemies.length} | Bullets: ${ctx.enemyBullets.length}`,
     ];
 

--- a/src/games/raptor/systems/InputManager.ts
+++ b/src/games/raptor/systems/InputManager.ts
@@ -12,6 +12,10 @@ export class InputManager {
   public mouseY = 0;
   public readonly isTouchDevice: boolean;
 
+  public weaponSlotPressed: number | null = null;
+  public wasCyclePrevPressed = false;
+  public wasCycleNextPressed = false;
+
   private canvas: HTMLCanvasElement;
   private logicalWidth: number;
   private logicalHeight: number;
@@ -26,6 +30,7 @@ export class InputManager {
   private boundTouchEnd: (e: TouchEvent) => void;
   private boundKeyDown: (e: KeyboardEvent) => void;
   private boundKeyUp: (e: KeyboardEvent) => void;
+  private boundWheel: (e: WheelEvent) => void;
 
   constructor(canvas: HTMLCanvasElement, logicalWidth?: number, logicalHeight?: number) {
     this.canvas = canvas;
@@ -43,6 +48,7 @@ export class InputManager {
     this.boundTouchEnd = (e) => this.onTouchEnd(e);
     this.boundKeyDown = (e) => this.onKeyDown(e);
     this.boundKeyUp = (e) => this.onKeyUp(e);
+    this.boundWheel = (e) => this.onWheel(e);
 
     canvas.addEventListener("mousemove", this.boundMouseMove);
     canvas.addEventListener("mousedown", this.boundMouseDown);
@@ -52,6 +58,7 @@ export class InputManager {
     canvas.addEventListener("touchend", this.boundTouchEnd, { passive: false });
     window.addEventListener("keydown", this.boundKeyDown);
     window.addEventListener("keyup", this.boundKeyUp);
+    canvas.addEventListener("wheel", this.boundWheel, { passive: false });
   }
 
   updateFromKeyboard(dt: number, canvasWidth: number, canvasHeight: number): void {
@@ -73,6 +80,9 @@ export class InputManager {
     this.wasBombPressed = false;
     this.wasDodgePressed = false;
     this.wasConsoleToggled = false;
+    this.weaponSlotPressed = null;
+    this.wasCyclePrevPressed = false;
+    this.wasCycleNextPressed = false;
   }
 
   destroy(): void {
@@ -84,6 +94,7 @@ export class InputManager {
     this.canvas.removeEventListener("touchend", this.boundTouchEnd);
     window.removeEventListener("keydown", this.boundKeyDown);
     window.removeEventListener("keyup", this.boundKeyUp);
+    this.canvas.removeEventListener("wheel", this.boundWheel);
   }
 
   private toCanvasX(clientX: number): number {
@@ -170,6 +181,25 @@ export class InputManager {
     if (e.key === "`") {
       this.wasConsoleToggled = true;
       e.preventDefault();
+    }
+    if (e.key === "q") {
+      this.wasCyclePrevPressed = true;
+    }
+    if (e.key === "e") {
+      this.wasCycleNextPressed = true;
+    }
+    const slotNum = parseInt(e.key, 10);
+    if (slotNum >= 1 && slotNum <= 7) {
+      this.weaponSlotPressed = slotNum;
+    }
+  }
+
+  private onWheel(e: WheelEvent): void {
+    e.preventDefault();
+    if (e.deltaY > 0) {
+      this.wasCycleNextPressed = true;
+    } else if (e.deltaY < 0) {
+      this.wasCyclePrevPressed = true;
     }
   }
 

--- a/src/games/raptor/systems/PowerUpManager.ts
+++ b/src/games/raptor/systems/PowerUpManager.ts
@@ -1,4 +1,4 @@
-import { RaptorPowerUpType, WeaponType } from "../types";
+import { RaptorPowerUpType, WeaponType, WEAPON_SLOT_ORDER } from "../types";
 
 export interface ActiveEffect {
   type: RaptorPowerUpType;
@@ -15,8 +15,8 @@ export type WeaponSetResult = "switched" | "upgraded" | "maxed";
 
 export class PowerUpManager {
   private effects: ActiveEffect[] = [];
+  private _inventory: Map<WeaponType, number> = new Map([["machine-gun", 1]]);
   private _currentWeapon: WeaponType = "machine-gun";
-  private _weaponTier: number = 1;
 
   activate(type: RaptorPowerUpType): void {
     const duration = EFFECT_DURATIONS[type];
@@ -31,14 +31,50 @@ export class PowerUpManager {
   }
 
   setWeapon(type: WeaponType): WeaponSetResult {
-    if (this._currentWeapon === type) {
-      if (this._weaponTier >= 3) return "maxed";
-      this._weaponTier++;
+    const existingTier = this._inventory.get(type);
+
+    if (existingTier === undefined) {
+      this._inventory.set(type, 1);
+      this._currentWeapon = type;
+      return "switched";
+    }
+
+    if (type === this._currentWeapon) {
+      if (existingTier >= 3) return "maxed";
+      this._inventory.set(type, existingTier + 1);
       return "upgraded";
     }
+
+    // Owned but not active: upgrade tier and switch to it
+    if (existingTier < 3) {
+      this._inventory.set(type, existingTier + 1);
+      this._currentWeapon = type;
+      return "upgraded";
+    }
+
     this._currentWeapon = type;
-    this._weaponTier = 1;
     return "switched";
+  }
+
+  switchWeapon(type: WeaponType): boolean {
+    if (!this._inventory.has(type)) return false;
+    if (this._currentWeapon === type) return false;
+    this._currentWeapon = type;
+    return true;
+  }
+
+  cycleWeapon(direction: 1 | -1): WeaponType {
+    const owned = WEAPON_SLOT_ORDER.filter((w) => this._inventory.has(w));
+    if (owned.length <= 1) return this._currentWeapon;
+
+    const currentIdx = owned.indexOf(this._currentWeapon);
+    const nextIdx = (currentIdx + direction + owned.length) % owned.length;
+    this._currentWeapon = owned[nextIdx];
+    return this._currentWeapon;
+  }
+
+  get inventory(): ReadonlyMap<WeaponType, number> {
+    return this._inventory;
   }
 
   get currentWeapon(): WeaponType {
@@ -46,11 +82,30 @@ export class PowerUpManager {
   }
 
   get weaponTier(): number {
-    return this._weaponTier;
+    return this._inventory.get(this._currentWeapon) ?? 1;
   }
 
   setTier(tier: number): void {
-    this._weaponTier = Math.max(1, Math.min(3, Math.floor(tier)));
+    const clamped = Math.max(1, Math.min(3, Math.floor(tier)));
+    this._inventory.set(this._currentWeapon, clamped);
+  }
+
+  setInventory(inventory: Map<WeaponType, number>): void {
+    this._inventory = new Map(inventory);
+    if (!this._inventory.has("machine-gun")) {
+      this._inventory.set("machine-gun", 1);
+    }
+  }
+
+  setActiveWeapon(type: WeaponType): void {
+    if (this._inventory.has(type)) {
+      this._currentWeapon = type;
+    }
+  }
+
+  addToInventory(type: WeaponType, tier: number = 1): void {
+    const clamped = Math.max(1, Math.min(3, Math.floor(tier)));
+    this._inventory.set(type, clamped);
   }
 
   update(dt: number): void {
@@ -74,7 +129,7 @@ export class PowerUpManager {
 
   reset(): void {
     this.effects = [];
+    this._inventory = new Map([["machine-gun", 1]]);
     this._currentWeapon = "machine-gun";
-    this._weaponTier = 1;
   }
 }

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -84,6 +84,20 @@ export class SaveSystem {
       }
     }
 
+    if (d.weaponInventory !== undefined) {
+      if (typeof d.weaponInventory !== "object" || d.weaponInventory === null || Array.isArray(d.weaponInventory)) {
+        return false;
+      }
+      const inv = d.weaponInventory as Record<string, unknown>;
+      const cleaned: Record<string, number> = {};
+      for (const [key, val] of Object.entries(inv)) {
+        if (!VALID_WEAPONS.includes(key as WeaponType)) continue;
+        if (typeof val !== "number" || !Number.isInteger(val) || val < 1 || val > 3) continue;
+        cleaned[key] = val;
+      }
+      d.weaponInventory = cleaned;
+    }
+
     return true;
   }
 }

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -151,6 +151,10 @@ export type RaptorSoundEvent =
 
 export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon" | "auto-gun" | "rocket";
 
+export const WEAPON_SLOT_ORDER: WeaponType[] = [
+  "machine-gun", "missile", "laser", "plasma", "ion-cannon", "auto-gun", "rocket"
+];
+
 export interface RaptorSaveData {
   version: 1;
   /** The highest level index the player has unlocked (0-based). */
@@ -165,8 +169,10 @@ export interface RaptorSaveData {
   savedAt: string;
   /** Mega bomb count at save point (0-5). */
   bombs?: number;
-  /** Weapon upgrade tier at save point (1-3, defaults to 1 if absent). */
+  /** @deprecated Kept for backward compat; use weaponInventory instead. */
   weaponTier?: number;
+  /** Full weapon inventory mapping weapon type to tier (1-3). */
+  weaponInventory?: Record<string, number>;
 }
 
 export interface WeaponTierConfig {

--- a/tests/raptor-combat-commands.test.ts
+++ b/tests/raptor-combat-commands.test.ts
@@ -606,7 +606,10 @@ describe("status command", () => {
     expect(result).toContainEqual("Level: 3 - Mountain Assault");
     expect(result).toContainEqual("Score: 1250 (Total: 3400)");
     expect(result).toContainEqual("Lives: 3 | Shield: 75");
-    expect(result).toContainEqual("Weapon: missile (Tier 1)");
+    const weaponLine = result.find((l: string) => l.startsWith("Weapon:"));
+    expect(weaponLine).toBeDefined();
+    expect(weaponLine).toContain("Weapon: missile (Tier 1)");
+    expect(weaponLine).toContain("Inventory:");
     expect(result).toContainEqual("Enemies: 4 | Bullets: 12");
 
     const effectsLine = result.find((l: string) => l.startsWith("Active effects:"));
@@ -662,7 +665,9 @@ describe("status command", () => {
     const ctx = makeContext({ weaponSystem });
 
     const result = registry.dispatch("status", ctx);
-    expect(result).toContainEqual("Weapon: laser (Tier 1)");
+    const weaponLine = result.find((l: string) => l.startsWith("Weapon:"));
+    expect(weaponLine).toBeDefined();
+    expect(weaponLine).toContain("Weapon: laser (Tier 1)");
   });
 
   test("Status shows enemy and bullet counts", () => {


### PR DESCRIPTION
## PR: Weapon inventory + weapon switching (Fixes #581)

### Summary / Why
This PR replaces the “single active weapon” model with a persistent **weapon inventory**, allowing players to switch back to any previously collected weapon while preserving **each weapon’s upgrade tier**. This addresses #581 where picking up a new weapon permanently replaced the old one (and effectively lost its tier).

Key behaviors added:
- Weapons are stored in an inventory (`WeaponType → tier (1–3)`), with **machine-gun always present**.
- Picking up a weapon:
  - Adds it if new, or upgrades its tier if already owned (cap 3).
  - Preserves tiers even when switching away and back.
- Player can switch weapons via:
  - **Number keys 1–7** (direct select)
  - **Q/E** or **mouse wheel** (cycle)
  - **Touch**: HUD cycle button
- HUD now displays a **weapon tray** showing owned weapons, tiers, and active highlight.
- Save/Load persists the full inventory with **backward compatibility** for older saves.

### Key files modified
- `src/games/raptor/systems/PowerUpManager.ts`
  - Replaced single `_currentWeapon/_weaponTier` with inventory `Map<WeaponType, number>`
  - Added `switchWeapon()`, `cycleWeapon()`, and inventory accessors
  - Updated pickup/upgrade logic and reset behavior
- `src/games/raptor/systems/InputManager.ts`
  - Added inputs for weapon slots (1–7), cycle (Q/E), and mouse wheel cycling
  - Ensured new fields are consumed/reset each frame
- `src/games/raptor/RaptorGame.ts`
  - Integrated switching logic into `updatePlaying()`
  - Updated weapon pickup flow to leverage inventory semantics
  - Save/load integration for `weaponInventory` with fallback for legacy saves
- `src/games/raptor/rendering/HUD.ts`
  - Added weapon tray UI (owned weapons + tier indicators + active highlight)
  - Added key hints (non-touch) and a touch weapon-cycle button
- `src/games/raptor/systems/SaveSystem.ts`
  - Added validation/sanitization for `weaponInventory`
  - Backward compatible loading from `weapon` + `weaponTier`
- `src/games/raptor/systems/CommandRegistry.ts`
  - Enhanced `weapon list` to reflect inventory + tiers
  - Added `weapon give <type> [tier]` for inventory manipulation without switching
- `src/games/raptor/types.ts`
  - Added `WEAPON_SLOT_ORDER`
  - Expanded `RaptorSaveData` with `weaponInventory` (kept legacy fields for compatibility)

### Testing notes
- Manual verification:
  - Collect multiple weapon power-ups; confirm previously owned weapons remain selectable.
  - Upgrade an inactive weapon via pickup; verify tier increases and switching back retains tier.
  - Weapon switching:
    - `1–7` selects owned weapons only (no-op for unowned).
    - `Q/E` and mouse wheel cycle through owned weapons and wrap correctly.
    - Touch cycle button cycles owned weapons.
  - HUD tray:
    - Shows only owned weapons (in canonical order), highlights active weapon, displays tier indicators and key hints on desktop.
  - Save/load:
    - New saves persist full `weaponInventory`.
    - Old saves without `weaponInventory` load into a reconstructed inventory (machine-gun + saved weapon/tier).
- Automated tests:
  - Updated tests to match the new dev-console/status output format (per commit message: “Update tests for new status command output format”).

Ref: https://github.com/asgardtech/archer/issues/581