### PR TITLE
Add save data integrity checks with checksums and backup saves

### DIFF
--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -23,8 +23,46 @@ export class SaveSystem {
     return `raptor_save_${slot}`;
   }
 
+  private static backupKey(slot: number): string {
+    return `${this.storageKey(slot)}_backup`;
+  }
+
   private static isValidSlot(slot: number): boolean {
     return Number.isInteger(slot) && slot >= 0 && slot < MAX_SAVE_SLOTS;
+  }
+
+  private static fnv1aHash(input: string): string {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+      hash ^= input.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+  }
+
+  private static computeChecksum(data: Record<string, unknown>): string {
+    const copy = { ...data };
+    delete copy.checksum;
+    return this.fnv1aHash(JSON.stringify(copy));
+  }
+
+  private static verifyAndLoad(raw: string): Record<string, unknown> | null {
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== "object" || parsed === null) return null;
+
+      const storedChecksum = parsed.checksum;
+      if (storedChecksum !== undefined) {
+        const copy = { ...parsed };
+        delete copy.checksum;
+        const computed = this.fnv1aHash(JSON.stringify(copy));
+        if (computed !== storedChecksum) return null;
+      }
+
+      return parsed;
+    } catch {
+      return null;
+    }
   }
 
   private static async runLegacyMigration(): Promise<void> {
@@ -46,7 +84,24 @@ export class SaveSystem {
     if (!this.isValidSlot(slot)) return;
     data.slotIndex = slot;
     const backend = getStorageBackend();
-    await backend.set(this.storageKey(slot), JSON.stringify(data));
+
+    const existing = await backend.get(this.storageKey(slot));
+
+    delete data.checksum;
+    const payload = JSON.stringify(data);
+    const checksum = this.fnv1aHash(payload);
+    data.checksum = checksum;
+    const finalPayload = JSON.stringify(data);
+
+    if (existing) {
+      try {
+        await backend.set(this.backupKey(slot), existing);
+      } catch {
+        console.warn(`Save slot ${slot}: failed to write backup, continuing with save`);
+      }
+    }
+
+    await backend.set(this.storageKey(slot), finalPayload);
   }
 
   static async autoSave(slot: number, data: RaptorSaveData): Promise<void> {
@@ -63,7 +118,12 @@ export class SaveSystem {
     if (!raw) return null;
 
     try {
-      const parsed = JSON.parse(raw);
+      const parsed = this.verifyAndLoad(raw);
+      if (!parsed) {
+        console.warn(`Save slot ${slot}: checksum mismatch, attempting backup recovery`);
+        return this.tryLoadBackup(slot);
+      }
+
       const migrated = this.runMigrations(parsed);
       if (!migrated) return null;
       if (!this.validate(migrated)) return null;
@@ -73,10 +133,37 @@ export class SaveSystem {
     }
   }
 
+  private static async tryLoadBackup(slot: number): Promise<RaptorSaveData | null> {
+    const backend = getStorageBackend();
+    const backupRaw = await backend.get(this.backupKey(slot));
+    if (!backupRaw) return null;
+
+    try {
+      const backupParsed = this.verifyAndLoad(backupRaw);
+      if (!backupParsed) {
+        console.warn(`Save slot ${slot}: backup also corrupted, save unrecoverable`);
+        return null;
+      }
+
+      const migrated = this.runMigrations(backupParsed);
+      if (!migrated || !this.validate(migrated)) {
+        console.warn(`Save slot ${slot}: backup also corrupted, save unrecoverable`);
+        return null;
+      }
+
+      console.warn(`Save slot ${slot}: recovered from backup`);
+      return migrated as RaptorSaveData;
+    } catch {
+      console.warn(`Save slot ${slot}: backup also corrupted, save unrecoverable`);
+      return null;
+    }
+  }
+
   static async clear(slot: number): Promise<void> {
     if (!this.isValidSlot(slot)) return;
     const backend = getStorageBackend();
     await backend.remove(this.storageKey(slot));
+    await backend.remove(this.backupKey(slot));
   }
 
   static async hasSave(slot: number): Promise<boolean> {
@@ -88,12 +175,44 @@ export class SaveSystem {
     if (!raw) return false;
 
     try {
-      const parsed = JSON.parse(raw);
+      const parsed = this.verifyAndLoad(raw);
+      if (!parsed) {
+        const backupRaw = await backend.get(this.backupKey(slot));
+        if (!backupRaw) return false;
+
+        const backupParsed = this.verifyAndLoad(backupRaw);
+        if (!backupParsed) return false;
+
+        const backupMigrated = this.runMigrations(backupParsed);
+        if (!backupMigrated) return false;
+        return this.validate(backupMigrated);
+      }
+
       const migrated = this.runMigrations(parsed);
       if (!migrated) return false;
       return this.validate(migrated);
     } catch {
       return false;
+    }
+  }
+
+  static async restoreFromBackup(slot: number): Promise<RaptorSaveData | null> {
+    if (!this.isValidSlot(slot)) return null;
+
+    const backend = getStorageBackend();
+    const backupRaw = await backend.get(this.backupKey(slot));
+    if (!backupRaw) return null;
+
+    try {
+      const parsed = this.verifyAndLoad(backupRaw);
+      if (!parsed) return null;
+
+      const migrated = this.runMigrations(parsed);
+      if (!migrated || !this.validate(migrated)) return null;
+
+      return migrated as RaptorSaveData;
+    } catch {
+      return null;
     }
   }
 

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -213,6 +213,8 @@ export interface RaptorSaveData {
   waveIndex?: number;
   /** Cumulative play time in seconds across all sessions. */
   playTimeSeconds?: number;
+  /** FNV-1a hash of the serialized save payload (excluding this field). Optional for backward compat with pre-checksum saves. */
+  checksum?: string;
 }
 
 export interface WeaponTierConfig {

--- a/tests/raptor-save.test.ts
+++ b/tests/raptor-save.test.ts
@@ -439,6 +439,7 @@ describe("Scenario: Save data is cleared on victory", () => {
     (game as any).updatePlaying(0.001);
 
     expect(game.state).toBe("victory");
+    await new Promise(r => setTimeout(r, 0));
     expect(await SaveSystem.hasSave(0)).toBe(false);
   });
 });
@@ -1460,6 +1461,7 @@ describe("Scenario: Between-wave checkpoint auto-save", () => {
     const { game } = createPlayingGame();
     game.currentLevel = 0;
     (game as any).startLevel(0);
+    await new Promise(r => setTimeout(r, 0));
     await SaveSystem.clear(0);
 
     (game as any).levelElapsed = 10;
@@ -1622,5 +1624,350 @@ describe("Scenario: Loading an auto-save resumes at the beginning of the saved l
     expect(game.player.lives).toBe(2);
     expect(game.powerUpManager.currentWeapon).toBe("missile");
     expect((game as any).playTimeSeconds).toBe(150);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CHECKSUM & BACKUP SAVE INTEGRITY TESTS
+// ════════════════════════════════════════════════════════════════
+
+function fnv1aHash(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+describe("Scenario: save() stores checksum in saved data", () => {
+  test("saved data contains a checksum field that is an 8-char hex string", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+    const raw = JSON.parse(mockBackend.data["raptor_save_0"]);
+    expect(raw.checksum).toBeDefined();
+    expect(raw.checksum).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  test("checksum matches FNV-1a hash of payload without checksum", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+    const raw = JSON.parse(mockBackend.data["raptor_save_0"]);
+    const storedChecksum = raw.checksum;
+    delete raw.checksum;
+    const expected = fnv1aHash(JSON.stringify(raw));
+    expect(storedChecksum).toBe(expected);
+  });
+});
+
+describe("Scenario: load() accepts valid checksum", () => {
+  test("save then load returns data correctly with checksum", async () => {
+    const data = validSaveData();
+    await SaveSystem.save(data, 0);
+    const loaded = await SaveSystem.load(0);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.levelReached).toBe(data.levelReached);
+    expect(loaded!.totalScore).toBe(data.totalScore);
+    expect(loaded!.weapon).toBe(data.weapon);
+  });
+});
+
+describe("Scenario: load() rejects corrupted data and falls back to backup", () => {
+  test("corrupted primary falls back to backup data", async () => {
+    const dataA = validSaveData({ totalScore: 100 });
+    const dataB = validSaveData({ totalScore: 200 });
+    await SaveSystem.save(dataA, 0);
+    await SaveSystem.save(dataB, 0);
+
+    const parsed = JSON.parse(mockBackend.data["raptor_save_0"]);
+    parsed.checksum = "deadbeef";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(parsed);
+
+    const loaded = await SaveSystem.load(0);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.totalScore).toBe(100);
+  });
+});
+
+describe("Scenario: load() returns null when both primary and backup are corrupted", () => {
+  test("both corrupted returns null", async () => {
+    const dataA = validSaveData({ totalScore: 100 });
+    const dataB = validSaveData({ totalScore: 200 });
+    await SaveSystem.save(dataA, 0);
+    await SaveSystem.save(dataB, 0);
+
+    const primary = JSON.parse(mockBackend.data["raptor_save_0"]);
+    primary.checksum = "deadbeef";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(primary);
+
+    const backup = JSON.parse(mockBackend.data["raptor_save_0_backup"]);
+    backup.checksum = "cafebabe";
+    mockBackend.data["raptor_save_0_backup"] = JSON.stringify(backup);
+
+    expect(await SaveSystem.load(0)).toBeNull();
+  });
+});
+
+describe("Scenario: load() accepts legacy save without checksum", () => {
+  test("legacy save without checksum field loads correctly", async () => {
+    const legacy = {
+      version: SAVE_FORMAT_VERSION,
+      levelReached: 2,
+      totalScore: 500,
+      lives: 2,
+      weapon: "machine-gun",
+      savedAt: "2026-03-10T12:00:00.000Z",
+    };
+    mockBackend.data["raptor_save_0"] = JSON.stringify(legacy);
+
+    const loaded = await SaveSystem.load(0);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.levelReached).toBe(2);
+    expect(loaded!.totalScore).toBe(500);
+  });
+
+  test("v1 save without checksum migrates and loads", async () => {
+    const v1Save = {
+      version: 1,
+      levelReached: 3,
+      totalScore: 1200,
+      lives: 2,
+      weapon: "laser",
+      savedAt: "2026-03-10T12:00:00.000Z",
+    };
+    mockBackend.data["raptor_save_0"] = JSON.stringify(v1Save);
+
+    const loaded = await SaveSystem.load(0);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.version).toBe(SAVE_FORMAT_VERSION);
+    expect(loaded!.levelReached).toBe(3);
+  });
+});
+
+describe("Scenario: load() rejects data with wrong checksum", () => {
+  test("tampered checksum falls back to backup", async () => {
+    const dataA = validSaveData({ totalScore: 100 });
+    const dataB = validSaveData({ totalScore: 200 });
+    await SaveSystem.save(dataA, 0);
+    await SaveSystem.save(dataB, 0);
+
+    const primary = JSON.parse(mockBackend.data["raptor_save_0"]);
+    primary.checksum = "00000000";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(primary);
+
+    const loaded = await SaveSystem.load(0);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.totalScore).toBe(100);
+  });
+
+  test("tampered checksum with no backup returns null", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+
+    const primary = JSON.parse(mockBackend.data["raptor_save_0"]);
+    primary.checksum = "00000000";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(primary);
+
+    expect(await SaveSystem.load(0)).toBeNull();
+  });
+});
+
+describe("Scenario: save() creates backup of previous save", () => {
+  test("second save creates backup containing first save's data", async () => {
+    const dataA = validSaveData({ totalScore: 100 });
+    await SaveSystem.save(dataA, 0);
+    const firstSaveRaw = mockBackend.data["raptor_save_0"];
+
+    const dataB = validSaveData({ totalScore: 200 });
+    await SaveSystem.save(dataB, 0);
+
+    expect(mockBackend.data["raptor_save_0_backup"]).toBe(firstSaveRaw);
+  });
+
+  test("first save does not create a backup", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+    expect(mockBackend.data["raptor_save_0_backup"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: autoSave also creates a backup", () => {
+  test("auto-save creates backup of previous save", async () => {
+    const dataA = validSaveData({ totalScore: 100 });
+    await SaveSystem.save(dataA, 0);
+    const firstSaveRaw = mockBackend.data["raptor_save_0"];
+
+    const dataB = validSaveData({ totalScore: 200 });
+    await SaveSystem.autoSave(0, dataB);
+
+    expect(mockBackend.data["raptor_save_0_backup"]).toBe(firstSaveRaw);
+  });
+});
+
+describe("Scenario: clear() removes both primary and backup", () => {
+  test("clear removes primary and backup keys", async () => {
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    expect(mockBackend.data["raptor_save_0"]).toBeDefined();
+    expect(mockBackend.data["raptor_save_0_backup"]).toBeDefined();
+
+    await SaveSystem.clear(0);
+
+    expect(mockBackend.data["raptor_save_0"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_0_backup"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: restoreFromBackup()", () => {
+  test("returns backup data when backup exists", async () => {
+    const dataA = validSaveData({ totalScore: 100 });
+    await SaveSystem.save(dataA, 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const restored = await SaveSystem.restoreFromBackup(0);
+    expect(restored).not.toBeNull();
+    expect(restored!.totalScore).toBe(100);
+  });
+
+  test("returns null when no backup exists", async () => {
+    expect(await SaveSystem.restoreFromBackup(0)).toBeNull();
+  });
+
+  test("returns null when backup is corrupted", async () => {
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const backup = JSON.parse(mockBackend.data["raptor_save_0_backup"]);
+    backup.checksum = "deadbeef";
+    mockBackend.data["raptor_save_0_backup"] = JSON.stringify(backup);
+
+    expect(await SaveSystem.restoreFromBackup(0)).toBeNull();
+  });
+
+  test("does not overwrite the primary key", async () => {
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const primaryBefore = mockBackend.data["raptor_save_0"];
+    await SaveSystem.restoreFromBackup(0);
+
+    expect(mockBackend.data["raptor_save_0"]).toBe(primaryBefore);
+  });
+});
+
+describe("Scenario: hasSave() with checksum integrity checks", () => {
+  test("returns true with valid checksum", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+    expect(await SaveSystem.hasSave(0)).toBe(true);
+  });
+
+  test("falls back to backup on corrupted primary", async () => {
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const primary = JSON.parse(mockBackend.data["raptor_save_0"]);
+    primary.checksum = "deadbeef";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(primary);
+
+    expect(await SaveSystem.hasSave(0)).toBe(true);
+  });
+
+  test("returns false when both primary and backup are corrupted", async () => {
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const primary = JSON.parse(mockBackend.data["raptor_save_0"]);
+    primary.checksum = "deadbeef";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(primary);
+
+    const backup = JSON.parse(mockBackend.data["raptor_save_0_backup"]);
+    backup.checksum = "cafebabe";
+    mockBackend.data["raptor_save_0_backup"] = JSON.stringify(backup);
+
+    expect(await SaveSystem.hasSave(0)).toBe(false);
+  });
+});
+
+describe("Scenario: Backup write failure does not prevent primary save", () => {
+  test("primary save succeeds even when backup write fails", async () => {
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+
+    const originalSet = mockBackend.set.bind(mockBackend);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(mockBackend, "set").mockImplementation(async (key: string, value: string) => {
+      if (key === "raptor_save_0_backup") {
+        throw new Error("storage full");
+      }
+      return originalSet(key, value);
+    });
+
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const loaded = await SaveSystem.load(0);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.totalScore).toBe(200);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to write backup")
+    );
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe("Scenario: No infinite loop on double corruption", () => {
+  test("returns null in bounded time when both primary and backup are corrupted", async () => {
+    mockBackend.data["raptor_save_0"] = "corrupted{{{not-json";
+    mockBackend.data["raptor_save_0_backup"] = "also-corrupted{{{";
+
+    const start = Date.now();
+    const result = await SaveSystem.load(0);
+    const elapsed = Date.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsed).toBeLessThan(1000);
+  });
+});
+
+describe("Scenario: Checksum warnings are logged appropriately", () => {
+  test("logs warning on checksum mismatch with backup recovery", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const primary = JSON.parse(mockBackend.data["raptor_save_0"]);
+    primary.checksum = "deadbeef";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(primary);
+
+    await SaveSystem.load(0);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("checksum mismatch")
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("recovered from backup")
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test("logs unrecoverable warning when both are corrupted", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
+    await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+
+    const primary = JSON.parse(mockBackend.data["raptor_save_0"]);
+    primary.checksum = "deadbeef";
+    mockBackend.data["raptor_save_0"] = JSON.stringify(primary);
+
+    const backup = JSON.parse(mockBackend.data["raptor_save_0_backup"]);
+    backup.checksum = "cafebabe";
+    mockBackend.data["raptor_save_0_backup"] = JSON.stringify(backup);
+
+    await SaveSystem.load(0);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("backup also corrupted")
+    );
+
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## PR: Add save data integrity checks with checksums and backup saves (Issue #668, part of Epic #607)

### Summary (what changed & why)
This PR hardens the Raptor `SaveSystem` against subtle save corruption that structural validation can’t detect (e.g., partial writes, quota issues, or manual tampering).

It introduces two complementary mechanisms:
- **Checksum verification (FNV-1a 32-bit)**: Each save now stores an 8-character hex checksum computed over the JSON-serialized payload **excluding** the checksum field. On load, the checksum is recomputed and compared to detect corruption.
- **Automatic backup saves**: On every successful `save()`, the previous primary save is copied to a `*_backup` key before overwriting. If the primary save fails checksum verification, the system **automatically falls back** to the backup.

This is **backward compatible**: legacy saves without a `checksum` field still load and validate as before.

### Key behaviors added/updated
- `save()` now:
  - Computes/stores `checksum`
  - Writes prior primary save to `raptor_save_{slot}_backup` (best-effort; backup write failure should not block saving)
- `load()` now:
  - Verifies checksum when present
  - Falls back to backup if primary fails checksum verification
- `hasSave()` now:
  - Reflects whether a **usable** (checksum-valid) save exists, with the same backup fallback behavior as `load()`
- `clear()` now:
  - Removes both primary and backup keys
- New public API:
  - `restoreFromBackup(slot)` to manually load backup data (does not overwrite primary)

### Key files modified
- **`src/games/raptor/types.ts`**
  - Adds optional `checksum?: string` to `RaptorSaveData` for backward compatibility.
- **`src/games/raptor/systems/SaveSystem.ts`**
  - Adds FNV-1a hash implementation and checksum compute/verify logic.
  - Adds backup key helper and backup read/write flow.
  - Adds fallback recovery logic and `restoreFromBackup()` method.
  - Updates `hasSave()` and `clear()` to account for backups/integrity.
- **`tests/raptor-save.test.ts`**
  - Adds extensive coverage for checksum storage/verification, backup creation/recovery, legacy saves without checksum, `hasSave()`, `clear()`, and `restoreFromBackup()`.

### Storage keys
- Primary (existing): `raptor_save_{slot}`
- Backup (new): `raptor_save_{slot}_backup`

### Testing notes
- Added **24 new tests** covering:
  - Checksum creation and format
  - Valid checksum load path
  - Corrupted primary fallback to backup
  - Double corruption returns `null` (bounded, no recursion)
  - Legacy saves without checksum load successfully
  - Backup creation rules (skips on first save)
  - `clear()` removes both keys
  - `restoreFromBackup()` behavior (success/no-backup/corrupted-backup)
  - `hasSave()` integrity-aware behavior and backup fallback
- Run locally:
  - `npm test` (or your repo’s standard test command) — includes updated `tests/raptor-save.test.ts`

### Notes / compatibility
- No new files and **no external dependencies** added.
- Checksum is for **corruption detection**, not security.
- Legacy saves (no checksum) remain loadable; checksum verification is only enforced when the field is present.

Ref: https://github.com/asgardtech/archer/issues/668