### PR TITLE
Support multiple save slots in SaveSystem

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,4 +1,4 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT, SAVE_FORMAT_VERSION } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT, SAVE_FORMAT_VERSION, MAX_SAVE_SLOTS } from "./types";
 import { detectSpeaker } from "./rendering/StoryRenderer";
 import { InputManager } from "./systems/InputManager";
 import { DevConsole } from "./systems/DevConsole";
@@ -125,6 +125,16 @@ export class RaptorGame implements IGame {
   private cachedSkyGradient: [string, string] | null = null;
 
   public onExit: (() => void) | null = null;
+  private activeSlot = 0;
+
+  get saveSlot(): number {
+    return this.activeSlot;
+  }
+
+  set saveSlot(slot: number) {
+    if (!Number.isInteger(slot) || slot < 0 || slot >= MAX_SAVE_SLOTS) return;
+    this.activeSlot = slot;
+  }
 
   constructor(canvas: HTMLCanvasElement, private width = 800, private height = 600) {
     this.canvas = canvas;
@@ -392,7 +402,7 @@ export class RaptorGame implements IGame {
     }
 
     if (this.hud.isClearSaveButtonHit(mx, my, this.width, this.height)) {
-      SaveSystem.clear();
+      SaveSystem.clear(this.activeSlot);
       this.input.consume();
       return true;
     }
@@ -463,7 +473,7 @@ export class RaptorGame implements IGame {
             } else if (this.hud.isNewGameButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
               this.audio.ensureContext();
               this.sound.play("menu_start");
-              SaveSystem.clear();
+              SaveSystem.clear(this.activeSlot);
               this.resetGame();
               const act = getActForLevel(0);
               this.storyRenderer.show([act.opening.join(" ")], "center", "pilot");
@@ -1094,7 +1104,7 @@ export class RaptorGame implements IGame {
         this.state = "victory";
         this.sound.play("victory");
         if (act.isFinal) {
-          SaveSystem.clear();
+          SaveSystem.clear(this.activeSlot);
         } else {
           const inventoryRecord: Record<string, number> = {};
           for (const [w, t] of this.powerUpManager.inventory) {
@@ -1113,7 +1123,7 @@ export class RaptorGame implements IGame {
             energy: this.player.energy,
             weaponTier: this.powerUpManager.weaponTier,
             weaponInventory: inventoryRecord,
-          });
+          }, this.activeSlot);
         }
         this.storyRenderer.show([act.ending.join(" ")], "center", "pilot");
         this.hud.setVictoryStoryActive(true);
@@ -1139,7 +1149,7 @@ export class RaptorGame implements IGame {
           energy: this.player.energy,
           weaponTier: this.powerUpManager.weaponTier,
           weaponInventory: inventoryRecord,
-        });
+        }, this.activeSlot);
       }
     }
   }
