### PR TITLE
Add save format versioning and migration framework

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,4 +1,4 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT, SAVE_FORMAT_VERSION } from "./types";
 import { detectSpeaker } from "./rendering/StoryRenderer";
 import { InputManager } from "./systems/InputManager";
 import { DevConsole } from "./systems/DevConsole";
@@ -1101,7 +1101,7 @@ export class RaptorGame implements IGame {
             inventoryRecord[w] = t;
           }
           SaveSystem.save({
-            version: 1,
+            version: SAVE_FORMAT_VERSION,
             levelReached: this.currentLevel + 1,
             totalScore: this.totalScore,
             lives: this.player.lives,
@@ -1127,7 +1127,7 @@ export class RaptorGame implements IGame {
           inventoryRecord[w] = t;
         }
         SaveSystem.save({
-          version: 1,
+          version: SAVE_FORMAT_VERSION,
           levelReached: this.currentLevel + 1,
           totalScore: this.totalScore,
           lives: this.player.lives,

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -1,8 +1,19 @@
-import { RaptorSaveData, WeaponType } from "../types";
+import { RaptorSaveData, WeaponType, SAVE_FORMAT_VERSION, SaveMigration } from "../types";
 import { LEVELS } from "../levels";
 import { tryGetStorage, trySetStorage, tryRemoveStorage } from "../../../shared/storage";
 
 const VALID_WEAPONS: WeaponType[] = ["machine-gun", "missile", "laser", "plasma", "ion-cannon", "auto-gun", "rocket"];
+
+const MIGRATIONS: readonly SaveMigration[] = [
+  {
+    fromVersion: 1,
+    toVersion: 2,
+    migrate(data) {
+      data.version = 2;
+      return data;
+    },
+  },
+];
 
 export class SaveSystem {
   private static readonly STORAGE_KEY = "raptor_save";
@@ -17,8 +28,10 @@ export class SaveSystem {
 
     try {
       const parsed = JSON.parse(raw);
-      if (!this.validate(parsed)) return null;
-      return parsed as RaptorSaveData;
+      const migrated = this.runMigrations(parsed);
+      if (!migrated) return null;
+      if (!this.validate(migrated)) return null;
+      return migrated as RaptorSaveData;
     } catch {
       return null;
     }
@@ -34,10 +47,35 @@ export class SaveSystem {
 
     try {
       const parsed = JSON.parse(raw);
-      return this.validate(parsed);
+      const migrated = this.runMigrations(parsed);
+      if (!migrated) return false;
+      return this.validate(migrated);
     } catch {
       return false;
     }
+  }
+
+  private static runMigrations(data: Record<string, unknown>): Record<string, unknown> | null {
+    if (typeof data !== "object" || data === null) return null;
+
+    let version = data.version;
+    if (typeof version !== "number" || !Number.isInteger(version) || version < 1) {
+      return null;
+    }
+    if (version > SAVE_FORMAT_VERSION) {
+      return null;
+    }
+    for (const migration of MIGRATIONS) {
+      if (version === SAVE_FORMAT_VERSION) break;
+      if (migration.fromVersion === version) {
+        data = migration.migrate(data);
+        version = data.version;
+      }
+    }
+    if (version !== SAVE_FORMAT_VERSION) {
+      return null;
+    }
+    return data;
   }
 
   private static validate(data: unknown): data is RaptorSaveData {
@@ -45,7 +83,7 @@ export class SaveSystem {
 
     const d = data as Record<string, unknown>;
 
-    if (d.version !== 1) return false;
+    if (d.version !== SAVE_FORMAT_VERSION) return false;
 
     if (
       typeof d.levelReached !== "number" ||

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -163,8 +163,16 @@ export const WEAPON_SLOT_ORDER: WeaponType[] = [
 
 export const HUD_BAR_HEIGHT = 48;
 
+export const SAVE_FORMAT_VERSION = 2;
+
+export interface SaveMigration {
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  migrate(data: Record<string, unknown>): Record<string, unknown>;
+}
+
 export interface RaptorSaveData {
-  version: 1;
+  version: number;
   /** The highest level index the player has unlocked (0-based). */
   levelReached: number;
   /** Cumulative score at the time of save. */

--- a/tests/raptor-save.test.ts
+++ b/tests/raptor-save.test.ts
@@ -1,5 +1,5 @@
 import { SaveSystem } from "../src/games/raptor/systems/SaveSystem";
-import { RaptorSaveData, WeaponType } from "../src/games/raptor/types";
+import { RaptorSaveData, WeaponType, SAVE_FORMAT_VERSION, SaveMigration } from "../src/games/raptor/types";
 import { LEVELS } from "../src/games/raptor/levels";
 import { raptorDescriptor } from "../src/games/raptor";
 
@@ -116,7 +116,7 @@ function createPlayingGame(): { game: any; canvas: HTMLCanvasElement } {
 
 function validSaveData(overrides?: Partial<RaptorSaveData>): RaptorSaveData {
   return {
-    version: 1,
+    version: SAVE_FORMAT_VERSION,
     levelReached: 2,
     totalScore: 500,
     lives: 2,
@@ -170,11 +170,11 @@ describe("Scenario: SaveSystem.hasSave() returns false when no save exists", () 
 });
 
 describe("Scenario: Save data includes a version number for forward compatibility", () => {
-  test("saved data has version field set to 1", () => {
+  test("saved data has version field set to SAVE_FORMAT_VERSION", () => {
     const data = validSaveData();
     SaveSystem.save(data);
     const loaded = SaveSystem.load();
-    expect(loaded!.version).toBe(1);
+    expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
   });
 });
 
@@ -260,7 +260,7 @@ describe("Scenario: Save data with missing version field is rejected", () => {
   });
 
   test("wrong version number returns null", () => {
-    const data = { ...validSaveData(), version: 2 } as any;
+    const data = { ...validSaveData(), version: 99 } as any;
     mockStorage["raptor_save"] = JSON.stringify(data);
     expect(SaveSystem.load()).toBeNull();
   });
@@ -390,7 +390,7 @@ describe("Scenario: Progress is saved automatically when a level is completed", 
     expect(saved!.totalScore).toBe(300);
     expect(saved!.lives).toBe(2);
     expect(saved!.weapon).toBe("missile");
-    expect(saved!.version).toBe(1);
+    expect(saved!.version).toBe(SAVE_FORMAT_VERSION);
     expect(saved!.savedAt).toBeDefined();
   });
 });
@@ -661,5 +661,207 @@ describe("Scenario: RaptorGame exposes hasSaveData getter", () => {
     SaveSystem.save(validSaveData());
     const { game } = createPlayingGame();
     expect(game.hasSaveData).toBe(true);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// SAVE FORMAT VERSIONING & MIGRATION TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: SAVE_FORMAT_VERSION constant is exported from types", () => {
+  test("SAVE_FORMAT_VERSION is a number equal to 2", () => {
+    expect(typeof SAVE_FORMAT_VERSION).toBe("number");
+    expect(SAVE_FORMAT_VERSION).toBe(2);
+  });
+});
+
+describe("Scenario: SaveMigration interface is exported from types", () => {
+  test("SaveMigration has the expected shape", () => {
+    const migration: SaveMigration = {
+      fromVersion: 1,
+      toVersion: 2,
+      migrate(data) {
+        data.version = 2;
+        return data;
+      },
+    };
+    expect(migration.fromVersion).toBe(1);
+    expect(migration.toVersion).toBe(2);
+    expect(typeof migration.migrate).toBe("function");
+  });
+});
+
+describe("Scenario: Loading a v1 save runs the v1→v2 migration", () => {
+  test("v1 save is migrated to current version with all fields preserved", () => {
+    const v1Save = {
+      version: 1,
+      levelReached: 3,
+      totalScore: 1200,
+      lives: 2,
+      weapon: "laser",
+      savedAt: "2026-03-10T12:00:00.000Z",
+      bombs: 3,
+      shieldBattery: 50,
+      armor: 80,
+      energy: 60,
+      weaponTier: 2,
+      weaponInventory: { "machine-gun": 1, "laser": 2 },
+    };
+    mockStorage["raptor_save"] = JSON.stringify(v1Save);
+
+    const loaded = SaveSystem.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
+    expect(loaded!.levelReached).toBe(3);
+    expect(loaded!.totalScore).toBe(1200);
+    expect(loaded!.lives).toBe(2);
+    expect(loaded!.weapon).toBe("laser");
+    expect(loaded!.bombs).toBe(3);
+    expect(loaded!.shieldBattery).toBe(50);
+    expect(loaded!.armor).toBe(80);
+    expect(loaded!.energy).toBe(60);
+    expect(loaded!.weaponTier).toBe(2);
+    expect(loaded!.weaponInventory).toEqual({ "machine-gun": 1, "laser": 2 });
+  });
+});
+
+describe("Scenario: A save at current version skips migrations", () => {
+  test("current-version save loads without migration", () => {
+    const data = validSaveData();
+    mockStorage["raptor_save"] = JSON.stringify(data);
+
+    const loaded = SaveSystem.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded).toEqual(data);
+  });
+});
+
+describe("Scenario: Loading an unknown future version returns null", () => {
+  test("version 99 returns null", () => {
+    const data = { ...validSaveData(), version: 99 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: Loading a save with missing version returns null", () => {
+  test("missing version field returns null", () => {
+    const data = { ...validSaveData() } as any;
+    delete data.version;
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: Loading a save with a non-integer version returns null", () => {
+  test("version 1.5 returns null", () => {
+    const data = { ...validSaveData(), version: 1.5 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: Loading a save with zero or negative version returns null", () => {
+  test("version 0 returns null", () => {
+    const data = { ...validSaveData(), version: 0 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+
+  test("version -1 returns null", () => {
+    const data = { ...validSaveData(), version: -1 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: Migration that throws is handled gracefully", () => {
+  test("exception in migration pipeline returns null from load", () => {
+    const corruptData = { version: 1, levelReached: "not-a-number" };
+    mockStorage["raptor_save"] = JSON.stringify(corruptData);
+    expect(() => SaveSystem.load()).not.toThrow();
+    expect(SaveSystem.load()).toBeNull();
+  });
+});
+
+describe("Scenario: Saving always writes the current SAVE_FORMAT_VERSION", () => {
+  test("saved data in localStorage has version equal to SAVE_FORMAT_VERSION", () => {
+    const data = validSaveData();
+    SaveSystem.save(data);
+    const raw = JSON.parse(mockStorage["raptor_save"]);
+    expect(raw.version).toBe(SAVE_FORMAT_VERSION);
+  });
+});
+
+describe("Scenario: hasSave with old and future versions", () => {
+  test("hasSave returns true for a migratable v1 save", () => {
+    const v1Save = {
+      version: 1,
+      levelReached: 2,
+      totalScore: 500,
+      lives: 2,
+      weapon: "machine-gun",
+      savedAt: "2026-03-10T12:00:00.000Z",
+    };
+    mockStorage["raptor_save"] = JSON.stringify(v1Save);
+    expect(SaveSystem.hasSave()).toBe(true);
+  });
+
+  test("hasSave returns false for a future-version save", () => {
+    const data = { ...validSaveData(), version: 99 };
+    mockStorage["raptor_save"] = JSON.stringify(data);
+    expect(SaveSystem.hasSave()).toBe(false);
+  });
+});
+
+describe("Scenario: v1 saves with and without optional fields migrate correctly", () => {
+  test("v1 save with optional fields preserves them after migration", () => {
+    const v1Save = {
+      version: 1,
+      levelReached: 2,
+      totalScore: 500,
+      lives: 2,
+      weapon: "machine-gun",
+      savedAt: "2026-03-10T12:00:00.000Z",
+      bombs: 2,
+      shieldBattery: 75,
+      armor: 90,
+      energy: 50,
+      weaponTier: 3,
+      weaponInventory: { "machine-gun": 1, "missile": 2 },
+    };
+    mockStorage["raptor_save"] = JSON.stringify(v1Save);
+
+    const loaded = SaveSystem.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
+    expect(loaded!.bombs).toBe(2);
+    expect(loaded!.shieldBattery).toBe(75);
+    expect(loaded!.armor).toBe(90);
+    expect(loaded!.energy).toBe(50);
+    expect(loaded!.weaponTier).toBe(3);
+    expect(loaded!.weaponInventory).toEqual({ "machine-gun": 1, "missile": 2 });
+  });
+
+  test("v1 save without optional fields migrates correctly", () => {
+    const v1Save = {
+      version: 1,
+      levelReached: 2,
+      totalScore: 500,
+      lives: 2,
+      weapon: "machine-gun",
+      savedAt: "2026-03-10T12:00:00.000Z",
+    };
+    mockStorage["raptor_save"] = JSON.stringify(v1Save);
+
+    const loaded = SaveSystem.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
+    expect(loaded!.bombs).toBeUndefined();
+    expect(loaded!.shieldBattery).toBeUndefined();
+    expect(loaded!.armor).toBeUndefined();
+    expect(loaded!.energy).toBeUndefined();
+    expect(loaded!.weaponTier).toBeUndefined();
+    expect(loaded!.weaponInventory).toBeUndefined();
   });
 });


### PR DESCRIPTION
## PR: Add save format versioning and migration framework (Issue #662, epic #607)

### Summary (what changed & why)
This PR introduces **explicit save format versioning** and a **structured migration pipeline** for Raptor saves.

Previously, the save format was effectively pinned to `version: 1`:
- `RaptorSaveData.version` was a literal type `1`
- `SaveSystem.validate()` rejected any save not exactly version 1
- New saves were stamped with a hardcoded `version: 1`

As soon as the schema changes, older saves would fail validation and be treated as invalid (effectively discarded) with no upgrade path. This PR resolves that by:
- Adding a single source of truth `SAVE_FORMAT_VERSION` (now `2`)
- Widening `version` to `number`
- Running **sequential, stepwise migrations** (`v1 → v2 → … → vN`) during `load()` and `hasSave()` before validation
- Updating save creation to always stamp the current `SAVE_FORMAT_VERSION`
- Adding a starter **no-op v1→v2 migration** (schema-identical) to establish the pattern for future changes

### Key files modified
- **`src/games/raptor/types.ts`**
  - Added `export const SAVE_FORMAT_VERSION = 2`
  - Added `SaveMigration` interface
  - Changed `RaptorSaveData.version` from literal `1` to `number`

- **`src/games/raptor/systems/SaveSystem.ts`**
  - Added `MIGRATIONS` registry (currently includes a no-op `1 → 2` bump)
  - Added `runMigrations()` to enforce version rules and apply contiguous migrations
  - Updated `load()` and `hasSave()` to migrate *before* validating
  - Updated `validate()` to check against `SAVE_FORMAT_VERSION` instead of `1`

- **`src/games/raptor/RaptorGame.ts`**
  - Replaced hardcoded `version: 1` save stamping with `version: SAVE_FORMAT_VERSION`

- **`tests/raptor-save.test.ts`**
  - Updated existing tests to expect the new version behavior
  - Added migration-specific coverage (upgrade path, invalid versions, optional field preservation, etc.)

### Behavior notes / edge cases
- Saves with **missing, non-integer, zero/negative, or future versions** return `null` gracefully.
- If there’s a **gap in the migration chain**, loading fails safely (`null`) rather than partially upgrading.
- Migrations are expected to be **pure** and must set `data.version` to `toVersion`.

### Testing
- Updated existing unit tests to reflect `SAVE_FORMAT_VERSION = 2`
- Added new migration-focused tests covering:
  - v1 save successfully migrates to v2
  - current-version saves skip migrations
  - future version (e.g., 99) is rejected
  - missing/invalid versions (e.g., undefined, `1.5`, `0`) are rejected
  - optional fields are preserved through migration
- Run locally:
  - `npm test` (or project-standard test command for the repo)

Ref: https://github.com/asgardtech/archer/issues/662