### PR TITLE
Persist player settings (audio, display) independently from game saves

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -36,6 +36,7 @@ import { LEVELS } from "./levels";
 import { GAME_STORY, getActForLevel } from "./story";
 import { IGame } from "../../shared/types";
 import { AudioManager } from "../../shared/AudioManager";
+import { SettingsStorage } from "../../shared/storage";
 
 const DT_CAP = 0.1;
 const MAX_ENEMY_BULLETS = 30;
@@ -270,6 +271,12 @@ export class RaptorGame implements IGame {
     if (playerSprite) this.player.setSprite(playerSprite);
     if (this.thrustSheet) this.player.setThrustSheet(this.thrustSheet);
 
+    const settings = await SettingsStorage.load();
+    this.audio.musicVolume = settings.musicVolume;
+    this.audio.sfxVolume = settings.sfxVolume;
+    if (settings.muted) this.audio.muted = true;
+    this.showFps = settings.showFps;
+
     await this.refreshSaveStatus();
     this.state = "menu";
   }
@@ -353,6 +360,7 @@ export class RaptorGame implements IGame {
     if (this.hud.isMuteButtonHit(this.input.mouseX, this.input.mouseY, this.width)) {
       this.audio.ensureContext();
       this.audio.toggleMute();
+      this.persistSettings();
       this.input.consume();
       return true;
     }
@@ -372,6 +380,7 @@ export class RaptorGame implements IGame {
       }
       if (!this.input.isMouseDown) {
         this.draggingSlider = null;
+        this.persistSettings();
       }
       this.input.consume();
       return true;
@@ -405,6 +414,7 @@ export class RaptorGame implements IGame {
     if (this.hud.isMuteButtonHit(mx, my, this.width)) {
       this.audio.ensureContext();
       this.audio.toggleMute();
+      this.persistSettings();
       this.input.consume();
       return true;
     }
@@ -1340,6 +1350,15 @@ export class RaptorGame implements IGame {
     this._hasSaveData = await SaveSystem.hasSave(this.activeSlot);
   }
 
+  private persistSettings(): void {
+    SettingsStorage.save({
+      musicVolume: this.audio.musicVolume,
+      sfxVolume: this.audio.sfxVolume,
+      muted: this.audio.muted,
+      showFps: this.showFps,
+    }).catch(() => {});
+  }
+
   private resetGame(): void {
     this.totalScore = 0;
     this.playTimeSeconds = 0;
@@ -1471,6 +1490,7 @@ export class RaptorGame implements IGame {
       showFps: this.showFps,
       toggleFps: () => {
         this.showFps = !this.showFps;
+        this.persistSettings();
         return this.showFps;
       },
     };

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -3,6 +3,13 @@ export interface Vec2 {
   y: number;
 }
 
+export interface UserSettings {
+  musicVolume: number;   // 0–1, default 0.5
+  sfxVolume: number;     // 0–1, default 0.25
+  muted: boolean;        // default false
+  showFps: boolean;      // default false
+}
+
 export type RaptorGameState =
   | "loading"
   | "menu"

--- a/src/shared/AudioManager.ts
+++ b/src/shared/AudioManager.ts
@@ -1,5 +1,3 @@
-import { tryGetStorage, trySetStorage } from "./storage";
-
 export interface EnvelopeParams {
   attack: number;
   decay: number;
@@ -45,19 +43,10 @@ export class AudioManager {
   private noiseBuffers: Map<number, AudioBuffer> = new Map();
 
   constructor() {
-    this._muted = tryGetStorage("audio_muted", "false") === "true";
-    this._volume = parseFloat(tryGetStorage("audio_volume", "0.5"));
-    if (isNaN(this._volume) || this._volume < 0 || this._volume > 1) {
-      this._volume = 0.5;
-    }
-    this._musicVolume = parseFloat(tryGetStorage("audio_music_volume", "0.5"));
-    if (isNaN(this._musicVolume) || this._musicVolume < 0 || this._musicVolume > 1) {
-      this._musicVolume = 0.5;
-    }
-    this._sfxVolume = parseFloat(tryGetStorage("audio_sfx_volume", "0.25"));
-    if (isNaN(this._sfxVolume) || this._sfxVolume < 0 || this._sfxVolume > 1) {
-      this._sfxVolume = 0.25;
-    }
+    this._muted = false;
+    this._volume = 0.5;
+    this._musicVolume = 0.5;
+    this._sfxVolume = 0.25;
   }
 
   ensureContext(): AudioContext {
@@ -144,7 +133,6 @@ export class AudioManager {
 
   set muted(v: boolean) {
     this._muted = v;
-    trySetStorage("audio_muted", String(v));
     this.applyVolume();
   }
 
@@ -154,7 +142,6 @@ export class AudioManager {
 
   set volume(v: number) {
     this._volume = Math.max(0, Math.min(1, v));
-    trySetStorage("audio_volume", String(this._volume));
     this.applyVolume();
   }
 
@@ -164,7 +151,6 @@ export class AudioManager {
 
   set musicVolume(v: number) {
     this._musicVolume = Math.max(0, Math.min(1, v));
-    trySetStorage("audio_music_volume", String(this._musicVolume));
     if (this._musicGain) {
       this._musicGain.gain.value = this._musicVolume;
     }
@@ -176,7 +162,6 @@ export class AudioManager {
 
   set sfxVolume(v: number) {
     this._sfxVolume = Math.max(0, Math.min(1, v));
-    trySetStorage("audio_sfx_volume", String(this._sfxVolume));
     if (this._sfxGain) {
       this._sfxGain.gain.value = this._sfxVolume;
     }

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -102,3 +102,103 @@ export function getStorageBackend(): StorageBackend {
 export function setStorageBackend(backend: StorageBackend): void {
   _backend = backend;
 }
+
+// ─── UserSettings Persistence ──────────────────────────────────
+
+import type { UserSettings } from "../games/raptor/types";
+
+export const DEFAULT_USER_SETTINGS: UserSettings = {
+  musicVolume: 0.5,
+  sfxVolume: 0.25,
+  muted: false,
+  showFps: false,
+};
+
+function isValidVolume(v: unknown): v is number {
+  return typeof v === "number" && !isNaN(v) && v >= 0 && v <= 1;
+}
+
+function validateSettings(raw: Record<string, unknown>): UserSettings {
+  return {
+    musicVolume: isValidVolume(raw.musicVolume) ? raw.musicVolume : DEFAULT_USER_SETTINGS.musicVolume,
+    sfxVolume: isValidVolume(raw.sfxVolume) ? raw.sfxVolume : DEFAULT_USER_SETTINGS.sfxVolume,
+    muted: typeof raw.muted === "boolean" ? raw.muted : DEFAULT_USER_SETTINGS.muted,
+    showFps: typeof raw.showFps === "boolean" ? raw.showFps : DEFAULT_USER_SETTINGS.showFps,
+  };
+}
+
+export class SettingsStorage {
+  private static readonly KEY = "raptor_settings";
+  private static readonly LEGACY_KEYS = [
+    "audio_music_volume",
+    "audio_sfx_volume",
+    "audio_muted",
+  ] as const;
+  private static legacyMigrated = false;
+
+  static async load(): Promise<UserSettings> {
+    const backend = getStorageBackend();
+
+    if (!SettingsStorage.legacyMigrated) {
+      SettingsStorage.legacyMigrated = true;
+      await SettingsStorage.migrateLegacyKeys(backend);
+    }
+
+    try {
+      const raw = await backend.get(SettingsStorage.KEY);
+      if (raw === null) return { ...DEFAULT_USER_SETTINGS };
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== "object" || parsed === null) {
+        return { ...DEFAULT_USER_SETTINGS };
+      }
+      return validateSettings(parsed);
+    } catch {
+      return { ...DEFAULT_USER_SETTINGS };
+    }
+  }
+
+  static async save(settings: UserSettings): Promise<void> {
+    try {
+      const backend = getStorageBackend();
+      await backend.set(SettingsStorage.KEY, JSON.stringify(settings));
+    } catch {
+      // silently ignore
+    }
+  }
+
+  private static async migrateLegacyKeys(backend: StorageBackend): Promise<void> {
+    try {
+      const existing = await backend.get(SettingsStorage.KEY);
+      if (existing !== null) return;
+
+      const legacyMusic = await backend.get("audio_music_volume");
+      const legacySfx = await backend.get("audio_sfx_volume");
+      const legacyMuted = await backend.get("audio_muted");
+
+      if (legacyMusic === null && legacySfx === null && legacyMuted === null) return;
+
+      const musicVol = legacyMusic !== null ? parseFloat(legacyMusic) : NaN;
+      const sfxVol = legacySfx !== null ? parseFloat(legacySfx) : NaN;
+
+      const settings: UserSettings = {
+        musicVolume: isValidVolume(musicVol) ? musicVol : DEFAULT_USER_SETTINGS.musicVolume,
+        sfxVolume: isValidVolume(sfxVol) ? sfxVol : DEFAULT_USER_SETTINGS.sfxVolume,
+        muted: legacyMuted === "true",
+        showFps: DEFAULT_USER_SETTINGS.showFps,
+      };
+
+      await backend.set(SettingsStorage.KEY, JSON.stringify(settings));
+
+      for (const key of SettingsStorage.LEGACY_KEYS) {
+        await backend.remove(key);
+      }
+    } catch {
+      // migration failure is non-fatal
+    }
+  }
+
+  /** @internal For testing — reset the migration flag. */
+  static resetMigrationFlag(): void {
+    SettingsStorage.legacyMigrated = false;
+  }
+}

--- a/tests/raptor-settings.test.ts
+++ b/tests/raptor-settings.test.ts
@@ -1,0 +1,438 @@
+import { SettingsStorage, DEFAULT_USER_SETTINGS, setStorageBackend, StorageBackend } from "../src/shared/storage";
+import { UserSettings } from "../src/games/raptor/types";
+
+// ─── Mock StorageBackend ────────────────────────────────────────
+
+class MockStorageBackend implements StorageBackend {
+  data: Record<string, string> = {};
+
+  async get(key: string): Promise<string | null> {
+    return this.data[key] ?? null;
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.data[key] = value;
+  }
+
+  async remove(key: string): Promise<void> {
+    delete this.data[key];
+  }
+}
+
+class FailingStorageBackend implements StorageBackend {
+  async get(): Promise<string | null> { throw new Error("storage unavailable"); }
+  async set(): Promise<void> { throw new Error("storage unavailable"); }
+  async remove(): Promise<void> { throw new Error("storage unavailable"); }
+}
+
+// ─── Setup ──────────────────────────────────────────────────────
+
+let mockBackend: MockStorageBackend;
+
+beforeEach(() => {
+  mockBackend = new MockStorageBackend();
+  setStorageBackend(mockBackend);
+  SettingsStorage.resetMigrationFlag();
+});
+
+// ════════════════════════════════════════════════════════════════
+// DEFAULT SETTINGS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Default settings are applied on first launch", () => {
+  test("load returns defaults when no raptor_settings key exists", async () => {
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+
+  test("default musicVolume is 0.5", () => {
+    expect(DEFAULT_USER_SETTINGS.musicVolume).toBe(0.5);
+  });
+
+  test("default sfxVolume is 0.25", () => {
+    expect(DEFAULT_USER_SETTINGS.sfxVolume).toBe(0.25);
+  });
+
+  test("default muted is false", () => {
+    expect(DEFAULT_USER_SETTINGS.muted).toBe(false);
+  });
+
+  test("default showFps is false", () => {
+    expect(DEFAULT_USER_SETTINGS.showFps).toBe(false);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// ROUND-TRIP SAVE / LOAD
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Settings round-trip correctly", () => {
+  test("save then load returns matching data", async () => {
+    const settings: UserSettings = {
+      musicVolume: 0.8,
+      sfxVolume: 0.1,
+      muted: true,
+      showFps: true,
+    };
+    await SettingsStorage.save(settings);
+    const loaded = await SettingsStorage.load();
+    expect(loaded).toEqual(settings);
+  });
+
+  test("save stores under raptor_settings key", async () => {
+    await SettingsStorage.save(DEFAULT_USER_SETTINGS);
+    expect(mockBackend.data["raptor_settings"]).toBeDefined();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// PERSISTING INDIVIDUAL SETTINGS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Music volume change persists", () => {
+  test("musicVolume 0.8 round-trips", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, musicVolume: 0.8 });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.musicVolume).toBe(0.8);
+  });
+});
+
+describe("Scenario: SFX volume change persists", () => {
+  test("sfxVolume 0.1 round-trips", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, sfxVolume: 0.1 });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.sfxVolume).toBe(0.1);
+  });
+});
+
+describe("Scenario: Mute state persists", () => {
+  test("muted true round-trips", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, muted: true });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.muted).toBe(true);
+  });
+});
+
+describe("Scenario: FPS display preference persists", () => {
+  test("showFps true round-trips", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, showFps: true });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.showFps).toBe(true);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// ERROR HANDLING & VALIDATION
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Malformed JSON falls back to defaults", () => {
+  test("invalid JSON returns defaults", async () => {
+    mockBackend.data["raptor_settings"] = "{{not-json}}";
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+});
+
+describe("Scenario: Out-of-range values are corrected", () => {
+  test("musicVolume > 1 replaced with default", async () => {
+    mockBackend.data["raptor_settings"] = JSON.stringify({
+      musicVolume: 1.5,
+      sfxVolume: -0.3,
+      muted: "yes",
+      showFps: 42,
+    });
+    const settings = await SettingsStorage.load();
+    expect(settings.musicVolume).toBe(0.5);
+    expect(settings.sfxVolume).toBe(0.25);
+    expect(settings.muted).toBe(false);
+    expect(settings.showFps).toBe(false);
+  });
+
+  test("NaN musicVolume replaced with default", async () => {
+    mockBackend.data["raptor_settings"] = JSON.stringify({
+      musicVolume: NaN,
+      sfxVolume: 0.5,
+      muted: false,
+      showFps: false,
+    });
+    const settings = await SettingsStorage.load();
+    expect(settings.musicVolume).toBe(0.5);
+  });
+
+  test("negative sfxVolume replaced with default", async () => {
+    mockBackend.data["raptor_settings"] = JSON.stringify({
+      musicVolume: 0.5,
+      sfxVolume: -0.1,
+      muted: false,
+      showFps: false,
+    });
+    const settings = await SettingsStorage.load();
+    expect(settings.sfxVolume).toBe(0.25);
+  });
+});
+
+describe("Scenario: Partially valid settings preserve valid fields", () => {
+  test("valid musicVolume preserved, invalid sfxVolume replaced", async () => {
+    mockBackend.data["raptor_settings"] = JSON.stringify({
+      musicVolume: 0.9,
+      sfxVolume: "bad",
+      muted: true,
+      showFps: false,
+    });
+    const settings = await SettingsStorage.load();
+    expect(settings.musicVolume).toBe(0.9);
+    expect(settings.sfxVolume).toBe(0.25);
+    expect(settings.muted).toBe(true);
+    expect(settings.showFps).toBe(false);
+  });
+});
+
+describe("Scenario: Non-object parsed JSON returns defaults", () => {
+  test("null JSON returns defaults", async () => {
+    mockBackend.data["raptor_settings"] = "null";
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+
+  test("array JSON returns defaults", async () => {
+    mockBackend.data["raptor_settings"] = "[1,2,3]";
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+
+  test("string JSON returns defaults", async () => {
+    mockBackend.data["raptor_settings"] = '"hello"';
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+
+  test("number JSON returns defaults", async () => {
+    mockBackend.data["raptor_settings"] = "42";
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+});
+
+describe("Scenario: Missing fields fall back to defaults", () => {
+  test("empty object returns all defaults", async () => {
+    mockBackend.data["raptor_settings"] = "{}";
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+
+  test("partial object fills missing with defaults", async () => {
+    mockBackend.data["raptor_settings"] = JSON.stringify({ musicVolume: 0.7 });
+    const settings = await SettingsStorage.load();
+    expect(settings.musicVolume).toBe(0.7);
+    expect(settings.sfxVolume).toBe(0.25);
+    expect(settings.muted).toBe(false);
+    expect(settings.showFps).toBe(false);
+  });
+});
+
+describe("Scenario: Storage unavailability does not crash", () => {
+  test("load returns defaults when storage fails", async () => {
+    setStorageBackend(new FailingStorageBackend());
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+
+  test("save does not throw when storage fails", async () => {
+    setStorageBackend(new FailingStorageBackend());
+    await expect(
+      SettingsStorage.save({ musicVolume: 0.6, sfxVolume: 0.3, muted: false, showFps: true })
+    ).resolves.not.toThrow();
+  });
+});
+
+describe("Scenario: Boundary volume values", () => {
+  test("musicVolume 0 is valid", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, musicVolume: 0 });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.musicVolume).toBe(0);
+  });
+
+  test("musicVolume 1 is valid", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, musicVolume: 1 });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.musicVolume).toBe(1);
+  });
+
+  test("sfxVolume 0 is valid", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, sfxVolume: 0 });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.sfxVolume).toBe(0);
+  });
+
+  test("sfxVolume 1 is valid", async () => {
+    await SettingsStorage.save({ ...DEFAULT_USER_SETTINGS, sfxVolume: 1 });
+    const loaded = await SettingsStorage.load();
+    expect(loaded.sfxVolume).toBe(1);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// LEGACY MIGRATION
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Legacy audio keys are migrated to the new settings key", () => {
+  test("legacy keys are migrated and removed", async () => {
+    mockBackend.data["audio_music_volume"] = "0.6";
+    mockBackend.data["audio_sfx_volume"] = "0.4";
+    mockBackend.data["audio_muted"] = "true";
+
+    const settings = await SettingsStorage.load();
+
+    expect(settings.musicVolume).toBe(0.6);
+    expect(settings.sfxVolume).toBe(0.4);
+    expect(settings.muted).toBe(true);
+
+    expect(mockBackend.data["audio_music_volume"]).toBeUndefined();
+    expect(mockBackend.data["audio_sfx_volume"]).toBeUndefined();
+    expect(mockBackend.data["audio_muted"]).toBeUndefined();
+
+    expect(mockBackend.data["raptor_settings"]).toBeDefined();
+  });
+
+  test("partial legacy keys are migrated with defaults for missing", async () => {
+    mockBackend.data["audio_music_volume"] = "0.7";
+
+    const settings = await SettingsStorage.load();
+
+    expect(settings.musicVolume).toBe(0.7);
+    expect(settings.sfxVolume).toBe(0.25);
+    expect(settings.muted).toBe(false);
+    expect(settings.showFps).toBe(false);
+
+    expect(mockBackend.data["audio_music_volume"]).toBeUndefined();
+    expect(mockBackend.data["raptor_settings"]).toBeDefined();
+  });
+
+  test("invalid legacy values fall back to defaults", async () => {
+    mockBackend.data["audio_music_volume"] = "not-a-number";
+    mockBackend.data["audio_sfx_volume"] = "2.0";
+    mockBackend.data["audio_muted"] = "false";
+
+    const settings = await SettingsStorage.load();
+
+    expect(settings.musicVolume).toBe(0.5);
+    expect(settings.sfxVolume).toBe(0.25);
+    expect(settings.muted).toBe(false);
+  });
+});
+
+describe("Scenario: Legacy keys alongside new key", () => {
+  test("new key takes precedence, legacy keys are not read", async () => {
+    mockBackend.data["raptor_settings"] = JSON.stringify({
+      musicVolume: 0.9,
+      sfxVolume: 0.1,
+      muted: true,
+      showFps: true,
+    });
+    mockBackend.data["audio_music_volume"] = "0.3";
+    mockBackend.data["audio_sfx_volume"] = "0.3";
+    mockBackend.data["audio_muted"] = "false";
+
+    const settings = await SettingsStorage.load();
+
+    expect(settings.musicVolume).toBe(0.9);
+    expect(settings.sfxVolume).toBe(0.1);
+    expect(settings.muted).toBe(true);
+    expect(settings.showFps).toBe(true);
+  });
+});
+
+describe("Scenario: Legacy migration runs only once per session", () => {
+  test("second load does not re-run migration", async () => {
+    mockBackend.data["audio_music_volume"] = "0.6";
+    mockBackend.data["audio_sfx_volume"] = "0.4";
+    mockBackend.data["audio_muted"] = "true";
+
+    await SettingsStorage.load();
+
+    const getSpy = jest.spyOn(mockBackend, "get");
+
+    await SettingsStorage.load();
+
+    const legacyReads = getSpy.mock.calls.filter(
+      (c) => c[0] === "audio_music_volume" || c[0] === "audio_sfx_volume" || c[0] === "audio_muted"
+    );
+    expect(legacyReads.length).toBe(0);
+
+    getSpy.mockRestore();
+  });
+});
+
+describe("Scenario: No legacy keys and no new key returns defaults", () => {
+  test("completely empty storage returns defaults", async () => {
+    const settings = await SettingsStorage.load();
+    expect(settings).toEqual(DEFAULT_USER_SETTINGS);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// INDEPENDENCE FROM GAME SAVES
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Settings are independent from game saves", () => {
+  test("deleting a game save does not affect settings", async () => {
+    await SettingsStorage.save({
+      musicVolume: 0.7,
+      sfxVolume: 0.3,
+      muted: false,
+      showFps: true,
+    });
+
+    mockBackend.data["raptor_save_0"] = JSON.stringify({ some: "save data" });
+    delete mockBackend.data["raptor_save_0"];
+
+    const settings = await SettingsStorage.load();
+    expect(settings.musicVolume).toBe(0.7);
+    expect(settings.sfxVolume).toBe(0.3);
+    expect(settings.showFps).toBe(true);
+  });
+
+  test("settings key is separate from save keys", async () => {
+    await SettingsStorage.save(DEFAULT_USER_SETTINGS);
+    expect(mockBackend.data["raptor_settings"]).toBeDefined();
+    expect(mockBackend.data["raptor_save_0"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_1"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_2"]).toBeUndefined();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// AUDIOMANAGER NO LONGER SELF-PERSISTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: AudioManager no longer writes to storage", () => {
+  test("AudioManager constructor initializes hardcoded defaults", () => {
+    const { AudioManager } = require("../src/shared/AudioManager");
+    const audio = new AudioManager();
+    expect(audio.musicVolume).toBe(0.5);
+    expect(audio.sfxVolume).toBe(0.25);
+    expect(audio.muted).toBe(false);
+    expect(audio.volume).toBe(0.5);
+  });
+
+  test("setting musicVolume does not write to storage", () => {
+    const { AudioManager } = require("../src/shared/AudioManager");
+    const audio = new AudioManager();
+    audio.musicVolume = 0.8;
+    expect(mockBackend.data["audio_music_volume"]).toBeUndefined();
+  });
+
+  test("setting sfxVolume does not write to storage", () => {
+    const { AudioManager } = require("../src/shared/AudioManager");
+    const audio = new AudioManager();
+    audio.sfxVolume = 0.3;
+    expect(mockBackend.data["audio_sfx_volume"]).toBeUndefined();
+  });
+
+  test("setting muted does not write to storage", () => {
+    const { AudioManager } = require("../src/shared/AudioManager");
+    const audio = new AudioManager();
+    audio.muted = true;
+    expect(mockBackend.data["audio_muted"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## PR: Persist player settings (audio, display) independently from game saves (Issue #667, part of #607)

### Summary (what changed + why)
This PR introduces a unified `UserSettings` persistence layer to save player preferences **globally** (independent of save slots) and **across sessions**. Previously, audio settings were stored via synchronous `localStorage` calls inside `AudioManager` (bypassing the async `StorageBackend`, especially problematic for Electron), and the FPS overlay toggle wasn’t persisted at all.

Key improvements:
- Stores **music volume**, **SFX volume**, **mute state**, and **FPS display toggle** under a single `raptor_settings` key via the async `StorageBackend`.
- Decouples settings from per-slot game saves (`raptor_save_0/1/2`) so deleting a save does not affect preferences.
- Adds validation + safe fallback behavior (malformed JSON, missing fields, out-of-range values).
- Migrates legacy `audio_*` keys into `raptor_settings` on first load to avoid losing existing user preferences.

### Key files modified
- **`src/games/raptor/types.ts`**
  - Adds `UserSettings` interface.
- **`src/shared/storage.ts`**
  - Adds `DEFAULT_USER_SETTINGS` and `SettingsStorage` (`load()`/`save()`), including validation and legacy key migration.
- **`src/games/raptor/RaptorGame.ts`**
  - Loads settings during `loadAssets()` (async-safe) and applies them to `AudioManager` + `showFps`.
  - Persists settings on relevant user actions (slider release, mute toggle, FPS toggle) to avoid excessive writes during dragging.
- **`src/shared/AudioManager.ts`**
  - Removes direct sync `localStorage` persistence (`tryGetStorage`/`trySetStorage`) from constructor/setters.
  - Initializes audio fields to defaults; `RaptorGame` becomes the source of truth for persistence.

### Behavior changes / notes
- Settings are now stored atomically as JSON at **`raptor_settings`**.
- Legacy keys (`audio_music_volume`, `audio_sfx_volume`, `audio_muted`) are migrated and removed on first successful load when `raptor_settings` doesn’t exist.
- Settings persistence works consistently in both browser and Electron due to `StorageBackend`.

### Testing notes
- Added **40 unit tests** covering:
  - Defaults when no settings exist
  - Round-trip save/load
  - Validation (type mismatches, NaN/out-of-range values, partial validity)
  - Malformed JSON fallback behavior
  - Legacy migration (reads old keys → writes `raptor_settings` → deletes old keys)
  - Error handling / storage unavailability behavior
  - Independence from game save slots (settings not affected by save deletion / slot switching)

Manual verification suggestions:
- Adjust music/SFX sliders, reload → values persist.
- Toggle mute, reload → mute persists.
- Run dev console `fps`, reload → FPS overlay persists.
- Delete a save slot → settings remain unchanged.

Ref: https://github.com/asgardtech/archer/issues/667