### PR TITLE
Add desktop window management and fullscreen support

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,20 +1,76 @@
 import { app, BrowserWindow, Menu } from 'electron';
 import path from 'path';
 import fs from 'fs';
+import { loadWindowState, saveWindowState } from './windowState';
 
 let mainWindow: BrowserWindow | null = null;
 
 const MAX_DEV_RETRIES = 10;
 const DEV_RETRY_INTERVAL_MS = 1000;
 
+function buildMenu(): void {
+  const isDev = !app.isPackaged;
+
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: 'File',
+      submenu: [{ role: 'quit' }],
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Toggle Fullscreen',
+          accelerator: 'F11',
+          click: () => {
+            if (mainWindow) {
+              mainWindow.setFullScreen(!mainWindow.isFullScreen());
+            }
+          },
+        },
+        ...(isDev
+          ? [
+              { type: 'separator' as const },
+              {
+                label: 'Toggle Developer Tools',
+                accelerator: 'CmdOrCtrl+Shift+I',
+                click: () => {
+                  mainWindow?.webContents.toggleDevTools();
+                },
+              },
+            ]
+          : []),
+      ],
+    },
+  ];
+
+  if (process.platform === 'darwin') {
+    template.unshift({
+      label: app.getName(),
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    });
+  }
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
 function createWindow(): void {
-  Menu.setApplicationMenu(null);
+  const saved = loadWindowState({ width: 800, height: 600 });
 
   mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
+    x: saved.x,
+    y: saved.y,
+    width: saved.width,
+    height: saved.height,
+    minWidth: 640,
+    minHeight: 480,
     useContentSize: true,
     resizable: true,
+    fullscreenable: true,
     backgroundColor: '#1a1a2e',
     title: 'Raptor Skies',
     webPreferences: {
@@ -23,6 +79,31 @@ function createWindow(): void {
       contextIsolation: true,
       sandbox: true,
     },
+  });
+
+  if (saved.isMaximized) {
+    mainWindow.maximize();
+  }
+  if (saved.isFullScreen) {
+    mainWindow.setFullScreen(true);
+  }
+
+  buildMenu();
+
+  let saveTimeout: ReturnType<typeof setTimeout> | undefined;
+  const debouncedSave = () => {
+    clearTimeout(saveTimeout);
+    saveTimeout = setTimeout(() => {
+      if (mainWindow) saveWindowState(mainWindow);
+    }, 500);
+  };
+
+  mainWindow.on('resize', debouncedSave);
+  mainWindow.on('move', debouncedSave);
+  mainWindow.on('enter-full-screen', debouncedSave);
+  mainWindow.on('leave-full-screen', debouncedSave);
+  mainWindow.on('close', () => {
+    if (mainWindow) saveWindowState(mainWindow);
   });
 
   const isDev = !app.isPackaged;

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -1,0 +1,89 @@
+import { app, BrowserWindow, screen } from 'electron';
+import path from 'path';
+import fs from 'fs';
+
+export interface WindowState {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+  isMaximized: boolean;
+  isFullScreen: boolean;
+}
+
+const STATE_FILE = 'window-state.json';
+
+function getStateFilePath(): string {
+  return path.join(app.getPath('userData'), STATE_FILE);
+}
+
+function isVisibleOnAnyDisplay(bounds: { x: number; y: number; width: number; height: number }): boolean {
+  const displays = screen.getAllDisplays();
+  return displays.some((display) => {
+    const { x, y, width, height } = display.bounds;
+    return (
+      bounds.x < x + width &&
+      bounds.x + bounds.width > x &&
+      bounds.y < y + height &&
+      bounds.y + bounds.height > y
+    );
+  });
+}
+
+export function loadWindowState(defaults: { width: number; height: number }): WindowState {
+  const fallback: WindowState = {
+    ...defaults,
+    isMaximized: false,
+    isFullScreen: false,
+  };
+
+  try {
+    const raw = fs.readFileSync(getStateFilePath(), 'utf-8');
+    const parsed = JSON.parse(raw);
+
+    const width =
+      typeof parsed.width === 'number' && parsed.width > 0
+        ? Math.round(parsed.width)
+        : defaults.width;
+    const height =
+      typeof parsed.height === 'number' && parsed.height > 0
+        ? Math.round(parsed.height)
+        : defaults.height;
+
+    const state: WindowState = {
+      width,
+      height,
+      isMaximized: parsed.isMaximized === true,
+      isFullScreen: parsed.isFullScreen === true,
+    };
+
+    if (typeof parsed.x === 'number' && typeof parsed.y === 'number') {
+      const bounds = { x: parsed.x, y: parsed.y, width, height };
+      if (isVisibleOnAnyDisplay(bounds)) {
+        state.x = parsed.x;
+        state.y = parsed.y;
+      }
+    }
+
+    return state;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveWindowState(win: BrowserWindow): void {
+  try {
+    const bounds = win.getNormalBounds();
+    const state: WindowState = {
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+      isMaximized: win.isMaximized(),
+      isFullScreen: win.isFullScreen(),
+    };
+    fs.writeFileSync(getStateFilePath(), JSON.stringify(state, null, 2), 'utf-8');
+  } catch (e) {
+    console.error('Failed to save window state:', e);
+  }
+}


### PR DESCRIPTION
## PR: Desktop window management + fullscreen support (Issue #638, part of epic #605)

### Summary (what changed + why)
This PR upgrades the Electron shell to behave like a proper desktop game window instead of a “browser tab in a frame”. It adds:

- **Fullscreen toggle via F11** (handled in the **main process** through a menu accelerator so it only triggers when the app is focused).
- **Native application menu** with standard desktop actions:
  - **File → Quit**
  - **View → Toggle Fullscreen (F11)**
  - **View → Toggle Developer Tools** (development builds only)
- **Minimum window size (640×480)** to prevent the UI from becoming unusable.
- **Window state persistence** (position, size, maximized/fullscreen state) saved to a small JSON file under `app.getPath('userData')`, with **off-screen detection** to recover gracefully when monitors change.

No renderer/game code changes are required: the existing resize handling in the game continues to work via Chromium’s normal `window.resize` events.

### Key files modified / added
- **Modified:** `electron/main.ts`
  - Sets `BrowserWindow` options (`minWidth/minHeight`, `fullscreenable`, etc.)
  - Builds and installs the native app menu (`Menu.buildFromTemplate`)
  - Wires fullscreen toggle (F11) and devtools toggle (dev-only)
  - Hooks window events (`resize`, `move`, `close`, `enter-full-screen`, `leave-full-screen`) to persist state with a **500ms debounce**
  - Restores maximized/fullscreen state on launch
- **Added:** `electron/windowState.ts`
  - Loads/saves window geometry and state to `<userData>/window-state.json`
  - Validates dimensions and discards saved `x/y` if the window would open off-screen (e.g., external monitor removed)

### Testing notes
Manual QA checklist:
- Press **F11** to enter fullscreen; press **F11** again to exit fullscreen.
- Use **View → Toggle Fullscreen**; behavior matches F11.
- Resize/move the window, close the app, reopen → **size/position persist**.
- Maximize, close, reopen → **maximized state persists**.
- Fullscreen, close, reopen → **fullscreen state persists**.
- Attempt to resize below **640×480** → window stops shrinking past the minimum.
- Dev build: **Ctrl/Cmd+Shift+I** toggles devtools and menu item is present.
- Packaged/prod: devtools menu item is **not present** and shortcut does nothing.
- If the saved position is on a disconnected monitor → app opens on the primary display with sane defaults.

Automated tests:
- None added in this PR (window state behavior validated manually).

Ref: https://github.com/asgardtech/archer/issues/638