### PR TITLE
Create SteamCMD VDF depot and app build configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ electron/dist/
 .cursor/
 release/
 build/
+steam_build_output/

--- a/steamcmd/README.md
+++ b/steamcmd/README.md
@@ -1,0 +1,44 @@
+# SteamCMD Build Configuration
+
+This directory contains [Valve Data Format (VDF)](https://developer.valvesoftware.com/wiki/KeyValues) configuration files used by [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) to upload Raptor Skies builds to the Steam content delivery network.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `app_build.vdf` | Top-level app build manifest — defines the App ID, description, build output path, and references each depot config |
+| `depot_build_windows.vdf` | Windows depot — maps `release/win-unpacked/` into the Windows depot |
+| `depot_build_macos.vdf` | macOS depot — maps `release/mac-arm64/` into the macOS depot |
+| `depot_build_linux.vdf` | Linux depot — maps `release/linux-unpacked/` into the Linux depot |
+
+## Placeholder IDs
+
+The VDF files use placeholder IDs that **must be replaced** with real values from the [Steamworks partner portal](https://partner.steamgames.com/) before uploading:
+
+| Placeholder | Meaning |
+|---|---|
+| `1000` | App ID (Raptor Skies) |
+| `1001` | Windows depot ID |
+| `1002` | macOS depot ID |
+| `1003` | Linux depot ID |
+
+## Prerequisites
+
+1. **Build the app** — Run `electron-builder` so that platform artifacts exist under `release/` (e.g., `release/win-unpacked/`, `release/mac-arm64/`, `release/linux-unpacked/`).
+2. **Install SteamCMD** — See [Valve's SteamCMD documentation](https://developer.valvesoftware.com/wiki/SteamCMD).
+3. **Replace placeholder IDs** — Update all `1000`–`1003` values in the VDF files with real IDs from the Steamworks partner portal.
+4. **Update `steam_appid.txt`** — The file currently contains `480` (Valve's Spacewar test app) for local development. Replace it with the real App ID before shipping.
+
+## Uploading a Build
+
+From the project root, run:
+
+```bash
+steamcmd +login <username> +run_app_build steamcmd/app_build.vdf +quit
+```
+
+SteamCMD will read `app_build.vdf`, resolve each depot config, upload the contents, and write logs to `steam_build_output/` (which is gitignored).
+
+## macOS Architecture
+
+The macOS depot defaults to the ARM64 (Apple Silicon) build at `release/mac-arm64/`. To upload an Intel (x64) build instead, change the `ContentRoot` in `depot_build_macos.vdf` from `../release/mac-arm64` to `../release/mac`.

--- a/steamcmd/app_build.vdf
+++ b/steamcmd/app_build.vdf
@@ -1,0 +1,15 @@
+"AppBuild"
+{
+  // Replace 1000 with your actual App ID from the Steamworks partner portal
+  "AppID" "1000"
+  "Desc" "Raptor Skies build"
+  "ContentRoot" "../release"
+  "BuildOutput" "../steam_build_output"
+  "Depots"
+  {
+    // Replace depot IDs with actual values from the Steamworks partner portal
+    "1001" "depot_build_windows.vdf"
+    "1002" "depot_build_macos.vdf"
+    "1003" "depot_build_linux.vdf"
+  }
+}

--- a/steamcmd/depot_build_linux.vdf
+++ b/steamcmd/depot_build_linux.vdf
@@ -1,0 +1,12 @@
+"DepotBuild"
+{
+  // Replace 1003 with your actual Linux depot ID from Steamworks
+  "DepotID" "1003"
+  "ContentRoot" "../release/linux-unpacked"
+  "FileMapping"
+  {
+    "LocalPath" "*"
+    "DepotPath" "."
+    "Recursive" "1"
+  }
+}

--- a/steamcmd/depot_build_macos.vdf
+++ b/steamcmd/depot_build_macos.vdf
@@ -1,0 +1,13 @@
+"DepotBuild"
+{
+  // Replace 1002 with your actual macOS depot ID from Steamworks
+  "DepotID" "1002"
+  // Uses ARM64 (Apple Silicon) build. For Intel, change to "../release/mac"
+  "ContentRoot" "../release/mac-arm64"
+  "FileMapping"
+  {
+    "LocalPath" "*"
+    "DepotPath" "."
+    "Recursive" "1"
+  }
+}

--- a/steamcmd/depot_build_windows.vdf
+++ b/steamcmd/depot_build_windows.vdf
@@ -1,0 +1,12 @@
+"DepotBuild"
+{
+  // Replace 1001 with your actual Windows depot ID from Steamworks
+  "DepotID" "1001"
+  "ContentRoot" "../release/win-unpacked"
+  "FileMapping"
+  {
+    "LocalPath" "*"
+    "DepotPath" "."
+    "Recursive" "1"
+  }
+}


### PR DESCRIPTION
## PR: Add SteamCMD VDF depot + app build configuration files (Issue #651, part of Epic #606)

### Summary (what changed & why)
This PR adds the required **SteamCMD Valve Data Format (VDF)** configuration files so we can upload **Raptor Skies** builds to Steam using SteamCMD. SteamCMD relies on an app-level build manifest plus per-platform depot manifests to know **which depots exist** and **which files to upload** for each platform.

Key decisions:
- Uses **placeholder IDs** (`1000`–`1003`) to avoid committing real Steamworks identifiers; comments indicate exactly what to replace.
- Uploads **unpacked electron-builder output directories** (Steam acts as the installer/updater), not installer artifacts.
- Adds `steam_build_output/` to `.gitignore` since SteamCMD writes logs/cache there.

### Key files modified / added
- **Added:** `steamcmd/app_build.vdf`  
  - Top-level SteamCMD app build config referencing depots and build output folder.
- **Added:** `steamcmd/depot_build_windows.vdf`  
  - Windows depot (placeholder `1001`) with `ContentRoot` set to `../release/win-unpacked`.
- **Added:** `steamcmd/depot_build_macos.vdf`  
  - macOS depot (placeholder `1002`) defaulting to Apple Silicon output `../release/mac-arm64` (comment includes Intel alternative `../release/mac`).
- **Added:** `steamcmd/depot_build_linux.vdf`  
  - Linux depot (placeholder `1003`) with `ContentRoot` set to `../release/linux-unpacked`.
- **Added:** `steamcmd/README.md`  
  - Explains the VDF layout, placeholder ID mapping, prerequisites, and how to run SteamCMD to upload.
- **Updated:** `.gitignore`  
  - Ignores `steam_build_output/` (SteamCMD build logs/cache/output).

### Testing / validation notes
- **No runtime/CI testing included** (config-only change; requires real Steam App/Depot IDs + Steamworks credentials to perform an actual upload).
- **Validated by inspection:** VDF structure is syntactically correct (quoted keys/values, balanced braces, standard `FileMapping` with recursive upload).
- **Path alignment check:** Depot `ContentRoot` values match expected `electron-builder` unpacked outputs under `release/`:
  - Windows: `release/win-unpacked/`
  - macOS: `release/mac-arm64/` (or `release/mac/` for Intel)
  - Linux: `release/linux-unpacked/`

### Notes for reviewers / follow-ups
- Replace placeholder IDs in the VDF files with the real values from the Steamworks partner portal before running uploads.
- `steam_appid.txt` (currently `480`) is unrelated to SteamCMD uploads and is not changed here; updating it for release is out of scope but called out in the README.

Ref: https://github.com/asgardtech/archer/issues/651