@@ -1270,7 +1280,7 @@ export class RaptorGame implements IGame {
   }
 
   get hasSaveData(): boolean {
-    return SaveSystem.hasSave();
+    return SaveSystem.hasSave(this.activeSlot);
   }
 
   private resetGame(): void {
@@ -1282,7 +1292,7 @@ export class RaptorGame implements IGame {
   }
 
   private continueGame(): void {
-    const data = SaveSystem.load();
+    const data = SaveSystem.load(this.activeSlot);
     if (!data) {
       this.resetGame();
       return;

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -1,4 +1,4 @@
-import { RaptorSaveData, WeaponType, SAVE_FORMAT_VERSION, SaveMigration } from "../types";
+import { RaptorSaveData, WeaponType, SAVE_FORMAT_VERSION, SaveMigration, MAX_SAVE_SLOTS } from "../types";
 import { LEVELS } from "../levels";
 import { tryGetStorage, trySetStorage, tryRemoveStorage } from "../../../shared/storage";
 
@@ -16,14 +16,42 @@ const MIGRATIONS: readonly SaveMigration[] = [
 ];
 
 export class SaveSystem {
-  private static readonly STORAGE_KEY = "raptor_save";
+  private static readonly LEGACY_STORAGE_KEY = "raptor_save";
+  private static migrationDone = false;
 
-  static save(data: RaptorSaveData): void {
-    trySetStorage(this.STORAGE_KEY, JSON.stringify(data));
+  private static storageKey(slot: number): string {
+    return `raptor_save_${slot}`;
   }
 
-  static load(): RaptorSaveData | null {
-    const raw = tryGetStorage(this.STORAGE_KEY, "");
+  private static isValidSlot(slot: number): boolean {
+    return Number.isInteger(slot) && slot >= 0 && slot < MAX_SAVE_SLOTS;
+  }
+
+  private static runLegacyMigration(): void {
+    if (this.migrationDone) return;
+    this.migrationDone = true;
+
+    const legacy = tryGetStorage(this.LEGACY_STORAGE_KEY, "");
+    if (!legacy) return;
+
+    const slot0 = tryGetStorage(this.storageKey(0), "");
+    if (slot0) return;
+
+    trySetStorage(this.storageKey(0), legacy);
+    tryRemoveStorage(this.LEGACY_STORAGE_KEY);
+  }
+
+  static save(data: RaptorSaveData, slot: number): void {
+    if (!this.isValidSlot(slot)) return;
+    data.slotIndex = slot;
+    trySetStorage(this.storageKey(slot), JSON.stringify(data));
+  }
+
+  static load(slot: number): RaptorSaveData | null {
+    this.runLegacyMigration();
+    if (!this.isValidSlot(slot)) return null;
+
+    const raw = tryGetStorage(this.storageKey(slot), "");
     if (!raw) return null;
 
     try {
@@ -37,12 +65,16 @@ export class SaveSystem {
     }
   }
 
-  static clear(): void {
-    tryRemoveStorage(this.STORAGE_KEY);
+  static clear(slot: number): void {
+    if (!this.isValidSlot(slot)) return;
+    tryRemoveStorage(this.storageKey(slot));
   }
 
-  static hasSave(): boolean {
-    const raw = tryGetStorage(this.STORAGE_KEY, "");
+  static hasSave(slot: number): boolean {
+    this.runLegacyMigration();
+    if (!this.isValidSlot(slot)) return false;
+
+    const raw = tryGetStorage(this.storageKey(slot), "");
     if (!raw) return false;
 
     try {
@@ -53,6 +85,20 @@ export class SaveSystem {
     } catch {
       return false;
     }
+  }
+
+  static listSlots(): (RaptorSaveData | null)[] {
+    this.runLegacyMigration();
+    const result: (RaptorSaveData | null)[] = [];
+    for (let i = 0; i < MAX_SAVE_SLOTS; i++) {
+      result.push(this.load(i));
+    }
+    return result;
+  }
+
+  /** @internal Exposed for testing only. */
+  static resetMigrationFlag(): void {
+    this.migrationDone = false;
   }
 
   private static runMigrations(data: Record<string, unknown>): Record<string, unknown> | null {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -165,6 +165,8 @@ export const HUD_BAR_HEIGHT = 48;
 
 export const SAVE_FORMAT_VERSION = 2;
 
+export const MAX_SAVE_SLOTS = 3;
+
 export interface SaveMigration {
   readonly fromVersion: number;
   readonly toVersion: number;
@@ -195,6 +197,8 @@ export interface RaptorSaveData {
   weaponTier?: number;
   /** Full weapon inventory mapping weapon type to tier (1-3). */
   weaponInventory?: Record<string, number>;
+  /** Which save slot this data was written to (0-based). */
+  slotIndex?: number;
 }
 
 export interface WeaponTierConfig {

--- a/tests/raptor-save.test.ts
+++ b/tests/raptor-save.test.ts
@@ -1,5 +1,5 @@
 import { SaveSystem } from "../src/games/raptor/systems/SaveSystem";
-import { RaptorSaveData, WeaponType, SAVE_FORMAT_VERSION, SaveMigration } from "../src/games/raptor/types";
+import { RaptorSaveData, WeaponType, SAVE_FORMAT_VERSION, SaveMigration, MAX_SAVE_SLOTS } from "../src/games/raptor/types";
 import { LEVELS } from "../src/games/raptor/levels";
 import { raptorDescriptor } from "../src/games/raptor";
 
@@ -14,6 +14,7 @@ beforeEach(() => {
     setItem: jest.fn((key: string, value: string) => { mockStorage[key] = value; }),
     removeItem: jest.fn((key: string) => { delete mockStorage[key]; }),
   };
+  SaveSystem.resetMigrationFlag();
 });
 
 afterEach(() => {
@@ -133,47 +134,47 @@ function validSaveData(overrides?: Partial<RaptorSaveData>): RaptorSaveData {
 describe("Scenario: SaveSystem.save() and load() round-trip correctly", () => {
   test("save then load returns matching data", () => {
     const data = validSaveData();
-    SaveSystem.save(data);
-    const loaded = SaveSystem.load();
-    expect(loaded).toEqual(data);
+    SaveSystem.save(data, 0);
+    const loaded = SaveSystem.load(0);
+    expect(loaded).toEqual({ ...data, slotIndex: 0 });
   });
 
-  test("save stores data under 'raptor_save' key", () => {
+  test("save stores data under slot-specific key", () => {
     const data = validSaveData();
-    SaveSystem.save(data);
+    SaveSystem.save(data, 0);
     expect(localStorage.setItem).toHaveBeenCalledWith(
-      "raptor_save",
-      JSON.stringify(data)
+      "raptor_save_0",
+      JSON.stringify({ ...data, slotIndex: 0 })
     );
   });
 });
 
 describe("Scenario: SaveSystem.clear() removes saved data", () => {
   test("hasSave returns false after clear", () => {
-    SaveSystem.save(validSaveData());
-    expect(SaveSystem.hasSave()).toBe(true);
-    SaveSystem.clear();
-    expect(SaveSystem.hasSave()).toBe(false);
+    SaveSystem.save(validSaveData(), 0);
+    expect(SaveSystem.hasSave(0)).toBe(true);
+    SaveSystem.clear(0);
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 
   test("load returns null after clear", () => {
-    SaveSystem.save(validSaveData());
-    SaveSystem.clear();
-    expect(SaveSystem.load()).toBeNull();
+    SaveSystem.save(validSaveData(), 0);
+    SaveSystem.clear(0);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: SaveSystem.hasSave() returns false when no save exists", () => {
   test("hasSave returns false with empty storage", () => {
-    expect(SaveSystem.hasSave()).toBe(false);
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 });
 
 describe("Scenario: Save data includes a version number for forward compatibility", () => {
   test("saved data has version field set to SAVE_FORMAT_VERSION", () => {
     const data = validSaveData();
-    SaveSystem.save(data);
-    const loaded = SaveSystem.load();
+    SaveSystem.save(data, 0);
+    const loaded = SaveSystem.load(0);
     expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
   });
 });
@@ -181,8 +182,8 @@ describe("Scenario: Save data includes a version number for forward compatibilit
 describe("Scenario: Save data includes a timestamp", () => {
   test("saved data has a valid ISO-8601 savedAt field", () => {
     const data = validSaveData();
-    SaveSystem.save(data);
-    const loaded = SaveSystem.load();
+    SaveSystem.save(data, 0);
+    const loaded = SaveSystem.load(0);
     expect(loaded!.savedAt).toBeDefined();
     const parsed = new Date(loaded!.savedAt);
     expect(parsed.getTime()).not.toBeNaN();
@@ -195,58 +196,58 @@ describe("Scenario: Save data includes a timestamp", () => {
 
 describe("Scenario: Corrupt save data is handled gracefully", () => {
   test("invalid JSON returns null from load", () => {
-    mockStorage["raptor_save"] = "not-json{{{";
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = "not-json{{{";
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("invalid JSON causes hasSave to return false", () => {
-    mockStorage["raptor_save"] = "not-json{{{";
-    expect(SaveSystem.hasSave()).toBe(false);
+    mockStorage["raptor_save_0"] = "not-json{{{";
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 
   test("no error is thrown for corrupt data", () => {
-    mockStorage["raptor_save"] = "not-json{{{";
-    expect(() => SaveSystem.load()).not.toThrow();
-    expect(() => SaveSystem.hasSave()).not.toThrow();
+    mockStorage["raptor_save_0"] = "not-json{{{";
+    expect(() => SaveSystem.load(0)).not.toThrow();
+    expect(() => SaveSystem.hasSave(0)).not.toThrow();
   });
 });
 
 describe("Scenario: Save data with out-of-range level is rejected", () => {
   test("levelReached of 99 is invalid", () => {
     const data = validSaveData({ levelReached: 99 } as any);
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
-    expect(SaveSystem.hasSave()).toBe(false);
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 
   test("negative levelReached is invalid", () => {
     const data = validSaveData({ levelReached: -1 } as any);
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: Save data with zero or negative lives is rejected", () => {
   test("lives of 0 is invalid", () => {
     const data = validSaveData({ lives: 0 } as any);
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
-    expect(SaveSystem.hasSave()).toBe(false);
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 
   test("negative lives is invalid", () => {
     const data = validSaveData({ lives: -1 } as any);
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: Save data with unknown weapon type is rejected", () => {
   test("weapon 'plasma-cannon' is invalid", () => {
     const data = { ...validSaveData(), weapon: "plasma-cannon" };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
-    expect(SaveSystem.hasSave()).toBe(false);
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 });
 
@@ -254,37 +255,42 @@ describe("Scenario: Save data with missing version field is rejected", () => {
   test("missing version returns null", () => {
     const data = { ...validSaveData() } as any;
     delete data.version;
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
-    expect(SaveSystem.hasSave()).toBe(false);
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 
   test("wrong version number returns null", () => {
     const data = { ...validSaveData(), version: 99 } as any;
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: localStorage is unavailable", () => {
   test("save does not throw when localStorage is unavailable", () => {
     delete (global as any).localStorage;
-    expect(() => SaveSystem.save(validSaveData())).not.toThrow();
+    expect(() => SaveSystem.save(validSaveData(), 0)).not.toThrow();
   });
 
   test("load returns null when localStorage is unavailable", () => {
     delete (global as any).localStorage;
-    expect(SaveSystem.load()).toBeNull();
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("hasSave returns false when localStorage is unavailable", () => {
     delete (global as any).localStorage;
-    expect(SaveSystem.hasSave()).toBe(false);
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 
   test("clear does not throw when localStorage is unavailable", () => {
     delete (global as any).localStorage;
-    expect(() => SaveSystem.clear()).not.toThrow();
+    expect(() => SaveSystem.clear(0)).not.toThrow();
+  });
+
+  test("listSlots returns [null, null, null] when localStorage is unavailable", () => {
+    delete (global as any).localStorage;
+    expect(SaveSystem.listSlots()).toEqual([null, null, null]);
   });
 });
 
@@ -297,58 +303,58 @@ describe("Scenario: Additional validation edge cases", () => {
     const weapons: WeaponType[] = ["machine-gun", "missile", "laser"];
     for (const weapon of weapons) {
       const data = validSaveData({ weapon });
-      SaveSystem.save(data);
-      const loaded = SaveSystem.load();
+      SaveSystem.save(data, 0);
+      const loaded = SaveSystem.load(0);
       expect(loaded!.weapon).toBe(weapon);
     }
   });
 
   test("levelReached at max valid index (LEVELS.length - 1) is valid", () => {
     const data = validSaveData({ levelReached: LEVELS.length - 1 });
-    SaveSystem.save(data);
-    expect(SaveSystem.load()).not.toBeNull();
+    SaveSystem.save(data, 0);
+    expect(SaveSystem.load(0)).not.toBeNull();
   });
 
   test("levelReached at 0 is valid", () => {
     const data = validSaveData({ levelReached: 0 });
-    SaveSystem.save(data);
-    expect(SaveSystem.load()).not.toBeNull();
+    SaveSystem.save(data, 0);
+    expect(SaveSystem.load(0)).not.toBeNull();
   });
 
   test("non-integer levelReached is rejected", () => {
     const data = { ...validSaveData(), levelReached: 1.5 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("non-integer lives is rejected", () => {
     const data = { ...validSaveData(), lives: 2.5 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("negative totalScore is rejected", () => {
     const data = { ...validSaveData(), totalScore: -100 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("empty savedAt string is rejected", () => {
     const data = { ...validSaveData(), savedAt: "" };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("null data in storage returns null", () => {
-    mockStorage["raptor_save"] = "null";
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = "null";
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("levelReached values 5 through 9 are valid for the 10-level game", () => {
     for (let level = 5; level <= 9; level++) {
       const data = validSaveData({ levelReached: level });
-      SaveSystem.save(data);
-      const loaded = SaveSystem.load();
+      SaveSystem.save(data, 0);
+      const loaded = SaveSystem.load(0);
       expect(loaded).not.toBeNull();
       expect(loaded!.levelReached).toBe(level);
     }
@@ -356,9 +362,9 @@ describe("Scenario: Additional validation edge cases", () => {
 
   test("levelReached of 10 (out of bounds) is rejected", () => {
     const data = validSaveData({ levelReached: 10 } as any);
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
-    expect(SaveSystem.hasSave()).toBe(false);
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 });
 
@@ -384,7 +390,7 @@ describe("Scenario: Progress is saved automatically when a level is completed", 
     (game as any).updatePlaying(0.001);
 
     expect(game.state).toBe("level_complete");
-    const saved = SaveSystem.load();
+    const saved = SaveSystem.load(0);
     expect(saved).not.toBeNull();
     expect(saved!.levelReached).toBe(2);
     expect(saved!.totalScore).toBe(300);
@@ -397,8 +403,8 @@ describe("Scenario: Progress is saved automatically when a level is completed", 
 
 describe("Scenario: Save data is cleared on victory", () => {
   test("completing the final level clears save data", () => {
-    SaveSystem.save(validSaveData());
-    expect(SaveSystem.hasSave()).toBe(true);
+    SaveSystem.save(validSaveData(), 0);
+    expect(SaveSystem.hasSave(0)).toBe(true);
 
     const { game } = createPlayingGame();
     game.currentLevel = LEVELS.length - 1;
@@ -414,13 +420,13 @@ describe("Scenario: Save data is cleared on victory", () => {
     (game as any).updatePlaying(0.001);
 
     expect(game.state).toBe("victory");
-    expect(SaveSystem.hasSave()).toBe(false);
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 });
 
 describe("Scenario: Save data is preserved on game over", () => {
   test("save data survives when player dies", () => {
-    SaveSystem.save(validSaveData({ levelReached: 2 }));
+    SaveSystem.save(validSaveData({ levelReached: 2 }), 0);
 
     const { game } = createPlayingGame();
     game.player.alive = false;
@@ -429,8 +435,8 @@ describe("Scenario: Save data is preserved on game over", () => {
     (game as any).updatePlaying(0.001);
 
     expect(game.state).toBe("gameover");
-    expect(SaveSystem.hasSave()).toBe(true);
-    expect(SaveSystem.load()!.levelReached).toBe(2);
+    expect(SaveSystem.hasSave(0)).toBe(true);
+    expect(SaveSystem.load(0)!.levelReached).toBe(2);
   });
 });
 
@@ -446,7 +452,7 @@ describe("Scenario: Clicking Continue resumes from the saved level", () => {
       totalScore: 500,
       lives: 2,
       weapon: "missile",
-    }));
+    }), 0);
 
     (game as any).continueGame();
 
@@ -471,33 +477,33 @@ describe("Scenario: Clicking Continue resumes from the saved level", () => {
 describe("Scenario: Starting a New Game clears existing save data", () => {
   test("new game from menu clears save and starts at level 0", () => {
     const { game } = createPlayingGame();
-    SaveSystem.save(validSaveData({ levelReached: 3 }));
+    SaveSystem.save(validSaveData({ levelReached: 3 }), 0);
     game.state = "menu";
 
     const newBtn = game.hud.isNewGameButtonHit;
     expect(typeof newBtn).toBe("function");
 
-    SaveSystem.clear();
+    SaveSystem.clear(0);
     (game as any).resetGame();
 
     expect(game.currentLevel).toBe(0);
     expect(game.totalScore).toBe(0);
     expect(game.player.lives).toBe(3);
-    expect(SaveSystem.hasSave()).toBe(false);
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 });
 
 describe("Scenario: Saved weapon type is restored on continue", () => {
   test("laser weapon is restored", () => {
     const { game } = createPlayingGame();
-    SaveSystem.save(validSaveData({ weapon: "laser" }));
+    SaveSystem.save(validSaveData({ weapon: "laser" }), 0);
     (game as any).continueGame();
     expect(game.powerUpManager.currentWeapon).toBe("laser");
   });
 
   test("missile weapon is restored", () => {
     const { game } = createPlayingGame();
-    SaveSystem.save(validSaveData({ weapon: "missile" }));
+    SaveSystem.save(validSaveData({ weapon: "missile" }), 0);
     (game as any).continueGame();
     expect(game.powerUpManager.currentWeapon).toBe("missile");
   });
@@ -601,10 +607,10 @@ describe("Scenario: Player can clear save data from the settings panel", () => {
   });
 
   test("clear save removes data and menu no longer shows Continue", () => {
-    SaveSystem.save(validSaveData());
-    expect(SaveSystem.hasSave()).toBe(true);
-    SaveSystem.clear();
-    expect(SaveSystem.hasSave()).toBe(false);
+    SaveSystem.save(validSaveData(), 0);
+    expect(SaveSystem.hasSave(0)).toBe(true);
+    SaveSystem.clear(0);
+    expect(SaveSystem.hasSave(0)).toBe(false);
 
     const { HUD } = require("../src/games/raptor/rendering/HUD");
     const hud = new HUD(false);
@@ -658,7 +664,7 @@ describe("Scenario: RaptorGame exposes hasSaveData getter", () => {
   });
 
   test("hasSaveData returns true when a valid save exists", () => {
-    SaveSystem.save(validSaveData());
+    SaveSystem.save(validSaveData(), 0);
     const { game } = createPlayingGame();
     expect(game.hasSaveData).toBe(true);
   });
@@ -707,9 +713,9 @@ describe("Scenario: Loading a v1 save runs the v1→v2 migration", () => {
       weaponTier: 2,
       weaponInventory: { "machine-gun": 1, "laser": 2 },
     };
-    mockStorage["raptor_save"] = JSON.stringify(v1Save);
+    mockStorage["raptor_save_0"] = JSON.stringify(v1Save);
 
-    const loaded = SaveSystem.load();
+    const loaded = SaveSystem.load(0);
     expect(loaded).not.toBeNull();
     expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
     expect(loaded!.levelReached).toBe(3);
@@ -728,9 +734,9 @@ describe("Scenario: Loading a v1 save runs the v1→v2 migration", () => {
 describe("Scenario: A save at current version skips migrations", () => {
   test("current-version save loads without migration", () => {
     const data = validSaveData();
-    mockStorage["raptor_save"] = JSON.stringify(data);
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
 
-    const loaded = SaveSystem.load();
+    const loaded = SaveSystem.load(0);
     expect(loaded).not.toBeNull();
     expect(loaded).toEqual(data);
   });
@@ -739,8 +745,8 @@ describe("Scenario: A save at current version skips migrations", () => {
 describe("Scenario: Loading an unknown future version returns null", () => {
   test("version 99 returns null", () => {
     const data = { ...validSaveData(), version: 99 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
@@ -748,47 +754,47 @@ describe("Scenario: Loading a save with missing version returns null", () => {
   test("missing version field returns null", () => {
     const data = { ...validSaveData() } as any;
     delete data.version;
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: Loading a save with a non-integer version returns null", () => {
   test("version 1.5 returns null", () => {
     const data = { ...validSaveData(), version: 1.5 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: Loading a save with zero or negative version returns null", () => {
   test("version 0 returns null", () => {
     const data = { ...validSaveData(), version: 0 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 
   test("version -1 returns null", () => {
     const data = { ...validSaveData(), version: -1 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: Migration that throws is handled gracefully", () => {
   test("exception in migration pipeline returns null from load", () => {
     const corruptData = { version: 1, levelReached: "not-a-number" };
-    mockStorage["raptor_save"] = JSON.stringify(corruptData);
-    expect(() => SaveSystem.load()).not.toThrow();
-    expect(SaveSystem.load()).toBeNull();
+    mockStorage["raptor_save_0"] = JSON.stringify(corruptData);
+    expect(() => SaveSystem.load(0)).not.toThrow();
+    expect(SaveSystem.load(0)).toBeNull();
   });
 });
 
 describe("Scenario: Saving always writes the current SAVE_FORMAT_VERSION", () => {
   test("saved data in localStorage has version equal to SAVE_FORMAT_VERSION", () => {
     const data = validSaveData();
-    SaveSystem.save(data);
-    const raw = JSON.parse(mockStorage["raptor_save"]);
+    SaveSystem.save(data, 0);
+    const raw = JSON.parse(mockStorage["raptor_save_0"]);
     expect(raw.version).toBe(SAVE_FORMAT_VERSION);
   });
 });
@@ -803,14 +809,14 @@ describe("Scenario: hasSave with old and future versions", () => {
       weapon: "machine-gun",
       savedAt: "2026-03-10T12:00:00.000Z",
     };
-    mockStorage["raptor_save"] = JSON.stringify(v1Save);
-    expect(SaveSystem.hasSave()).toBe(true);
+    mockStorage["raptor_save_0"] = JSON.stringify(v1Save);
+    expect(SaveSystem.hasSave(0)).toBe(true);
   });
 
   test("hasSave returns false for a future-version save", () => {
     const data = { ...validSaveData(), version: 99 };
-    mockStorage["raptor_save"] = JSON.stringify(data);
-    expect(SaveSystem.hasSave()).toBe(false);
+    mockStorage["raptor_save_0"] = JSON.stringify(data);
+    expect(SaveSystem.hasSave(0)).toBe(false);
   });
 });
 
@@ -830,9 +836,9 @@ describe("Scenario: v1 saves with and without optional fields migrate correctly"
       weaponTier: 3,
       weaponInventory: { "machine-gun": 1, "missile": 2 },
     };
-    mockStorage["raptor_save"] = JSON.stringify(v1Save);
+    mockStorage["raptor_save_0"] = JSON.stringify(v1Save);
 
-    const loaded = SaveSystem.load();
+    const loaded = SaveSystem.load(0);
     expect(loaded).not.toBeNull();
     expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
     expect(loaded!.bombs).toBe(2);
@@ -852,9 +858,9 @@ describe("Scenario: v1 saves with and without optional fields migrate correctly"
       weapon: "machine-gun",
       savedAt: "2026-03-10T12:00:00.000Z",
     };
-    mockStorage["raptor_save"] = JSON.stringify(v1Save);
+    mockStorage["raptor_save_0"] = JSON.stringify(v1Save);
 
-    const loaded = SaveSystem.load();
+    const loaded = SaveSystem.load(0);
     expect(loaded).not.toBeNull();
     expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
     expect(loaded!.bombs).toBeUndefined();
@@ -863,5 +869,318 @@ describe("Scenario: v1 saves with and without optional fields migrate correctly"
     expect(loaded!.energy).toBeUndefined();
     expect(loaded!.weaponTier).toBeUndefined();
     expect(loaded!.weaponInventory).toBeUndefined();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// MULTIPLE SAVE SLOTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: MAX_SAVE_SLOTS is exported and set to 3", () => {
+  test("MAX_SAVE_SLOTS equals 3", () => {
+    expect(MAX_SAVE_SLOTS).toBe(3);
+  });
+});
+
+describe("Scenario: Saving to a slot stores data independently", () => {
+  test("slots store and retrieve data independently", () => {
+    SaveSystem.save(validSaveData({ levelReached: 3, totalScore: 500 }), 0);
+    SaveSystem.save(validSaveData({ levelReached: 1, totalScore: 100 }), 1);
+
+    const slot0 = SaveSystem.load(0);
+    const slot1 = SaveSystem.load(1);
+    const slot2 = SaveSystem.load(2);
+
+    expect(slot0!.levelReached).toBe(3);
+    expect(slot0!.totalScore).toBe(500);
+    expect(slot1!.levelReached).toBe(1);
+    expect(slot1!.totalScore).toBe(100);
+    expect(slot2).toBeNull();
+  });
+});
+
+describe("Scenario: Each slot uses its own localStorage key", () => {
+  test("saving to slot 0 only writes raptor_save_0", () => {
+    SaveSystem.save(validSaveData(), 0);
+    expect(mockStorage["raptor_save_0"]).toBeDefined();
+    expect(mockStorage["raptor_save_1"]).toBeUndefined();
+    expect(mockStorage["raptor_save_2"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: Saving to slot 1 does not affect slot 0", () => {
+  test("slot 0 is unaffected by writing slot 1", () => {
+    SaveSystem.save(validSaveData({ totalScore: 500 }), 0);
+    SaveSystem.save(validSaveData({ totalScore: 999 }), 1);
+    expect(SaveSystem.load(0)!.totalScore).toBe(500);
+  });
+});
+
+describe("Scenario: Saving stamps the slotIndex field on the data", () => {
+  test("slotIndex matches the slot parameter", () => {
+    SaveSystem.save(validSaveData(), 2);
+    expect(SaveSystem.load(2)!.slotIndex).toBe(2);
+  });
+});
+
+describe("Scenario: hasSave checks only the specified slot", () => {
+  test("hasSave is slot-specific", () => {
+    SaveSystem.save(validSaveData(), 0);
+    expect(SaveSystem.hasSave(0)).toBe(true);
+    expect(SaveSystem.hasSave(1)).toBe(false);
+    expect(SaveSystem.hasSave(2)).toBe(false);
+  });
+});
+
+describe("Scenario: Clearing one slot does not affect others", () => {
+  test("clearing slot 1 preserves slots 0 and 2", () => {
+    SaveSystem.save(validSaveData(), 0);
+    SaveSystem.save(validSaveData(), 1);
+    SaveSystem.save(validSaveData(), 2);
+
+    SaveSystem.clear(1);
+
+    expect(SaveSystem.hasSave(0)).toBe(true);
+    expect(SaveSystem.hasSave(1)).toBe(false);
+    expect(SaveSystem.hasSave(2)).toBe(true);
+  });
+});
+
+describe("Scenario: Loading a cleared slot returns null", () => {
+  test("load returns null after clearing", () => {
+    SaveSystem.save(validSaveData(), 0);
+    SaveSystem.clear(0);
+    expect(SaveSystem.load(0)).toBeNull();
+  });
+});
+
+describe("Scenario: listSlots returns metadata for all slots", () => {
+  test("listSlots reflects populated and empty slots", () => {
+    SaveSystem.save(validSaveData({ levelReached: 3 }), 0);
+    SaveSystem.save(validSaveData({ levelReached: 7 }), 2);
+
+    const result = SaveSystem.listSlots();
+    expect(result).toHaveLength(3);
+    expect(result[0]!.levelReached).toBe(3);
+    expect(result[1]).toBeNull();
+    expect(result[2]!.levelReached).toBe(7);
+  });
+
+  test("listSlots returns all nulls when no saves exist", () => {
+    expect(SaveSystem.listSlots()).toEqual([null, null, null]);
+  });
+});
+
+describe("Scenario: Invalid slot index is rejected gracefully", () => {
+  test("save to slot -1 is a no-op", () => {
+    SaveSystem.save(validSaveData(), -1);
+    expect(Object.keys(mockStorage)).toHaveLength(0);
+  });
+
+  test("save to slot 3 is a no-op", () => {
+    SaveSystem.save(validSaveData(), 3);
+    expect(Object.keys(mockStorage)).toHaveLength(0);
+  });
+
+  test("load from slot 1.5 returns null", () => {
+    expect(SaveSystem.load(1.5)).toBeNull();
+  });
+
+  test("hasSave for slot 99 returns false", () => {
+    expect(SaveSystem.hasSave(99)).toBe(false);
+  });
+
+  test("clear for invalid slot is a no-op", () => {
+    SaveSystem.save(validSaveData(), 0);
+    SaveSystem.clear(-1);
+    expect(SaveSystem.hasSave(0)).toBe(true);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// LEGACY MIGRATION
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Existing single-key save is migrated to slot 0", () => {
+  test("legacy raptor_save is migrated to raptor_save_0 and removed", () => {
+    mockStorage["raptor_save"] = JSON.stringify(validSaveData());
+
+    expect(SaveSystem.hasSave(0)).toBe(true);
+    expect(mockStorage["raptor_save_0"]).toBeDefined();
+    expect(mockStorage["raptor_save"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: Legacy migration does not overwrite existing slot 0", () => {
+  test("slot 0 data takes precedence over legacy key", () => {
+    mockStorage["raptor_save"] = JSON.stringify(validSaveData({ levelReached: 1 }));
+    mockStorage["raptor_save_0"] = JSON.stringify(validSaveData({ levelReached: 5 }));
+
+    const loaded = SaveSystem.load(0);
+    expect(loaded!.levelReached).toBe(5);
+    expect(mockStorage["raptor_save"]).toBeDefined();
+  });
+});
+
+describe("Scenario: Legacy migration runs only once per session", () => {
+  test("migration logic executes only on the first call", () => {
+    mockStorage["raptor_save"] = JSON.stringify(validSaveData());
+
+    SaveSystem.hasSave(0);
+    const getItemCalls1 = (localStorage.getItem as jest.Mock).mock.calls.length;
+
+    SaveSystem.hasSave(0);
+    const getItemCalls2 = (localStorage.getItem as jest.Mock).mock.calls.length;
+
+    // Second call should not re-read the legacy key for migration
+    const legacyReads1 = (localStorage.getItem as jest.Mock).mock.calls
+      .slice(0, getItemCalls1)
+      .filter((c: string[]) => c[0] === "raptor_save").length;
+    const legacyReads2 = (localStorage.getItem as jest.Mock).mock.calls
+      .slice(getItemCalls1)
+      .filter((c: string[]) => c[0] === "raptor_save").length;
+
+    expect(legacyReads1).toBeGreaterThan(0);
+    expect(legacyReads2).toBe(0);
+  });
+});
+
+describe("Scenario: Legacy migration with corrupt data copies verbatim and load rejects it", () => {
+  test("corrupt legacy data is migrated but load returns null", () => {
+    mockStorage["raptor_save"] = "not-valid-json{{{";
+
+    expect(() => SaveSystem.load(0)).not.toThrow();
+    expect(SaveSystem.load(0)).toBeNull();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// RAPTORGAME ACTIVE SLOT TRACKING
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: RaptorGame defaults to active slot 0", () => {
+  test("activeSlot is 0 by default", () => {
+    const { game } = createPlayingGame();
+    expect(game.saveSlot).toBe(0);
+  });
+});
+
+describe("Scenario: RaptorGame passes activeSlot to SaveSystem on level complete", () => {
+  test("SaveSystem.save is called with the active slot", () => {
+    const { game } = createPlayingGame();
+    game.saveSlot = 1;
+    game.currentLevel = 1;
+    game.totalScore = 200;
+    game.score = 100;
+    game.player.lives = 2;
+    game.spawner.configure(LEVELS[1]);
+
+    for (let t = 0; t < 100; t += 0.1) {
+      game.spawner.update(0.1, 800);
+    }
+    game.enemies = [];
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("level_complete");
+    expect(SaveSystem.hasSave(1)).toBe(true);
+    expect(SaveSystem.hasSave(0)).toBe(false);
+  });
+});
+
+describe("Scenario: RaptorGame passes activeSlot to SaveSystem.load on continue", () => {
+  test("continueGame loads from the active slot", () => {
+    const { game } = createPlayingGame();
+    SaveSystem.save(validSaveData({ levelReached: 5, totalScore: 999 }), 2);
+    game.saveSlot = 2;
+
+    (game as any).continueGame();
+
+    expect(game.currentLevel).toBe(5);
+    expect(game.totalScore).toBe(999);
+  });
+});
+
+describe("Scenario: RaptorGame passes activeSlot to SaveSystem.clear on New Game", () => {
+  test("new game clears the active slot", () => {
+    const { game } = createPlayingGame();
+    SaveSystem.save(validSaveData(), 1);
+    game.saveSlot = 1;
+    game.state = "menu";
+
+    SaveSystem.clear(game.saveSlot);
+    (game as any).resetGame();
+
+    expect(SaveSystem.hasSave(1)).toBe(false);
+  });
+});
+
+describe("Scenario: RaptorGame passes activeSlot to SaveSystem.hasSave in hasSaveData getter", () => {
+  test("hasSaveData checks the active slot", () => {
+    const { game } = createPlayingGame();
+    SaveSystem.save(validSaveData(), 1);
+
+    game.saveSlot = 0;
+    expect(game.hasSaveData).toBe(false);
+
+    game.saveSlot = 1;
+    expect(game.hasSaveData).toBe(true);
+  });
+});
+
+describe("Scenario: RaptorGame saveSlot setter validates input", () => {
+  test("invalid slot values are ignored", () => {
+    const { game } = createPlayingGame();
+    game.saveSlot = -1;
+    expect(game.saveSlot).toBe(0);
+
+    game.saveSlot = 3;
+    expect(game.saveSlot).toBe(0);
+
+    game.saveSlot = 1.5;
+    expect(game.saveSlot).toBe(0);
+
+    game.saveSlot = 2;
+    expect(game.saveSlot).toBe(2);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// FULL ROUND-TRIP INDEPENDENCE
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Full round-trip independence across all three slots", () => {
+  test("three slots store and retrieve independent data", () => {
+    SaveSystem.save(validSaveData({ levelReached: 2, lives: 3, weapon: "machine-gun" }), 0);
+    SaveSystem.save(validSaveData({ levelReached: 5, lives: 1, weapon: "laser" }), 1);
+    SaveSystem.save(validSaveData({ levelReached: 8, lives: 2, weapon: "missile" }), 2);
+
+    const s0 = SaveSystem.load(0)!;
+    const s1 = SaveSystem.load(1)!;
+    const s2 = SaveSystem.load(2)!;
+
+    expect(s0.levelReached).toBe(2);
+    expect(s0.lives).toBe(3);
+    expect(s0.weapon).toBe("machine-gun");
+
+    expect(s1.levelReached).toBe(5);
+    expect(s1.lives).toBe(1);
+    expect(s1.weapon).toBe("laser");
+
+    expect(s2.levelReached).toBe(8);
+    expect(s2.lives).toBe(2);
+    expect(s2.weapon).toBe("missile");
+  });
+});
+
+describe("Scenario: Overwriting a slot replaces only that slot's data", () => {
+  test("overwriting slot 1 does not affect other slots", () => {
+    SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    SaveSystem.save(validSaveData({ totalScore: 100 }), 1);
+
+    SaveSystem.save(validSaveData({ totalScore: 999 }), 1);
+
+    expect(SaveSystem.load(1)!.totalScore).toBe(999);
+    expect(SaveSystem.load(0)!.totalScore).toBe(100);
   });
 });


### PR DESCRIPTION
## PR: Support multiple save slots in `SaveSystem` (Issue #663, epic #607)

### Summary (what changed + why)
This PR refactors the Raptor `SaveSystem` from a single-save model (`localStorage` key `raptor_save`) to a slot-based model supporting **up to 3 independent save slots**. Each slot is stored under its own key (`raptor_save_0`, `raptor_save_1`, `raptor_save_2`) so players can keep separate playthroughs (e.g., replay earlier levels or share the game without overwriting progress).

Key behavior changes:
- `SaveSystem` public APIs now require a `slot: number` parameter (`save/load/clear/hasSave`) to keep the system stateless and push slot selection to the caller.
- `RaptorGame` now tracks a single `activeSlot` (default `0`) and threads it through all save-related call sites.
- A **one-time legacy migration** moves existing `raptor_save` data into slot `0` (without overwriting an existing slot 0 save).
- Added `listSlots()` to enumerate save metadata across all slots.
- Added `slotIndex?: number` to `RaptorSaveData` (stamped on save) as self-describing metadata (no save format version bump since it’s additive/optional).

### Key files modified
- **`src/games/raptor/types.ts`**
  - Added `MAX_SAVE_SLOTS = 3`
  - Extended `RaptorSaveData` with optional `slotIndex?: number`

- **`src/games/raptor/systems/SaveSystem.ts`**
  - Replaced single `STORAGE_KEY` with `storageKey(slot)` + `LEGACY_STORAGE_KEY`
  - Added slot validation (invalid slots fail safely: no-op / `null` / `false`)
  - Updated signatures:
    - `save(data, slot)`
    - `load(slot)`
    - `clear(slot)`
    - `hasSave(slot)`
  - Added `listSlots(): (RaptorSaveData | null)[]`
  - Added one-time legacy migration from `raptor_save` → `raptor_save_0`

- **`src/games/raptor/RaptorGame.ts`**
  - Added `private activeSlot = 0`
  - Added `saveSlot` getter/setter (for future UI integration)
  - Updated all existing SaveSystem call sites to pass `this.activeSlot` (save/load/clear/hasSave)

### Testing notes
- Added/updated tests covering:
  - Slot independence (saving/loading across slots 0–2)
  - Key correctness (`raptor_save_0..2`)
  - `hasSave()` / `clear()` scoped to the specified slot
  - `listSlots()` contract (length 3, nulls for empty slots)
  - Invalid slot handling (graceful no-op / null / false, no throws)
  - Legacy migration behavior:
    - Migrates `raptor_save` → slot 0 when slot 0 is empty
    - Does not overwrite existing slot 0
    - Runs once per session and is safe with corrupt legacy data
  - Safe behavior when `localStorage` is unavailable

Manual verification suggestions:
- Start from an environment with an existing `raptor_save` key and confirm it is migrated to `raptor_save_0` on first `load/hasSave/listSlots`.
- Create saves in slots 0/1/2 and verify clearing one slot does not affect others.

--- 

Closes: #663

Ref: https://github.com/asgardtech/archer/issues/663