### PR TITLE
Create manual GitHub Actions workflow to deploy builds to Steam via SteamCMD

### DIFF
--- a/.github/workflows/release-steam.yml
+++ b/.github/workflows/release-steam.yml
@@ -1,0 +1,98 @@
+name: Release to Steam
+
+on:
+  workflow_dispatch:
+    inputs:
+      steam_branch:
+        description: >
+          Steam branch to set the build live on after upload
+          (e.g., "staging", "beta", "default" for production)
+        required: true
+        default: staging
+        type: string
+      description:
+        description: >
+          Build description shown in the Steamworks dashboard
+          (leave empty for default)
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: steam-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  upload-to-steam:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-windows
+          path: release/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-macos
+          path: release/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-linux
+          path: release/
+
+      - name: Validate artifact directories
+        run: |
+          missing=0
+          for dir in release/win-unpacked release/mac-arm64 release/linux-unpacked; do
+            if [ ! -d "$dir" ]; then
+              echo "::error::Required directory $dir is missing"
+              missing=1
+            else
+              echo "✓ $dir exists ($(find "$dir" -type f | wc -l) files)"
+            fi
+          done
+          if [ "$missing" -eq 1 ]; then
+            exit 1
+          fi
+
+      - name: Configure app_build.vdf
+        run: |
+          if [ -n "${{ inputs.description }}" ]; then
+            sed -i 's|"Desc".*|"Desc" "${{ inputs.description }}"|' steamcmd/app_build.vdf
+          fi
+          if [ -n "${{ inputs.steam_branch }}" ]; then
+            sed -i '/"Desc"/a\  "SetLive" "${{ inputs.steam_branch }}"' steamcmd/app_build.vdf
+          fi
+          echo "--- Final app_build.vdf ---"
+          cat steamcmd/app_build.vdf
+
+      - name: Install SteamCMD
+        uses: CyberAndrii/setup-steamcmd@v1
+
+      - name: Write Steam config.vdf
+        run: |
+          mkdir -p ~/Steam/config
+          echo "${{ secrets.STEAM_CONFIG_VDF }}" | base64 -d > ~/Steam/config/config.vdf
+          echo "::add-mask::$(cat ~/Steam/config/config.vdf)"
+
+      - name: Upload to Steam via SteamCMD
+        run: |
+          steamcmd +login ${{ secrets.STEAM_USERNAME }} \
+                   +run_app_build "${{ github.workspace }}/steamcmd/app_build.vdf" \
+                   +quit
+
+      - name: Upload SteamCMD build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: steam-build-logs
+          path: steam_build_output/
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Adds a new **manually-triggered GitHub Actions workflow** to build Raptor Skies for **Windows/macOS/Linux** and **deploy the resulting artifacts to Steam via SteamCMD**. This is the core “push to Steam” release pipeline and ties together the reusable build workflow (#649) with the SteamCMD VDF configuration (#651).

**Why:** We need a controlled, operator-initiated release mechanism (rather than automatic releases) so the team can choose *when* a build is published and *which Steam branch* (e.g., `staging`, `beta`, `default`) it goes live on.

## Key Changes

- Introduced a new workflow: **`Release to Steam`**
  - Trigger: `workflow_dispatch`
  - Inputs:
    - `steam_branch` (default: `staging`) — branch to set live after upload
    - `description` (optional) — build description shown in Steamworks
- Two-job pipeline:
  - **`build`**: calls the existing reusable workflow `./.github/workflows/build.yml` to produce platform artifacts
  - **`upload-to-steam`**: downloads artifacts, validates required directories, injects branch/description into `steamcmd/app_build.vdf`, installs SteamCMD, authenticates using a pre-authenticated `config.vdf`, and runs `steamcmd +run_app_build ...`
- Added **concurrency protection** so multiple Steam deploys can’t run in parallel (deploys queue instead of overlapping).
- Added **failure diagnostics** by uploading SteamCMD output logs as a workflow artifact when the upload job fails.
- Ensured **secrets are not leaked** (Steam credentials/config are masked and not printed).

## Key Files Modified / Added

- **Added:** `.github/workflows/release-steam.yml`  
  Manual workflow that orchestrates build + Steam upload via SteamCMD.

(Uses existing VDF files under `steamcmd/` created in #651 and the reusable build workflow in `.github/workflows/build.yml` from #649.)

## Secrets / Configuration Required

This workflow expects the following GitHub Actions secrets to be configured:

- `STEAM_USERNAME` — Steam builder account username
- `STEAM_CONFIG_VDF` — Base64-encoded pre-authenticated `config.vdf` (avoids Steam Guard prompts in CI)

## Testing Notes

- **Not executed against Steam in this PR** (requires repository secrets and valid Steam app/depot IDs).
- Recommended validation steps:
  - Run `actionlint` / workflow YAML validation on `.github/workflows/release-steam.yml`
  - Trigger workflow manually targeting `steam_branch: staging` with a test description
  - Confirm:
    - artifacts download correctly and `release/win-unpacked`, `release/mac-arm64`, `release/linux-unpacked` exist
    - SteamCMD login succeeds using `config.vdf`
    - SteamCMD `+run_app_build` completes successfully
    - on failure, `steam_build_output/` is uploaded as `steam-build-logs`
    - logs do not contain secret values

Ref: https://github.com/asgardtech/archer/issues/652