### PR TITLE
Add BossType to type system and refactor hardcoded boss checks

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -18,7 +18,7 @@ import { TrackingBullet } from "./entities/TrackingBullet";
 import { PlasmaBolt } from "./entities/PlasmaBolt";
 import { IonBolt } from "./entities/IonBolt";
 import { Rocket } from "./entities/Rocket";
-import { Enemy } from "./entities/Enemy";
+import { Enemy, isBossVariant } from "./entities/Enemy";
 import { EnemyBullet } from "./entities/EnemyBullet";
 import { EnemyMissile } from "./entities/EnemyMissile";
 import { Explosion } from "./entities/Explosion";
@@ -859,7 +859,7 @@ export class RaptorGame implements IGame {
         } else if (hit.bullet instanceof Rocket) {
           this.sound.play("missile_hit");
           this.vfx.triggerExplosionFlash(hit.enemy.pos.x, hit.enemy.pos.y, 20);
-        } else if (hit.enemy.variant === "boss") {
+        } else if (isBossVariant(hit.enemy.variant)) {
           this.sound.play("boss_hit");
         } else {
           this.sound.play("enemy_hit");
@@ -894,7 +894,7 @@ export class RaptorGame implements IGame {
       if (hit.destroyed) {
         this.handleEnemyDestroyed(hit.enemy, config);
       } else {
-        if (hit.enemy.variant === "boss") {
+        if (isBossVariant(hit.enemy.variant)) {
           this.sound.play("boss_hit");
         } else {
           this.sound.play("enemy_hit");
@@ -922,12 +922,12 @@ export class RaptorGame implements IGame {
 
     const enemyPlayerHits = this.collisions.checkPlayerEnemies(this.player, this.enemies);
     for (const hit of enemyPlayerHits) {
-      const explosionSize = (hit.enemy.variant === "boss" || hit.enemy.variant === "juggernaut") ? 3
+      const explosionSize = (isBossVariant(hit.enemy.variant) || hit.enemy.variant === "juggernaut") ? 3
         : (hit.enemy.variant === "bomber" || hit.enemy.variant === "gunship" || hit.enemy.variant === "cruiser" || hit.enemy.variant === "destroyer" || hit.enemy.variant === "minelayer") ? 2
         : 1;
       this.addExplosion(new Explosion(hit.enemy.pos.x, hit.enemy.pos.y, explosionSize));
       this.score += hit.enemy.scoreValue;
-      if (hit.enemy.variant === "boss") {
+      if (isBossVariant(hit.enemy.variant)) {
         this.sound.play("boss_destroy");
         this.spawner.markBossDefeated();
         this.vfx.triggerScreenShake(10, 0.5);
@@ -1094,12 +1094,12 @@ export class RaptorGame implements IGame {
 
   private handleEnemyDestroyed(enemy: Enemy, config: RaptorLevelConfig): void {
     this.score += enemy.scoreValue;
-    const explosionSize = (enemy.variant === "boss" || enemy.variant === "juggernaut") ? 3
+    const explosionSize = (isBossVariant(enemy.variant) || enemy.variant === "juggernaut") ? 3
       : (enemy.variant === "bomber" || enemy.variant === "gunship" || enemy.variant === "cruiser" || enemy.variant === "destroyer" || enemy.variant === "minelayer") ? 2
       : 1;
     this.addExplosion(new Explosion(enemy.pos.x, enemy.pos.y, explosionSize));
 
-    if (enemy.variant === "boss") {
+    if (isBossVariant(enemy.variant)) {
       this.sound.play("boss_destroy");
       this.spawner.markBossDefeated();
       this.vfx.triggerScreenShake(10, 0.5);

--- a/src/games/raptor/entities/Enemy.ts
+++ b/src/games/raptor/entities/Enemy.ts
@@ -1,5 +1,9 @@
 import { Vec2, EnemyVariant, EnemyConfig, EnemyWeaponType, ENEMY_CONFIGS } from "../types";
 
+export function isBossVariant(variant: EnemyVariant): boolean {
+  return variant === "boss";
+}
+
 export class Enemy {
   public pos: Vec2;
   public vel: Vec2;
@@ -33,7 +37,7 @@ export class Enemy {
   constructor(x: number, y: number, variant: EnemyVariant, speed?: number, overrideConfig?: Partial<EnemyConfig>) {
     const config = { ...ENEMY_CONFIGS[variant], ...overrideConfig };
     this.variant = variant;
-    this.hitPoints = Math.max(config.hitPoints, variant === "boss" ? 25 : 1);
+    this.hitPoints = Math.max(config.hitPoints, isBossVariant(variant) ? 25 : 1);
     this.maxHitPoints = this.hitPoints;
     this.scoreValue = config.scoreValue;
     this.fireRate = config.fireRate;
@@ -62,7 +66,7 @@ export class Enemy {
 
     if (this.flashTimer > 0) this.flashTimer -= dt;
 
-    if (this.variant === "boss") {
+    if (isBossVariant(this.variant)) {
       this.pos.x += Math.sin(this.time * 1.5) * 60 * dt;
       const bossTargetY = canvasHeight * 0.15;
       if (this.pos.y < bossTargetY) {
@@ -153,7 +157,7 @@ export class Enemy {
     }
 
     if (
-      this.variant !== "boss" && this.variant !== "destroyer" &&
+      !isBossVariant(this.variant) && this.variant !== "destroyer" &&
       this.variant !== "juggernaut" && this.variant !== "minelayer" &&
       this.pos.y > canvasHeight + 50
     ) {
@@ -266,7 +270,7 @@ export class Enemy {
   }
 
   private renderSpriteVariant(ctx: CanvasRenderingContext2D, x: number, y: number, flash: boolean): void {
-    if (this.variant === "boss") {
+    if (isBossVariant(this.variant)) {
       ctx.fillStyle = "rgba(255, 50, 50, 0.15)";
       ctx.beginPath();
       ctx.arc(x, y, this.width * 0.7, 0, Math.PI * 2);
@@ -310,7 +314,7 @@ export class Enemy {
       }
     }
 
-    if (this.variant === "boss" || this.variant === "cruiser" || this.variant === "destroyer" || this.variant === "juggernaut") {
+    if (isBossVariant(this.variant) || this.variant === "cruiser" || this.variant === "destroyer" || this.variant === "juggernaut") {
       this.renderHPBar(ctx, x, y);
     }
   }

--- a/src/games/raptor/systems/CollisionSystem.ts
+++ b/src/games/raptor/systems/CollisionSystem.ts
@@ -5,7 +5,7 @@ import { PlasmaBolt } from "../entities/PlasmaBolt";
 import { Rocket } from "../entities/Rocket";
 import { LaserBeam } from "../entities/LaserBeam";
 import { EnemyLaserBeam } from "../entities/EnemyLaserBeam";
-import { Enemy } from "../entities/Enemy";
+import { Enemy, isBossVariant } from "../entities/Enemy";
 import { EnemyBullet } from "../entities/EnemyBullet";
 import { EnemyMissile } from "../entities/EnemyMissile";
 import { Player } from "../entities/Player";
@@ -88,7 +88,7 @@ export class CollisionSystem {
         const canFlash = !this.hitFlashTimers.has(enemy) ||
           this.hitFlashTimers.get(enemy)! <= 0;
 
-        if (enemy.variant === "boss" && !canFlash) {
+        if (isBossVariant(enemy.variant) && !canFlash) {
           enemy.hitPoints -= beam.damage;
           if (enemy.hitPoints <= 0) {
             enemy.hitPoints = 0;
@@ -99,7 +99,7 @@ export class CollisionSystem {
         }
         hitEnemies.push(enemy);
 
-        if (enemy.variant === "boss" && canFlash) {
+        if (isBossVariant(enemy.variant) && canFlash) {
           this.hitFlashTimers.set(enemy, BOSS_HIT_FLASH_COOLDOWN);
         }
       }

--- a/src/games/raptor/systems/EnemySpawner.ts
+++ b/src/games/raptor/systems/EnemySpawner.ts
@@ -81,6 +81,7 @@ export class EnemySpawner {
   spawnBoss(canvasWidth: number): Enemy | null {
     if (!this.bossConfig) return null;
     this.bossSpawned = true;
+    const _bossType = this.bossConfig.bossType ?? "standard";
     const overrides: Partial<EnemyConfig> = {
       hitPoints: Math.max(25, this.bossConfig.hitPoints),
       scoreValue: this.bossConfig.scoreValue,
@@ -92,7 +93,7 @@ export class EnemySpawner {
     return new Enemy(
       canvasWidth / 2,
       -40,
-      "boss" as EnemyVariant,
+      "boss",
       this.bossConfig.speed,
       overrides
     );

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -22,6 +22,8 @@ export type EnemyVariant =
 
 export type EnemyWeaponType = "standard" | "spread" | "missile" | "laser";
 
+export type BossType = "standard" | "gunship_commander" | "missile_dreadnought" | "laser_fortress" | "carrier";
+
 export interface EnemyWeaponConfig {
   type: EnemyWeaponType;
   damage: number;
@@ -367,6 +369,7 @@ export interface WaveConfig {
 }
 
 export interface BossConfig {
+  bossType?: BossType;
   hitPoints: number;
   speed: number;
   fireRate: number;

--- a/tests/raptor-issue-573-visual-qa.test.ts
+++ b/tests/raptor-issue-573-visual-qa.test.ts
@@ -377,7 +377,11 @@ describe("10. HP bar eligibility", () => {
   });
 
   test.each(HP_BAR_VARIANTS)("renderSpriteVariant calls renderHPBar for %s", (variant) => {
-    expect(hpBarBlock).toContain(`"${variant}"`);
+    if (variant === "boss") {
+      expect(hpBarBlock).toMatch(/isBossVariant|"boss"/);
+    } else {
+      expect(hpBarBlock).toContain(`"${variant}"`);
+    }
   });
 
   test.each(NON_HP_BAR_VARIANTS)("renderSpriteVariant does NOT call renderHPBar for %s", (variant) => {


### PR DESCRIPTION
## PR: Add `BossType` to type system + refactor hardcoded boss checks (Issue #619, epic #604)

### Summary / Why
This PR prepares the Raptor boss system for epic #604 by introducing a dedicated `BossType` discriminator in the type layer while keeping runtime behavior unchanged. It also removes scattered `variant === "boss"` checks across the codebase in favor of a single reusable predicate (`isBossVariant()`), reducing duplication and making future boss-variant expansion safer and more maintainable.

No gameplay or behavior changes are intended—this is a refactor + forward-compatible typing update.

---

### What changed
- **Added `BossType` union type** to describe future boss encounter archetypes:
  - `"standard" | "gunship_commander" | "missile_dreadnought" | "laser_fortress" | "carrier"`
- **Extended `BossConfig`** with optional `bossType?: BossType` (defaults to `"standard"` at consumption sites for backward compatibility).
- **Introduced `isBossVariant(variant: EnemyVariant)`** exported from `Enemy.ts` as the single source of truth for identifying boss enemies.
- **Refactored all hardcoded boss checks** (`variant === "boss"`) to use `isBossVariant()` across game logic, collision logic, and rendering/movement code paths.
- **Spawner prep:** `EnemySpawner.spawnBoss()` now reads `bossConfig.bossType` (stored for future branching) and removes an unnecessary `"boss" as EnemyVariant` cast. Bosses still spawn with `variant: "boss"` for now.
- **Test adjustment:** updated the source-scanning test to accept the new `isBossVariant` pattern (no behavioral assertions changed).

---

### Key files modified
- `src/games/raptor/types.ts`
  - Adds `BossType`
  - Adds `bossType?: BossType` to `BossConfig`
- `src/games/raptor/entities/Enemy.ts`
  - Adds `export function isBossVariant(...)`
  - Replaces boss-specific conditionals (HP floor, movement, rendering, HP bar, off-screen rules) to call helper
- `src/games/raptor/RaptorGame.ts`
  - Replaces boss checks for hit/destroy sound events, explosion sizing, sprite assignment, and collision handling
- `src/games/raptor/systems/CollisionSystem.ts`
  - Refactors beam flash cooldown gating to use `isBossVariant`
- `src/games/raptor/systems/EnemySpawner.ts`
  - Reads `bossConfig.bossType ?? "standard"` (no-op for now)
  - Removes unnecessary type cast when spawning `"boss"`

---

### Testing notes
- Existing tests should pass **without modification** (typing change is additive; `bossType` is optional).
- The only test-related change is updating a source-scan expectation to reflect the new helper usage.
- Manual sanity check suggested:
  - Play through a few levels and confirm boss behavior is unchanged (movement pattern, HP bar rendering, boss_hit/boss_destroy sounds, explosion size, and no off-screen despawn).

Ref: https://github.com/asgardtech/archer/issues/619