### PR TITLE
Add Missile Dreadnought boss type with missile barrage attacks

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -778,6 +778,23 @@ export class RaptorGame implements IGame {
         );
         this.enemyBullets.push(mine);
       }
+
+      if (enemy.variant === "boss_dreadnought" && enemy.hasPendingBurst()) {
+        if (this.enemyBullets.length < MAX_ENEMY_BULLETS) {
+          const { offsetX, offsetY } = enemy.consumeBurstTick();
+          const result = this.enemyWeaponSystem.fireMissileFrom(
+            enemy, this.player.pos.x, this.player.pos.y, offsetX, offsetY
+          );
+          for (const eb of result.bullets) {
+            const sprite = this.assets.getOptional(eb.spriteKey);
+            if (sprite) eb.setSprite(sprite);
+            this.enemyBullets.push(eb);
+          }
+          if (result.soundEvent) {
+            this.sound.play(result.soundEvent);
+          }
+        }
+      }
     }
 
     const laserSoundEvents = this.enemyWeaponSystem.updateLasers(dt, this.player.pos.x);
@@ -1196,6 +1213,7 @@ export class RaptorGame implements IGame {
       bomber: "enemy_bomber",
       boss: "enemy_boss",
       boss_gunship: "enemy_boss_gunship",
+      boss_dreadnought: "enemy_boss_dreadnought",
       interceptor: "enemy_interceptor",
       dart: "enemy_dart",
       drone: "enemy_drone",

--- a/src/games/raptor/entities/Enemy.ts
+++ b/src/games/raptor/entities/Enemy.ts
@@ -1,7 +1,7 @@
 import { Vec2, EnemyVariant, EnemyConfig, EnemyWeaponType, ENEMY_CONFIGS } from "../types";
 
 export function isBossVariant(variant: EnemyVariant): boolean {
-  return variant === "boss" || variant === "boss_gunship";
+  return variant === "boss" || variant === "boss_gunship" || variant === "boss_dreadnought";
 }
 
 export class Enemy {
@@ -38,6 +38,19 @@ export class Enemy {
   private gunshipStrafeTarget = 0;
   private gunshipPauseTimer = 0;
   private gunshipStrafeDirection: 1 | -1 = 1;
+
+  private dreadnoughtPhase: "entering" | "drifting" | "locking" = "entering";
+  private dreadnoughtDriftTimer = 0;
+  private dreadnoughtLockTimer = 0;
+  private readonly DREADNOUGHT_DRIFT_DURATION_MIN = 3.0;
+  private readonly DREADNOUGHT_DRIFT_DURATION_MAX = 5.0;
+  private readonly DREADNOUGHT_LOCK_DURATION = 1.5;
+
+  private burstRemaining = 0;
+  private burstTimer = 0;
+  private burstSpreadIndex = 0;
+  private readonly BURST_COUNT = 4;
+  private readonly BURST_INTERVAL = 0.15;
 
   constructor(x: number, y: number, variant: EnemyVariant, speed?: number, overrideConfig?: Partial<EnemyConfig>) {
     const config = { ...ENEMY_CONFIGS[variant], ...overrideConfig };
@@ -111,6 +124,43 @@ export class Enemy {
       }
 
       this.pos.x = Math.max(margin, Math.min(cw - margin, this.pos.x));
+    } else if (this.variant === "boss_dreadnought") {
+      const dCw = canvasWidth ?? 800;
+      const dMargin = 50;
+      const parkY = canvasHeight * 0.25;
+
+      if (this.dreadnoughtPhase === "entering") {
+        this.pos.y += this.vel.y * dt;
+        if (this.pos.y >= parkY) {
+          this.pos.y = parkY;
+          this.dreadnoughtPhase = "drifting";
+          this.dreadnoughtDriftTimer = this.DREADNOUGHT_DRIFT_DURATION_MIN
+            + Math.random() * (this.DREADNOUGHT_DRIFT_DURATION_MAX - this.DREADNOUGHT_DRIFT_DURATION_MIN);
+        }
+      } else if (this.dreadnoughtPhase === "drifting") {
+        this.pos.x += Math.sin(this.time * 0.5) * 35 * dt;
+        this.pos.y = parkY + Math.sin(this.time * 0.3) * 4;
+        this.pos.x = Math.max(dMargin, Math.min(dCw - dMargin, this.pos.x));
+
+        this.dreadnoughtDriftTimer -= dt;
+        if (this.dreadnoughtDriftTimer <= 0) {
+          this.dreadnoughtPhase = "locking";
+          this.dreadnoughtLockTimer = this.DREADNOUGHT_LOCK_DURATION;
+        }
+      } else if (this.dreadnoughtPhase === "locking") {
+        this.pos.x += Math.sin(this.time * 20) * 0.5;
+        this.dreadnoughtLockTimer -= dt;
+        if (this.dreadnoughtLockTimer <= 0) {
+          this.initiateBurst();
+          this.dreadnoughtPhase = "drifting";
+          this.dreadnoughtDriftTimer = this.DREADNOUGHT_DRIFT_DURATION_MIN
+            + Math.random() * (this.DREADNOUGHT_DRIFT_DURATION_MAX - this.DREADNOUGHT_DRIFT_DURATION_MIN);
+        }
+      }
+
+      if (this.burstRemaining > 0) {
+        this.burstTimer -= dt;
+      }
     } else if (isBossVariant(this.variant)) {
       this.pos.x += Math.sin(this.time * 1.5) * 60 * dt;
       const bossTargetY = canvasHeight * 0.15;
@@ -228,6 +278,25 @@ export class Enemy {
     this.fireCooldown = (1 / this.fireRate) * multiplier;
   }
 
+  private initiateBurst(): void {
+    this.burstRemaining = this.BURST_COUNT;
+    this.burstTimer = 0;
+    this.burstSpreadIndex = 0;
+  }
+
+  public hasPendingBurst(): boolean {
+    return this.burstRemaining > 0 && this.burstTimer <= 0;
+  }
+
+  public consumeBurstTick(): { offsetX: number; offsetY: number } {
+    this.burstRemaining--;
+    this.burstTimer = this.BURST_INTERVAL;
+    const spreadOffsets = [-24, -8, 8, 24];
+    const offsetX = spreadOffsets[this.burstSpreadIndex % spreadOffsets.length];
+    this.burstSpreadIndex++;
+    return { offsetX, offsetY: this.height * 0.3 };
+  }
+
   hit(damage = 1): boolean {
     if (!this.alive) return false;
     this.hitPoints -= damage;
@@ -267,6 +336,9 @@ export class Enemy {
           break;
         case "boss_gunship":
           this.renderBossGunship(ctx, x, y, isFlashing);
+          break;
+        case "boss_dreadnought":
+          this.renderBossDreadnought(ctx, x, y, isFlashing);
           break;
         case "interceptor":
           this.renderInterceptor(ctx, x, y, isFlashing);
@@ -802,6 +874,61 @@ export class Enemy {
     ctx.fillStyle = flash ? "#cccccc" : "#5577cc";
     ctx.beginPath();
     ctx.arc(x, y - hh * 0.15, 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    this.renderHPBar(ctx, x, y);
+  }
+
+  private renderBossDreadnought(ctx: CanvasRenderingContext2D, x: number, y: number, flash: boolean): void {
+    const hw = this.width / 2;
+    const hh = this.height / 2;
+
+    ctx.fillStyle = "rgba(136, 34, 68, 0.15)";
+    ctx.beginPath();
+    ctx.arc(x, y, hw * 1.3, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = flash ? "#ffffff" : "#882244";
+    ctx.beginPath();
+    ctx.moveTo(x, y + hh);
+    ctx.lineTo(x - hw * 0.35, y + hh * 0.6);
+    ctx.lineTo(x - hw, y + hh * 0.1);
+    ctx.lineTo(x - hw, y - hh * 0.3);
+    ctx.lineTo(x - hw * 0.5, y - hh);
+    ctx.lineTo(x + hw * 0.5, y - hh);
+    ctx.lineTo(x + hw, y - hh * 0.3);
+    ctx.lineTo(x + hw, y + hh * 0.1);
+    ctx.lineTo(x + hw * 0.35, y + hh * 0.6);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.strokeStyle = flash ? "#cccccc" : "#aa3366";
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    ctx.strokeStyle = flash ? "#cccccc" : "#773355";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x - hw * 0.7, y - hh * 0.1);
+    ctx.lineTo(x + hw * 0.7, y - hh * 0.1);
+    ctx.moveTo(x - hw * 0.6, y + hh * 0.3);
+    ctx.lineTo(x + hw * 0.6, y + hh * 0.3);
+    ctx.stroke();
+
+    ctx.fillStyle = flash ? "#cccccc" : "#663344";
+    ctx.fillRect(x - hw * 0.95 - 4, y - hh * 0.15, 8, 14);
+    ctx.fillRect(x + hw * 0.95 - 4, y - hh * 0.15, 8, 14);
+
+    ctx.fillStyle = flash ? "#999999" : "#441122";
+    for (let i = 0; i < 3; i++) {
+      const ty = y - hh * 0.1 + i * 4;
+      ctx.fillRect(x - hw * 0.95 - 1, ty, 2, 2);
+      ctx.fillRect(x + hw * 0.95 - 1, ty, 2, 2);
+    }
+
+    ctx.fillStyle = flash ? "#cccccc" : "#aa4466";
+    ctx.beginPath();
+    ctx.arc(x, y - hh * 0.15, 7, 0, Math.PI * 2);
     ctx.fill();
 
     this.renderHPBar(ctx, x, y);

--- a/src/games/raptor/rendering/assets.ts
+++ b/src/games/raptor/rendering/assets.ts
@@ -11,6 +11,7 @@ export const ASSET_MANIFEST: AssetManifest = {
   enemy_bomber:     `${BASE}enemy_bomber.png`,
   enemy_boss:       `${BASE}enemy_boss.png`,
   enemy_boss_gunship: `${BASE}enemy_boss_gunship.png`,
+  enemy_boss_dreadnought: `${BASE}enemy_boss_dreadnought.png`,
   enemy_interceptor: `${BASE}enemy_interceptor.png`,
   enemy_dart:       `${BASE}enemy_dart.png`,
   enemy_drone:      `${BASE}enemy_drone.png`,

--- a/src/games/raptor/systems/EnemySpawner.ts
+++ b/src/games/raptor/systems/EnemySpawner.ts
@@ -80,6 +80,7 @@ export class EnemySpawner {
 
   private static readonly BOSS_TYPE_TO_VARIANT: Partial<Record<BossType, EnemyVariant>> = {
     gunship_commander: "boss_gunship",
+    missile_dreadnought: "boss_dreadnought",
   };
 
   spawnBoss(canvasWidth: number): Enemy | null {

--- a/src/games/raptor/systems/EnemyWeaponSystem.ts
+++ b/src/games/raptor/systems/EnemyWeaponSystem.ts
@@ -164,4 +164,25 @@ export class EnemyWeaponSystem {
       soundEvent: WEAPON_SOUND_MAP["missile"],
     };
   }
+
+  fireMissileFrom(enemy: Enemy, targetX: number, targetY: number, offsetX: number, offsetY: number): EnemyFireResult {
+    const config = ENEMY_WEAPON_CONFIGS["missile"];
+    const bullet = new EnemyMissile(
+      enemy.pos.x + offsetX,
+      enemy.bottom + offsetY,
+      targetX, targetY,
+      {
+        damage: config.damage,
+        speed: config.projectileSpeed,
+        homing: config.homing,
+        homingStrength: config.homingStrength,
+        spriteKey: config.spriteKey,
+        radius: 7,
+      }
+    );
+    return {
+      bullets: [bullet],
+      soundEvent: WEAPON_SOUND_MAP["missile"],
+    };
+  }
 }

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -14,7 +14,7 @@ export type RaptorGameState =
   | "victory";
 
 export type EnemyVariant =
-  | "scout" | "fighter" | "bomber" | "boss" | "boss_gunship"
+  | "scout" | "fighter" | "bomber" | "boss" | "boss_gunship" | "boss_dreadnought"
   | "interceptor" | "dart" | "drone" | "swarmer"
   | "gunship" | "cruiser"
   | "destroyer" | "juggernaut"
@@ -614,5 +614,15 @@ export const ENEMY_CONFIGS: Record<EnemyVariant, EnemyConfig> = {
     fireRate: 0,
     width: 32,
     height: 28,
+  },
+  boss_dreadnought: {
+    variant: "boss_dreadnought",
+    hitPoints: 80,
+    speed: 25,
+    scoreValue: 800,
+    fireRate: 1.0,
+    width: 80,
+    height: 68,
+    weaponType: "missile",
   },
 };


### PR DESCRIPTION
## PR: Add Missile Dreadnought boss type with missile barrage attacks (Issue #621, Epic #604)

### Summary (what changed + why)
This PR introduces a new boss variant, **Missile Dreadnought** (`boss_dreadnought`), designed to feel like a heavy capital ship: **largest silhouette, very high HP, slow movement**, and a **telegraphed lock-on → missile barrage** attack pattern. The goal is to expand boss variety and add a distinct “armored, menacing, volley-based” encounter that differs from existing boss behaviors.

Key gameplay additions:
- New boss spawns via `bossConfig.bossType: "missile_dreadnought"`.
- Movement pattern: **slow entry → parks at ~25% screen height → drifting + vertical bob → periodic lock-on pause**.
- Attack pattern: **4-missile burst**, fired from multiple hardpoints with **0.15s stagger** (spread offsets), using existing homing missile behavior.

---

### Key files modified
- **`src/games/raptor/types.ts`**
  - Added `boss_dreadnought` to `EnemyVariant`.
  - Added `ENEMY_CONFIGS.boss_dreadnought` (80x68, HP 80, speed 25, score 800, fireRate 1.0, weaponType `"missile"`).

- **`src/games/raptor/entities/Enemy.ts`**
  - Updated `isBossVariant()` to include `boss_dreadnought`.
  - Implemented dreadnought movement state machine (`entering → drifting → locking`) with:
    - park position at **25% screen height**
    - slow horizontal drift, subtle vertical bobbing
    - lock-on pause + micro-vibration telegraph
  - Added burst-fire state + API (`initiateBurst`, `hasPendingBurst`, `consumeBurstTick`) to support staggered volleys.
  - Added `renderBossDreadnought()` fallback rendering (maroon armored hull, missile pods, panel lines, threat glow, HP bar).

- **`src/games/raptor/systems/EnemySpawner.ts`**
  - Mapped `bossType: "missile_dreadnought"` → variant `boss_dreadnought`.

- **`src/games/raptor/systems/EnemyWeaponSystem.ts`**
  - Added `fireMissileFrom()` helper to fire missiles from **offset hardpoints** without changing core missile behavior.

- **`src/games/raptor/rendering/assets.ts`**
  - Added asset manifest entry: `enemy_boss_dreadnought`.

- **`src/games/raptor/RaptorGame.ts`**
  - Wired sprite assignment for `boss_dreadnought` → `enemy_boss_dreadnought`.
  - Integrated dreadnought burst firing in the game loop (respects `MAX_ENEMY_BULLETS` cap, spawns missiles with hardpoint offsets, plays weapon SFX).

---

### Testing notes
Manual verification recommended (no automated tests added in this PR):

- Spawn via level config:
  - Set `bossConfig.bossType = "missile_dreadnought"` and confirm spawner creates `boss_dreadnought`.
- Behavior checks:
  - Boss enters slowly and parks around **25%** screen height (lower than standard bosses).
  - Drift + bobbing visible; periodically transitions into **lock-on pause** (telegraph).
  - After lock-on, fires **4 homing missiles**, **staggered ~0.15s**, from visibly different X offsets.
- Rendering checks:
  - With sprite present: sprite renders with boss glow/HP bar behavior.
  - With sprite missing: fallback `renderBossDreadnought()` draws correctly (hull, pods, armor detail, HP bar).
- Edge/cap checks:
  - Ensure burst respects `MAX_ENEMY_BULLETS` and doesn’t crash when capped.
  - Ensure boss doesn’t despawn due to off-screen checks (covered by `isBossVariant()`).

--- 

### Related
- Implements **Issue #621** (part of **Epic #604**)

Ref: https://github.com/asgardtech/archer/issues/621