### PR TITLE
Configure Webpack for Electron renderer target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/pngjs": "^6.0.5",
+        "copy-webpack-plugin": "^14.0.0",
         "electron": "^41.0.2",
         "html-webpack-plugin": "^5.6.6",
         "jest": "^30.2.0",
@@ -3787,6 +3788,53 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-webpack-plugin": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
+      "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-parent": "^6.0.1",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^7.0.3",
+        "tinyglobby": "^0.2.12"
+      },
+      "engines": {
+        "node": ">= 20.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -8850,6 +8898,54 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "electron:build": "tsc -p electron/tsconfig.json",
     "electron:dev": "RAPTOR_DEV=1 npx electron .",
-    "electron:start": "npm run build && npm run electron:build && npx electron ."
+    "build:electron": "webpack --mode production --config webpack.electron.config.js",
+    "electron:start": "npm run build:electron && npm run electron:build && npx electron ."
   },
   "keywords": [
     "game",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/pngjs": "^6.0.5",
+    "copy-webpack-plugin": "^14.0.0",
     "electron": "^41.0.2",
     "html-webpack-plugin": "^5.6.6",
     "jest": "^30.2.0",

--- a/webpack.electron.config.js
+++ b/webpack.electron.config.js
@@ -1,0 +1,48 @@
+const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+
+module.exports = {
+  target: "electron-renderer",
+  entry: "./src/index.ts",
+  output: {
+    filename: "bundle.[contenthash].js",
+    path: path.resolve(__dirname, "dist"),
+    publicPath: "./",
+    clean: true,
+  },
+  resolve: {
+    extensions: [".ts", ".js"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: "ts-loader",
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.(png|jpe?g|gif|svg)$/i,
+        type: "asset/resource",
+        generator: {
+          filename: "assets/[name][ext]",
+        },
+      },
+    ],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: "./public/index.html",
+      title: "Raptor Skies",
+    }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: "public/assets",
+          to: "assets",
+          noErrorOnMissing: false,
+        },
+      ],
+    }),
+  ],
+};


### PR DESCRIPTION
## PR: Configure Webpack for Electron renderer target (Issue #635)

### Summary (what changed + why)
This PR adds an Electron-specific Webpack production build so the renderer can be loaded from the local filesystem (`file://`) without broken script or asset paths.

Electron production differs from browser dev in two key ways:
- The renderer loads `dist/index.html` via `BrowserWindow.loadFile()` (so assets must exist in `dist/`).
- Webpack’s default `publicPath: 'auto'` can resolve incorrectly under `file://`, causing missing bundle/assets.

To address this, we introduce a dedicated Electron Webpack config that:
- Targets `electron-renderer`
- Forces a relative `output.publicPath: './'` so bundle/script URLs resolve correctly when opened from disk
- Copies runtime-loaded static assets from `public/assets/` into `dist/assets/` (since these assets are referenced by string URLs at runtime, not imported via Webpack)

Browser development (`npm run dev`) remains unchanged.

---

### Key files modified / added
- **Added:** `webpack.electron.config.js`
  - `target: 'electron-renderer'`
  - `output.publicPath: './'`
  - `CopyWebpackPlugin` to copy `public/assets/**` → `dist/assets/**`
  - `HtmlWebpackPlugin` to generate `dist/index.html` compatible with filesystem loading
- **Modified:** `package.json`
  - **Added:** `build:electron` script (`webpack --mode production --config webpack.electron.config.js`)
  - **Updated:** `electron:start` to run `build:electron` before launching Electron
  - **Added:** `copy-webpack-plugin` to `devDependencies`

---

### Testing notes
Manual verification recommended:
1. **Browser dev unchanged**
   - `npm run dev`
   - Confirm app loads at `http://localhost:3000` and assets load as before.
2. **Electron build output**
   - `npm run build:electron`
   - Confirm:
     - `dist/index.html` exists
     - `dist/bundle.*.js` exists
     - `dist/assets/raptor/**` exists (SVG/audio files present)
     - `dist/index.html` references the bundle via a relative path starting with `./`
3. **Run Electron against packaged dist**
   - `npm run electron:start`
   - In Electron DevTools, confirm no `ERR_FILE_NOT_FOUND` / 404s and that sprites + audio load correctly.

--- 

### Notes / scope
- This PR intentionally keeps the existing browser Webpack config untouched to avoid impacting the `webpack-dev-server` workflow.
- Offline font loading (Google Fonts) is not addressed here (out of scope for #635).

Ref: https://github.com/asgardtech/archer/issues/635