### PR TITLE
Add Carrier boss type that spawns drone reinforcements

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -809,6 +809,27 @@ export class RaptorGame implements IGame {
           }
         }
       }
+
+      if (enemy.variant === "boss_carrier" && enemy.shouldSpawnDrones()) {
+        const MAX_ACTIVE_DRONES = 8;
+        const activeDrones = this.enemies.filter(
+          e => e.alive && (e.variant === "drone" || e.variant === "swarmer")
+        ).length;
+        if (activeDrones < MAX_ACTIVE_DRONES) {
+          const spawnVariant = enemy.getDroneSpawnVariant();
+          const spawnPositions = enemy.getDroneSpawnPositions();
+          const spawnCount = Math.min(
+            2 + Math.floor(Math.random() * 2),
+            MAX_ACTIVE_DRONES - activeDrones
+          );
+          for (let i = 0; i < spawnCount; i++) {
+            const spawnPos = spawnPositions[i % spawnPositions.length];
+            const drone = new Enemy(spawnPos.x, spawnPos.y, spawnVariant);
+            this.assignEnemySprite(drone);
+            this.enemies.push(drone);
+          }
+        }
+      }
     }
 
     const laserSoundEvents = this.enemyWeaponSystem.updateLasers(dt, this.player.pos.x);
