### PR TITLE
hitting ESC and continue restarts the level, it should continue the game

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -471,10 +471,7 @@ export class RaptorGame implements IGame {
     if (this.handleUIClicks()) return;
 
     if (this.state === "playing" && this.input.wasEscPressed) {
-      this.weaponSystem.laserBeam.active = false;
-      this.sound.stopMusic();
-      this.state = "menu";
-      this.refreshSaveStatus().catch(console.error);
+      this.state = "paused";
       this.input.consume();
       return;
     }
@@ -598,6 +595,21 @@ export class RaptorGame implements IGame {
 
       case "playing":
         this.updatePlaying(dt);
+        break;
+
+      case "paused":
+        if (this.input.wasEscPressed) {
+          this.state = "playing";
+        } else if (this.input.wasClicked) {
+          if (this.hud.isResumeButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+            this.state = "playing";
+          } else if (this.hud.isQuitButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+            this.weaponSystem.laserBeam.active = false;
+            this.sound.stopMusic();
+            this.state = "menu";
+            this.refreshSaveStatus().catch(console.error);
+          }
+        }
         break;
 
       case "level_complete":
@@ -1712,6 +1724,7 @@ export class RaptorGame implements IGame {
 
     if (
       this.state === "playing" ||
+      this.state === "paused" ||
       this.state === "gameover" ||
       this.state === "level_complete"
     ) {
@@ -1745,7 +1758,7 @@ export class RaptorGame implements IGame {
     this.vfx.applyPostRender(this.ctx);
 
     const config = this.currentLevelConfig;
-    const displayScore = this.state === "playing" ? this.score : this.totalScore;
+    const displayScore = (this.state === "playing" || this.state === "paused") ? this.score : this.totalScore;
     this.hud.render(
       this.ctx,
       this.state,
@@ -1774,6 +1787,10 @@ export class RaptorGame implements IGame {
 
     if (this.state === "playing" || (this.state === "victory" && this.storyRenderer.isActive)) {
       this.storyRenderer.render(this.ctx, this.width, this.height);
+    }
+
+    if (this.state === "paused") {
+      this.hud.renderPauseMenu(this.ctx, this.width, this.height);
     }
 
     if (this.settingsOpen) {

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -478,6 +478,7 @@ export class HUD {
       case "briefing":
         break;
       case "playing":
+      case "paused":
         this.renderPlayingHUD(ctx, score, lives, armor, level, levelName, width, height, activeEffects, currentWeapon, chargeLevel, bombs, weaponTier, isEnergyRegenerating, dodgeCooldownFraction, inventory, shieldBattery, empCooldownFraction, energy);
         this.renderBottomBar(ctx, width, height, currentWeapon ?? "machine-gun", inventory, bombs ?? 0, weaponTier ?? 1, chargeLevel ?? 0);
         break;
@@ -959,6 +960,95 @@ export class HUD {
     const btnY = rect.y + rect.h - btnH - 16;
     return clickX >= noX && clickX <= noX + btnW
         && clickY >= btnY && clickY <= btnY + btnH;
+  }
+
+  // --- Pause menu ---
+
+  private getPauseMenuRect(width: number, height: number) {
+    const panelW = 340;
+    const panelH = 200;
+    const px = (width - panelW) / 2;
+    const py = (height - panelH) / 2;
+    return { px, py, panelW, panelH };
+  }
+
+  private getResumeButtonRect(width: number, height: number) {
+    const { px, py, panelW } = this.getPauseMenuRect(width, height);
+    const btnW = 200;
+    const btnH = 36;
+    const btnX = px + (panelW - btnW) / 2;
+    const btnY = py + 95;
+    return { x: btnX, y: btnY, w: btnW, h: btnH };
+  }
+
+  private getQuitButtonRect(width: number, height: number) {
+    const { px, py, panelW } = this.getPauseMenuRect(width, height);
+    const btnW = 200;
+    const btnH = 36;
+    const btnX = px + (panelW - btnW) / 2;
+    const btnY = py + 145;
+    return { x: btnX, y: btnY, w: btnW, h: btnH };
+  }
+
+  isResumeButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    const btn = this.getResumeButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w
+        && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  isQuitButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    const btn = this.getQuitButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w
+        && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  renderPauseMenu(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+    ctx.save();
+
+    ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+    ctx.fillRect(0, 0, width, height);
+
+    const { px, py, panelW, panelH } = this.getPauseMenuRect(width, height);
+
+    const panelGrad = ctx.createLinearGradient(px, py, px, py + panelH);
+    panelGrad.addColorStop(0, "rgba(15, 25, 50, 0.92)");
+    panelGrad.addColorStop(1, "rgba(5, 10, 25, 0.96)");
+    ctx.fillStyle = panelGrad;
+    this.roundedRect(ctx, px, py, panelW, panelH, 12);
+    ctx.fill();
+
+    ctx.strokeStyle = "rgba(100, 140, 220, 0.3)";
+    ctx.lineWidth = 1;
+    this.roundedRect(ctx, px, py, panelW, panelH, 12);
+    ctx.stroke();
+
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = "#FFFFFF";
+    ctx.font = `20px ${RETRO_FONT}`;
+    ctx.fillText("PAUSED", width / 2, py + 45);
+
+    const resumeBtn = this.getResumeButtonRect(width, height);
+    ctx.fillStyle = "#2ecc71";
+    this.roundedRect(ctx, resumeBtn.x, resumeBtn.y, resumeBtn.w, resumeBtn.h, 6);
+    ctx.fill();
+    ctx.font = `12px ${RETRO_FONT}`;
+    ctx.fillStyle = "#FFFFFF";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("RESUME", resumeBtn.x + resumeBtn.w / 2, resumeBtn.y + resumeBtn.h / 2);
+
+    const quitBtn = this.getQuitButtonRect(width, height);
+    ctx.fillStyle = "rgba(231, 76, 60, 0.8)";
+    this.roundedRect(ctx, quitBtn.x, quitBtn.y, quitBtn.w, quitBtn.h, 6);
+    ctx.fill();
+    ctx.font = `10px ${RETRO_FONT}`;
+    ctx.fillStyle = "#FFFFFF";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("QUIT TO MENU", quitBtn.x + quitBtn.w / 2, quitBtn.y + quitBtn.h / 2);
+
+    ctx.restore();
   }
 
   private renderPlayingHUD(

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -17,6 +17,7 @@ export type RaptorGameState =
   | "story_intro"
   | "briefing"
   | "playing"
+  | "paused"
   | "level_complete"
   | "gameover"
   | "victory";


### PR DESCRIPTION
## Fix #672: ESC now pauses instead of restarting the level on “Continue”

### Summary (what changed / why)
Pressing **ESC** during gameplay previously **quit to the main menu**, which discarded all in-memory run state (player position, enemies, projectiles, score, power-ups, spawner state, etc.). If the player then chose **Continue**, the game reloaded from the last auto-save and called `startLevel()`, effectively **restarting the current level**.

This PR introduces a proper **pause flow**:
- **ESC in-game → pauses** (`state = "paused"`) without tearing down the current run.
- While paused, the game **freezes simulation** and shows a **PAUSED overlay** with **Resume** and **Quit to Menu** actions.
- **Resume** returns to gameplay **exactly where you left off**.
- **Quit to Menu** preserves the previous behavior (stop music, deactivate laser beam, return to menu, refresh save status).

### Key behavior changes
- New `RaptorGameState`: `"paused"`.
- Paused state:
  - No `updatePlaying()` (no movement/spawns/autosaves/time advance).
  - Game scene remains rendered “frozen” underneath the overlay.
  - Mouse cursor becomes visible for interacting with pause menu buttons.
  - Music continues playing while paused.

### Key files modified
- `src/games/raptor/types.ts`
  - Add `"paused"` to the `RaptorGameState` union.
- `src/games/raptor/RaptorGame.ts`
  - Change ESC handling in `"playing"` to transition to `"paused"` instead of `"menu"`.
  - Add `"paused"` handling in `update()`:
    - ESC or Resume click → back to `"playing"`.
    - Quit click → stop music, deactivate laser, go to `"menu"`, refresh save status.
  - Add paused rendering: draw gameplay scene + pause overlay.
  - Update cursor visibility logic to show cursor while paused.
- `src/games/raptor/rendering/HUD.ts`
  - Add pause overlay rendering (`renderPauseMenu`)
  - Add hit-testing helpers (`isResumeButtonHit`, `isQuitButtonHit`)

### Testing notes
Manual verification:
- Start a level → press **ESC**:
  - Pause overlay appears and **cursor is visible**.
  - Enemies/projectiles stop moving; no new spawns occur.
- Press **ESC** again or click **Resume**:
  - Returns to gameplay with **unchanged** player position, enemies, projectiles, score, etc.
- Click **Quit to Menu**:
  - Returns to menu, **music stops**, and **laser beam is deactivated**.
- Confirm existing precedence:
  - If settings panel or dev console is open, **ESC closes those first** (game remains paused if it was paused).

No save format/API changes.

Ref: https://github.com/asgardtech/archer/issues/672