### PR TITLE
the wingman updates are blocking the view of the game - they must be displayed in the HUD bar

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -695,7 +695,6 @@ export class RaptorGame implements IGame {
       if (this.levelElapsed >= msg.triggerTime) {
         const speaker: SpeakerType = msg.speaker ?? detectSpeaker(msg.text);
         const duration = msg.duration ?? 3;
-        this.storyRenderer.showQuick(msg.text, duration, "bottom", speaker);
         this.hud.setWingmanMessage(speaker, msg.text, duration);
         this.nextStoryMessageIndex++;
       }

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -95,6 +95,7 @@ export class HUD {
   private wingmanText = "";
   private wingmanTimer = 0;
   private wingmanSpeaker: SpeakerType = "pilot";
+  private wingmanFlashTimer = 0;
 
   constructor(isTouchDevice: boolean) {
     this.isTouchDevice = isTouchDevice;
@@ -156,11 +157,15 @@ export class HUD {
     else if (cleanText.startsWith("Sensor:")) cleanText = cleanText.substring(7).trim();
     this.wingmanText = cleanText;
     this.wingmanTimer = duration;
+    this.wingmanFlashTimer = 0.3;
   }
 
   updateWingmanTimer(dt: number): void {
     if (this.wingmanTimer > 0) {
       this.wingmanTimer = Math.max(0, this.wingmanTimer - dt);
+    }
+    if (this.wingmanFlashTimer > 0) {
+      this.wingmanFlashTimer = Math.max(0, this.wingmanFlashTimer - dt);
     }
   }
 
@@ -1419,6 +1424,30 @@ export class HUD {
     ctx.restore();
   }
 
+  private wrapWingmanText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+    const words = text.split(" ");
+    const lines: string[] = [];
+    let currentLine = "";
+
+    for (const word of words) {
+      if (currentLine === "") {
+        currentLine = word;
+        continue;
+      }
+      const testLine = currentLine + " " + word;
+      if (ctx.measureText(testLine).width > maxWidth) {
+        lines.push(currentLine);
+        currentLine = word;
+      } else {
+        currentLine = testLine;
+      }
+    }
+    if (currentLine !== "") {
+      lines.push(currentLine);
+    }
+    return lines;
+  }
+
   private renderWingmanSection(
     ctx: CanvasRenderingContext2D,
     barY: number
@@ -1448,15 +1477,36 @@ export class HUD {
     ctx.textAlign = "left";
     ctx.textBaseline = "middle";
 
+    if (this.wingmanFlashTimer > 0) {
+      const flashIntensity = this.wingmanFlashTimer / 0.3;
+      const highlightAlpha = 0.15 * flashIntensity;
+      ctx.fillStyle = `rgba(255, 255, 255, ${highlightAlpha})`;
+      const labelWidth = ctx.measureText(label + ": " + this.wingmanText).width;
+      ctx.fillRect(msgX - 4, barY + 2, Math.min(labelWidth + 12, ctx.canvas.width * 0.45), HUD_BAR_HEIGHT - 4);
+    }
+
     ctx.fillStyle = speakerColor;
-    ctx.fillText(label + ":", msgX, centerY - 7);
+    ctx.fillText(label + ":", msgX, barY + 12);
+
+    const maxTextWidth = Math.max(80, ctx.canvas.width * 0.4 - msgX);
+    const wrapped = this.wrapWingmanText(ctx, this.wingmanText, maxTextWidth);
 
     ctx.fillStyle = "#D0D8E8";
-    let displayText = this.wingmanText;
-    if (displayText.length > 35) {
-      displayText = displayText.substring(0, 32) + "...";
+    if (wrapped.length <= 1) {
+      ctx.fillText(wrapped[0] ?? "", msgX, barY + 28);
+    } else {
+      let line1 = wrapped[0];
+      let line2 = wrapped.slice(1).join(" ");
+      if (ctx.measureText(line2).width > maxTextWidth) {
+        const truncated = this.wrapWingmanText(ctx, line2, maxTextWidth);
+        line2 = truncated[0];
+        if (truncated.length > 1) {
+          line2 = line2.replace(/\s+\S*$/, "") + "...";
+        }
+      }
+      ctx.fillText(line1, msgX, barY + 22);
+      ctx.fillText(line2, msgX, barY + 36);
     }
-    ctx.fillText(displayText, msgX, centerY + 7);
 
     ctx.restore();
   }


### PR DESCRIPTION
## PR: Display wingman updates in HUD bar (fixes view-blocking overlay) — Issue #599

### Summary / Why
During gameplay, in-game story messages (HQ/Wingman/Sensor/Pilot) were being shown **twice**: once via `StoryRenderer.showQuick()` as a large overlay panel and again in the HUD wingman section. The overlay panel sits on top of the playfield and **blocks visibility of enemies, projectiles, and pickups**, especially during high-action moments.

This PR removes the blocking `StoryRenderer.showQuick()` path for **in-game** messages during the `"playing"` state and improves the HUD wingman section so messages remain readable without obstructing gameplay.

### What changed
- **Stop rendering the blocking overlay** for in-game quick messages during active gameplay; messages now render **exclusively in the bottom HUD bar**.
- **Improve HUD wingman message rendering**:
  - Pixel-based **two-line word wrapping** (replaces the old ~35 character truncation behavior)
  - **Ellipsis truncation** after two lines for very long messages
  - Subtle **arrival flash/highlight** (~0.3s) to draw attention
  - **Dynamic max width** based on canvas size to better support small screens

> Note: Full story sequences (intro/briefing/victory) continue to use `StoryRenderer` overlays as intended.

### Key files modified
- `src/games/raptor/RaptorGame.ts`
  - Removed `storyRenderer.showQuick()` invocation for in-game story messages while playing.
  - Click-to-advance behavior remains intact for story overlays that still exist (e.g., victory story).
- `src/games/raptor/rendering/HUD.ts`
  - Enhanced `renderWingmanSection()` with pixel-based wrapping, two-line layout, ellipsis, arrival flash, and responsive width.

### Testing notes
Manual verification recommended:
- Start a level that triggers in-game messages:
  - Confirm messages appear **only** in the HUD wingman section (no overlay panel).
  - Confirm gameplay area remains unobstructed (enemies/projectiles/powerups fully visible).
- Trigger long/very long messages:
  - Confirm **two-line wrapping** within the HUD bar.
  - Confirm **ellipsis** appears after two lines when needed.
- Validate story sequences:
  - Intro/briefing/victory overlays still render via `StoryRenderer` and **click-to-advance** still works.
- Small canvas width (<400px):
  - Confirm text wrapping respects measured pixel width and does not overlap critical HUD areas.

### Related issue
- Fixes **#599**: Wingman updates blocking the view of the game; must be displayed in the HUD bar.

Ref: https://github.com/asgardtech/archer/issues/599