@@ -1229,6 +1250,7 @@ export class RaptorGame implements IGame {
       boss_gunship: "enemy_boss_gunship",
       boss_dreadnought: "enemy_boss_dreadnought",
       boss_fortress: "enemy_boss_fortress",
+      boss_carrier: "enemy_boss_carrier",
       interceptor: "enemy_interceptor",
       dart: "enemy_dart",
       drone: "enemy_drone",

--- a/src/games/raptor/entities/Enemy.ts
+++ b/src/games/raptor/entities/Enemy.ts
@@ -1,7 +1,7 @@
 import { Vec2, EnemyVariant, EnemyConfig, EnemyWeaponType, ENEMY_CONFIGS } from "../types";
 
 export function isBossVariant(variant: EnemyVariant): boolean {
-  return variant === "boss" || variant === "boss_gunship" || variant === "boss_dreadnought" || variant === "boss_fortress";
+  return variant === "boss" || variant === "boss_gunship" || variant === "boss_dreadnought" || variant === "boss_fortress" || variant === "boss_carrier";
 }
 
 export class Enemy {
@@ -48,6 +48,14 @@ export class Enemy {
 
   private fortressPhase: "entering" | "hovering" = "entering";
   public fortressAttackPhase: "A" | "B" = "A";
+
+  private carrierPhase: "entering" | "patrolling" | "deploying" = "entering";
+  private droneSpawnTimer = 0;
+  private carrierDeployPauseTimer = 0;
+  private droneSpawnReady = false;
+  private droneWaveVariantToggle = false;
+  private readonly DRONE_SPAWN_INTERVAL = 5.5;
+  private readonly CARRIER_DEPLOY_PAUSE = 0.8;
 
   private burstRemaining = 0;
   private burstTimer = 0;
@@ -179,6 +187,38 @@ export class Enemy {
         this.pos.x += Math.sin(this.time * 0.3) * 8 * dt;
         this.pos.y = parkY + Math.sin(this.time * 0.2) * 3;
         this.pos.x = Math.max(fMargin, Math.min(fCw - fMargin, this.pos.x));
+      }
+    } else if (this.variant === "boss_carrier") {
+      const cCw = canvasWidth ?? 800;
+      const cMargin = 50;
+      const cParkY = canvasHeight * 0.2;
+
+      if (this.carrierPhase === "entering") {
+        this.pos.y += this.vel.y * dt;
+        if (this.pos.y >= cParkY) {
+          this.pos.y = cParkY;
+          this.carrierPhase = "patrolling";
+        }
+      } else if (this.carrierPhase === "patrolling") {
+        this.pos.x += Math.sin(this.time * 0.4) * 45 * dt;
+        this.pos.y = cParkY + Math.sin(this.time * 0.25) * 5;
+        this.pos.x = Math.max(cMargin, Math.min(cCw - cMargin, this.pos.x));
+
+        if (this.hitPoints / this.maxHitPoints >= 0.25) {
+          this.droneSpawnTimer += dt;
+          if (this.droneSpawnTimer >= this.DRONE_SPAWN_INTERVAL) {
+            this.droneSpawnTimer = 0;
+            this.carrierPhase = "deploying";
+            this.carrierDeployPauseTimer = this.CARRIER_DEPLOY_PAUSE;
+            this.droneSpawnReady = true;
+          }
+        }
+      } else if (this.carrierPhase === "deploying") {
+        this.pos.y = cParkY + Math.sin(this.time * 0.25) * 5;
+        this.carrierDeployPauseTimer -= dt;
+        if (this.carrierDeployPauseTimer <= 0) {
+          this.carrierPhase = "patrolling";
+        }
       }
     } else if (isBossVariant(this.variant)) {
       this.pos.x += Math.sin(this.time * 1.5) * 60 * dt;
@@ -320,6 +360,30 @@ export class Enemy {
     this.fortressAttackPhase = this.fortressAttackPhase === "A" ? "B" : "A";
   }
 
+  public shouldSpawnDrones(): boolean {
+    if (this.variant !== "boss_carrier") return false;
+    if (!this.droneSpawnReady) return false;
+    this.droneSpawnReady = false;
+    return true;
+  }
+
+  public getDroneSpawnVariant(): EnemyVariant {
+    this.droneWaveVariantToggle = !this.droneWaveVariantToggle;
+    return this.droneWaveVariantToggle ? "swarmer" : "drone";
+  }
+
+  public getDroneSpawnPositions(): Vec2[] {
+    const offsetX = this.width * 0.4;
+    return [
+      { x: this.pos.x - offsetX, y: this.pos.y + this.height * 0.3 },
+      { x: this.pos.x + offsetX, y: this.pos.y + this.height * 0.3 },
+    ];
+  }
+
+  public get isDeploying(): boolean {
+    return this.variant === "boss_carrier" && this.carrierPhase === "deploying";
+  }
+
   hit(damage = 1): boolean {
     if (!this.alive) return false;
     this.hitPoints -= damage;
@@ -365,6 +429,9 @@ export class Enemy {
           break;
         case "boss_fortress":
           this.renderBossFortress(ctx, x, y, isFlashing);
+          break;
+        case "boss_carrier":
+          this.renderBossCarrier(ctx, x, y, isFlashing);
           break;
         case "interceptor":
           this.renderInterceptor(ctx, x, y, isFlashing);
@@ -1009,6 +1076,62 @@ export class Enemy {
     ctx.fillStyle = flash ? "#cccccc" : "#00ccff";
     ctx.beginPath();
     ctx.arc(x, y - hh * 0.15, 7, 0, Math.PI * 2);
+    ctx.fill();
+
+    this.renderHPBar(ctx, x, y);
+  }
+
+  private renderBossCarrier(ctx: CanvasRenderingContext2D, x: number, y: number, flash: boolean): void {
+    const hw = this.width / 2;
+    const hh = this.height / 2;
+
+    ctx.fillStyle = "rgba(85, 102, 68, 0.15)";
+    ctx.beginPath();
+    ctx.arc(x, y, hw * 1.3, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = flash ? "#ffffff" : "#556644";
+    ctx.beginPath();
+    ctx.moveTo(x - hw * 0.4, y - hh);
+    ctx.lineTo(x + hw * 0.4, y - hh);
+    ctx.lineTo(x + hw * 0.8, y - hh * 0.5);
+    ctx.lineTo(x + hw, y - hh * 0.1);
+    ctx.lineTo(x + hw, y + hh * 0.5);
+    ctx.lineTo(x + hw * 0.6, y + hh);
+    ctx.lineTo(x - hw * 0.6, y + hh);
+    ctx.lineTo(x - hw, y + hh * 0.5);
+    ctx.lineTo(x - hw, y - hh * 0.1);
+    ctx.lineTo(x - hw * 0.8, y - hh * 0.5);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.strokeStyle = flash ? "#cccccc" : "#6b7a55";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    ctx.strokeStyle = flash ? "#cccccc" : "#4a5a3a";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x - hw * 0.7, y - hh * 0.2);
+    ctx.lineTo(x + hw * 0.7, y - hh * 0.2);
+    ctx.moveTo(x - hw * 0.6, y + hh * 0.2);
+    ctx.lineTo(x + hw * 0.6, y + hh * 0.2);
+    ctx.stroke();
+
+    const bayGlow = this.carrierPhase === "deploying"
+      || (this.droneSpawnTimer > this.DRONE_SPAWN_INTERVAL - 1.0
+          && this.hitPoints / this.maxHitPoints >= 0.25);
+    const bayPulse = 0.5 + Math.sin(this.time * 6) * 0.5;
+    const bayColor = flash ? "#cccccc"
+      : bayGlow ? `rgba(204, 170, 34, ${0.5 + bayPulse * 0.5})` : "#445533";
+
+    ctx.fillStyle = bayColor;
+    ctx.fillRect(x - hw * 0.9 - 2, y + hh * 0.05, 8, 12);
+    ctx.fillRect(x + hw * 0.9 - 6, y + hh * 0.05, 8, 12);
+
+    ctx.fillStyle = flash ? "#cccccc" : "#667755";
+    ctx.beginPath();
+    ctx.arc(x, y - hh * 0.2, 6, 0, Math.PI * 2);
     ctx.fill();
 
     this.renderHPBar(ctx, x, y);

--- a/src/games/raptor/rendering/assets.ts
+++ b/src/games/raptor/rendering/assets.ts
@@ -13,6 +13,7 @@ export const ASSET_MANIFEST: AssetManifest = {
   enemy_boss_gunship: `${BASE}enemy_boss_gunship.png`,
   enemy_boss_dreadnought: `${BASE}enemy_boss_dreadnought.png`,
   enemy_boss_fortress: `${BASE}enemy_boss_fortress.png`,
+  enemy_boss_carrier: `${BASE}enemy_boss_carrier.png`,
   enemy_interceptor: `${BASE}enemy_interceptor.png`,
   enemy_dart:       `${BASE}enemy_dart.png`,
   enemy_drone:      `${BASE}enemy_drone.png`,

--- a/src/games/raptor/systems/EnemySpawner.ts
+++ b/src/games/raptor/systems/EnemySpawner.ts
@@ -82,6 +82,7 @@ export class EnemySpawner {
     gunship_commander: "boss_gunship",
     missile_dreadnought: "boss_dreadnought",
     laser_fortress: "boss_fortress",
+    carrier: "boss_carrier",
   };
 
   spawnBoss(canvasWidth: number): Enemy | null {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -14,7 +14,7 @@ export type RaptorGameState =
   | "victory";
 
 export type EnemyVariant =
-  | "scout" | "fighter" | "bomber" | "boss" | "boss_gunship" | "boss_dreadnought" | "boss_fortress"
+  | "scout" | "fighter" | "bomber" | "boss" | "boss_gunship" | "boss_dreadnought" | "boss_fortress" | "boss_carrier"
   | "interceptor" | "dart" | "drone" | "swarmer"
   | "gunship" | "cruiser"
   | "destroyer" | "juggernaut"
@@ -634,5 +634,15 @@ export const ENEMY_CONFIGS: Record<EnemyVariant, EnemyConfig> = {
     width: 76,
     height: 64,
     weaponType: "laser",
+  },
+  boss_carrier: {
+    variant: "boss_carrier",
+    hitPoints: 55,
+    speed: 30,
+    scoreValue: 700,
+    fireRate: 0.8,
+    width: 84,
+    height: 70,
+    weaponType: "standard",
   },
 };


### PR DESCRIPTION
## PR: Add Carrier boss type that spawns drone reinforcements (Issue #623)

### Summary (what + why)
This change introduces a new boss variant, **`boss_carrier`**, designed to function as a mobile command platform that periodically **deploys drone reinforcements**. The Carrier itself has moderate survivability and direct firepower, but escalates pressure by spawning **2–3 drone/swarmer enemies per wave** on a timer, with safeguards to maintain gameplay balance and performance:
- **Global active-drone cap** (max 8 drones/swarmers alive)
- **Spawning stops below 25% HP**, shifting the final phase into a more direct boss duel

### Key changes
- Added **`boss_carrier`** to enemy variants and configs (84×70, 55 HP, speed 30, fireRate 0.8, score 700, standard weapon).
- Implemented a **three-phase movement pattern** in `Enemy.update()`:
  - `entering` → descends and parks at ~20% screen height  
  - `patrolling` → slow, wide sinusoidal lateral patrol  
  - `deploying` → brief pause during drone deployment, then returns to patrol
- Added Carrier-specific drone spawn API on `Enemy` (modeled after existing “minelayer” style hooks):
  - `shouldSpawnDrones()`
  - `getDroneSpawnVariant()` (alternates drone/swarmer by wave)
  - `getDroneSpawnPositions()` (spawns from left/right hangar bays)
- Implemented drone creation in the main game loop to ensure proper array ownership and sprite assignment.
- Added **fallback rendering** for the Carrier (olive/military green hull with **pulsing amber hangar lights** when a deploy is imminent/active) plus HP bar.
- Wired `"carrier"` bossType → `boss_carrier` in the spawner and added the sprite key + assignment path.
- Updated `isBossVariant()` to treat the Carrier as a boss for boss-level effects and defeat tracking.

### Key files modified
- `src/games/raptor/types.ts`
  - Add `boss_carrier` to `EnemyVariant`
  - Add `ENEMY_CONFIGS.boss_carrier`
- `src/games/raptor/entities/Enemy.ts`
  - Carrier movement state machine + timers
  - Drone spawn signaling methods
  - `renderBossCarrier()` fallback rendering
  - Update `isBossVariant()` to include `boss_carrier`
- `src/games/raptor/systems/EnemySpawner.ts`
  - Map `bossConfig.bossType === "carrier"` → `boss_carrier`
- `src/games/raptor/RaptorGame.ts`
  - Assign sprite key for carrier
  - Spawn drones in `updatePlaying()` when carrier requests it (cap enforced here)
- `src/games/raptor/rendering/assets.ts`
  - Add `enemy_boss_carrier` to `ASSET_MANIFEST`

### Testing notes
Manual verification (dev console / in-level config):
- Spawned via dev console (`spawn boss_carrier`) and via level config (`bossType: "carrier"`).
- Confirmed movement phases: entering → patrolling → deploying pause → patrolling.
- Confirmed drone waves spawn every ~5.5s (2–3 units), from carrier flanks, alternating **drone/swarmer**.
- Confirmed **global cap at 8** active drones/swarmers prevents additional spawns.
- Confirmed spawning **stops below 25% HP** and hangar glow ceases accordingly.
- Confirmed boss defeat behavior uses boss logic (`isBossVariant`): destruction effects + level progression only after remaining enemies (including spawned drones) are cleared.
- Verified fallback rendering appears if sprite asset is missing; sprite path is available via `enemy_boss_carrier` when provided.

Ref: https://github.com/asgardtech/archer/issues/623