### PR TITLE
missiles are the very best weapon, we should have rockets appear first in the game, then missiles later because they're OP

### DIFF
--- a/src/games/raptor/levels.ts
+++ b/src/games/raptor/levels.ts
@@ -67,7 +67,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#F4A460", "#87CEEB"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.0,
-    weaponDrops: ["missile"] as WeaponType[],
+    weaponDrops: ["rocket"] as WeaponType[],
     terrain: {
       theme: "desert",
       horizonAssets: ["horizon_desert"],
@@ -119,7 +119,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#4A6670", "#8BA8B7"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.2,
-    weaponDrops: ["missile", "laser"] as WeaponType[],
+    weaponDrops: ["rocket", "laser"] as WeaponType[],
     terrain: {
       theme: "mountain",
       horizonAssets: ["horizon_mountain"],
@@ -171,7 +171,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#B0C4DE", "#D3D3D3"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.4,
-    weaponDrops: ["missile", "laser", "auto-gun"] as WeaponType[],
+    weaponDrops: ["rocket", "laser", "auto-gun"] as WeaponType[],
     terrain: {
       theme: "arctic",
       horizonAssets: ["horizon_arctic"],
@@ -226,7 +226,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#2F1B14", "#1a1a1a"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.6,
-    weaponDrops: ["missile", "laser", "auto-gun", "plasma"] as WeaponType[],
+    weaponDrops: ["rocket", "laser", "auto-gun", "plasma"] as WeaponType[],
     terrain: {
       theme: "fortress",
       horizonAssets: ["horizon_fortress"],
@@ -285,7 +285,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#2b1d1d", "#4a3333"],
     starDensity: 0,
     enemyFireRateMultiplier: 1.8,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon"] as WeaponType[],
+    weaponDrops: ["rocket", "laser", "plasma", "ion-cannon", "missile"] as WeaponType[],
     terrain: {
       theme: "shipyard",
       horizonAssets: ["horizon_shipyard"],
@@ -356,7 +356,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#1a1a0e", "#3d3520"],
     starDensity: 0,
     enemyFireRateMultiplier: 2.0,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
+    weaponDrops: ["rocket", "laser", "plasma", "ion-cannon", "missile"] as WeaponType[],
     terrain: {
       theme: "wasteland",
       horizonAssets: ["horizon_wasteland"],
@@ -427,7 +427,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#1c1c1c", "#333030"],
     starDensity: 0,
     enemyFireRateMultiplier: 2.2,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
+    weaponDrops: ["rocket", "laser", "plasma", "ion-cannon", "missile"] as WeaponType[],
     terrain: {
       theme: "industrial",
       horizonAssets: ["horizon_industrial"],
@@ -501,7 +501,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#050510", "#0a0a20"],
     starDensity: 40,
     enemyFireRateMultiplier: 2.4,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
+    weaponDrops: ["rocket", "laser", "plasma", "ion-cannon", "missile"] as WeaponType[],
     terrain: {
       theme: "orbital",
       horizonAssets: ["horizon_orbital"],
@@ -575,7 +575,7 @@ export const LEVELS: RaptorLevelConfig[] = [
     skyGradient: ["#0a0000", "#1a0505"],
     starDensity: 50,
     enemyFireRateMultiplier: 2.5,
-    weaponDrops: ["missile", "laser", "plasma", "ion-cannon", "rocket"] as WeaponType[],
+    weaponDrops: ["rocket", "laser", "plasma", "ion-cannon", "missile"] as WeaponType[],
     terrain: {
       theme: "stronghold",
       horizonAssets: ["horizon_stronghold"],

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -156,7 +156,7 @@ export type RaptorSoundEvent =
 export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon" | "auto-gun" | "rocket";
 
 export const WEAPON_SLOT_ORDER: WeaponType[] = [
-  "machine-gun", "missile", "laser", "plasma", "ion-cannon", "auto-gun", "rocket"
+  "machine-gun", "rocket", "laser", "plasma", "ion-cannon", "auto-gun", "missile"
 ];
 
 export const HUD_BAR_HEIGHT = 48;

--- a/tests/raptor-weapons-qa.test.ts
+++ b/tests/raptor-weapons-qa.test.ts
@@ -895,11 +895,12 @@ describe("Power-Up Drop Configuration (Levels)", () => {
     expect(level1.weaponDrops).toBeUndefined();
   });
 
-  test("Level 2 has missile in weaponDrops", () => {
+  test("Level 2 has rocket in weaponDrops", () => {
     const level2 = LEVELS[1];
     expect(level2.level).toBe(2);
     expect(level2.weaponDrops).toBeDefined();
-    expect(level2.weaponDrops).toContain("missile");
+    expect(level2.weaponDrops).toContain("rocket");
+    expect(level2.weaponDrops).not.toContain("missile");
   });
 
   test("Level 2 does not have laser in weaponDrops", () => {
@@ -907,55 +908,57 @@ describe("Power-Up Drop Configuration (Levels)", () => {
     expect(level2.weaponDrops).not.toContain("laser");
   });
 
-  test("Level 3 drops missile and laser only", () => {
+  test("Level 3 drops rocket and laser only", () => {
     const level3 = LEVELS[2];
     expect(level3.level).toBe(3);
-    expect(level3.weaponDrops).toContain("missile");
+    expect(level3.weaponDrops).toContain("rocket");
     expect(level3.weaponDrops).toContain("laser");
     expect(level3.weaponDrops).not.toContain("auto-gun");
     expect(level3.weaponDrops).not.toContain("plasma");
     expect(level3.weaponDrops).not.toContain("ion-cannon");
-    expect(level3.weaponDrops).not.toContain("rocket");
+    expect(level3.weaponDrops).not.toContain("missile");
   });
 
   test("Level 4 introduces auto-gun", () => {
     const level4 = LEVELS[3];
     expect(level4.level).toBe(4);
-    expect(level4.weaponDrops).toContain("missile");
+    expect(level4.weaponDrops).toContain("rocket");
     expect(level4.weaponDrops).toContain("laser");
     expect(level4.weaponDrops).toContain("auto-gun");
     expect(level4.weaponDrops).not.toContain("plasma");
     expect(level4.weaponDrops).not.toContain("ion-cannon");
-    expect(level4.weaponDrops).not.toContain("rocket");
+    expect(level4.weaponDrops).not.toContain("missile");
   });
 
   test("Level 5 introduces plasma", () => {
     const level5 = LEVELS[4];
     expect(level5.level).toBe(5);
-    expect(level5.weaponDrops).toContain("missile");
+    expect(level5.weaponDrops).toContain("rocket");
     expect(level5.weaponDrops).toContain("laser");
     expect(level5.weaponDrops).toContain("auto-gun");
     expect(level5.weaponDrops).toContain("plasma");
+    expect(level5.weaponDrops).not.toContain("missile");
   });
 
-  test("Level 6 replaces auto-gun with ion-cannon", () => {
+  test("Level 6 introduces missile and ion-cannon, replaces auto-gun", () => {
     const level6 = LEVELS[5];
     expect(level6.level).toBe(6);
-    expect(level6.weaponDrops).toContain("missile");
+    expect(level6.weaponDrops).toContain("rocket");
     expect(level6.weaponDrops).toContain("laser");
     expect(level6.weaponDrops).toContain("plasma");
     expect(level6.weaponDrops).toContain("ion-cannon");
+    expect(level6.weaponDrops).toContain("missile");
     expect(level6.weaponDrops).not.toContain("auto-gun");
   });
 
   test("Levels 7-10 have full late-game arsenal without auto-gun", () => {
     for (let i = 6; i < LEVELS.length; i++) {
       const level = LEVELS[i];
-      expect(level.weaponDrops).toContain("missile");
+      expect(level.weaponDrops).toContain("rocket");
       expect(level.weaponDrops).toContain("laser");
       expect(level.weaponDrops).toContain("plasma");
       expect(level.weaponDrops).toContain("ion-cannon");
-      expect(level.weaponDrops).toContain("rocket");
+      expect(level.weaponDrops).toContain("missile");
       expect(level.weaponDrops).not.toContain("auto-gun");
     }
   });


### PR DESCRIPTION
## PR: Reorder weapon progression — rockets early, missiles late (Fixes #596)

### Summary / Why
Missiles were being introduced as early as **Level 2**, making mid-game difficulty too easy due to their **homing + splash** behavior. This PR **reorders weapon progression** so players unlock a strong but skill-based weapon first (**rockets**) and receive the more consistently powerful homing option (**missiles**) later.

No weapon stats were changed—this is strictly a progression/timing fix to improve the difficulty curve and pacing.

### What changed
- **Weapon drop progression swapped**
  - **Level 2–5:** missile removed, **rocket added**
  - **Level 6+:** missile introduced and remains available in late-game pools
- **Weapon cycling order updated**
  - `WEAPON_SLOT_ORDER` now places **rocket before missile**, matching the new acquisition order.
- **Tests updated**
  - Drop table assertions updated to reflect the new level-by-level weapon pools.

### Key files modified
- `src/games/raptor/levels.ts`
  - Updated `weaponDrops` for Levels 2–10 to introduce rockets early and defer missiles until Level 6.
- `src/games/raptor/types.ts`
  - Updated `WEAPON_SLOT_ORDER` to:  
    `["machine-gun", "rocket", "laser", "plasma", "ion-cannon", "auto-gun", "missile"]`
- `tests/raptor-weapons-qa.test.ts`
  - Updated Section 9 (“Power-Up Drop Configuration”) expectations for the new progression.

### Testing notes
- ✅ Updated test suite expectations for weapon drop pools.
- Recommended manual sanity checks:
  - Start a new game and confirm **Level 2 drops rockets (not missiles)**.
  - Confirm **missiles do not appear before Level 6**, then appear starting at Level 6.
  - If a save already contains missiles, verify the inventory still loads and missiles can still be fired (save compatibility is unchanged since weapon IDs did not change).

Ref: https://github.com/asgardtech/archer/issues/596