### PR TITLE
the sound and settings icons should be part of the ESC menu, not always on the top right

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -353,18 +353,20 @@ export class RaptorGame implements IGame {
 
     if (!this.input.wasClicked) return false;
 
-    if (this.hud.isSettingsButtonHit(this.input.mouseX, this.input.mouseY, this.width, HUD_RIGHT_PANEL_WIDTH)) {
-      this.settingsOpen = true;
-      this.input.consume();
-      return true;
-    }
+    if (this.state !== "playing" && this.state !== "paused") {
+      if (this.hud.isSettingsButtonHit(this.input.mouseX, this.input.mouseY, this.width, HUD_RIGHT_PANEL_WIDTH)) {
+        this.settingsOpen = true;
+        this.input.consume();
+        return true;
+      }
 
-    if (this.hud.isMuteButtonHit(this.input.mouseX, this.input.mouseY, this.width, HUD_RIGHT_PANEL_WIDTH)) {
-      this.audio.ensureContext();
-      this.audio.toggleMute();
-      this.persistSettings();
-      this.input.consume();
-      return true;
+      if (this.hud.isMuteButtonHit(this.input.mouseX, this.input.mouseY, this.width, HUD_RIGHT_PANEL_WIDTH)) {
+        this.audio.ensureContext();
+        this.audio.toggleMute();
+        this.persistSettings();
+        this.input.consume();
+        return true;
+      }
     }
 
     return false;
@@ -608,6 +610,12 @@ export class RaptorGame implements IGame {
         if (this.input.wasClicked) {
           if (this.hud.isResumeButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
             this.state = "playing";
+          } else if (this.hud.isPauseMuteButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+            this.audio.ensureContext();
+            this.audio.toggleMute();
+            this.persistSettings();
+          } else if (this.hud.isPauseSettingsButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
+            this.settingsOpen = true;
           } else if (this.hud.isQuitButtonHit(this.input.mouseX, this.input.mouseY, this.width, this.height)) {
             this.weaponSystem.laserBeam.active = false;
             this.sound.stopMusic();
@@ -1796,15 +1804,17 @@ export class RaptorGame implements IGame {
       this.player.empCooldownFraction,
       this.player.energy
     );
-    this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width, HUD_RIGHT_PANEL_WIDTH);
-    this.hud.renderSettingsButton(this.ctx, this.width, HUD_RIGHT_PANEL_WIDTH);
+    if (this.state !== "playing" && this.state !== "paused") {
+      this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width, HUD_RIGHT_PANEL_WIDTH);
+      this.hud.renderSettingsButton(this.ctx, this.width, HUD_RIGHT_PANEL_WIDTH);
+    }
 
     if (this.state === "playing" || this.state === "paused" || (this.state === "victory" && this.storyRenderer.isActive)) {
       this.storyRenderer.render(this.ctx, this.width, this.height);
     }
 
     if (this.state === "paused") {
-      this.hud.renderPauseMenu(this.ctx, this.width, this.height);
+      this.hud.renderPauseMenu(this.ctx, this.width, this.height, this.audio.muted);
     }
 
     if (this.settingsOpen) {

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -959,94 +959,7 @@ export class HUD {
         && clickY >= btnY && clickY <= btnY + btnH;
   }
 
-  // --- Pause menu ---
-
-  private getPauseMenuRect(width: number, height: number) {
-    const panelW = 340;
-    const panelH = 200;
-    const px = (width - panelW) / 2;
-    const py = (height - panelH) / 2;
-    return { px, py, panelW, panelH };
-  }
-
-  private getResumeButtonRect(width: number, height: number) {
-    const { px, py, panelW } = this.getPauseMenuRect(width, height);
-    const btnW = 200;
-    const btnH = 36;
-    const btnX = px + (panelW - btnW) / 2;
-    const btnY = py + 95;
-    return { x: btnX, y: btnY, w: btnW, h: btnH };
-  }
-
-  private getQuitButtonRect(width: number, height: number) {
-    const { px, py, panelW } = this.getPauseMenuRect(width, height);
-    const btnW = 200;
-    const btnH = 36;
-    const btnX = px + (panelW - btnW) / 2;
-    const btnY = py + 145;
-    return { x: btnX, y: btnY, w: btnW, h: btnH };
-  }
-
-  isResumeButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
-    const btn = this.getResumeButtonRect(width, height);
-    return clickX >= btn.x && clickX <= btn.x + btn.w
-        && clickY >= btn.y && clickY <= btn.y + btn.h;
-  }
-
-  isQuitButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
-    const btn = this.getQuitButtonRect(width, height);
-    return clickX >= btn.x && clickX <= btn.x + btn.w
-        && clickY >= btn.y && clickY <= btn.y + btn.h;
-  }
-
-  renderPauseMenu(ctx: CanvasRenderingContext2D, width: number, height: number): void {
-    ctx.save();
-
-    ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
-    ctx.fillRect(0, 0, width, height);
-
-    const { px, py, panelW, panelH } = this.getPauseMenuRect(width, height);
-
-    const panelGrad = ctx.createLinearGradient(px, py, px, py + panelH);
-    panelGrad.addColorStop(0, "rgba(15, 25, 50, 0.92)");
-    panelGrad.addColorStop(1, "rgba(5, 10, 25, 0.96)");
-    ctx.fillStyle = panelGrad;
-    this.roundedRect(ctx, px, py, panelW, panelH, 12);
-    ctx.fill();
-
-    ctx.strokeStyle = "rgba(100, 140, 220, 0.3)";
-    ctx.lineWidth = 1;
-    this.roundedRect(ctx, px, py, panelW, panelH, 12);
-    ctx.stroke();
-
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.fillStyle = "#FFFFFF";
-    ctx.font = `20px ${RETRO_FONT}`;
-    ctx.fillText("PAUSED", width / 2, py + 45);
-
-    const resumeBtn = this.getResumeButtonRect(width, height);
-    ctx.fillStyle = "#2ecc71";
-    this.roundedRect(ctx, resumeBtn.x, resumeBtn.y, resumeBtn.w, resumeBtn.h, 6);
-    ctx.fill();
-    ctx.font = `12px ${RETRO_FONT}`;
-    ctx.fillStyle = "#FFFFFF";
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.fillText("RESUME", resumeBtn.x + resumeBtn.w / 2, resumeBtn.y + resumeBtn.h / 2);
-
-    const quitBtn = this.getQuitButtonRect(width, height);
-    ctx.fillStyle = "rgba(231, 76, 60, 0.8)";
-    this.roundedRect(ctx, quitBtn.x, quitBtn.y, quitBtn.w, quitBtn.h, 6);
-    ctx.fill();
-    ctx.font = `10px ${RETRO_FONT}`;
-    ctx.fillStyle = "#FFFFFF";
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.fillText("QUIT TO MENU", quitBtn.x + quitBtn.w / 2, quitBtn.y + quitBtn.h / 2);
-
-    ctx.restore();
-  }
+  // --- Pause menu (legacy block — overridden by methods below) ---
 
   private renderPlayingHUD(
     ctx: CanvasRenderingContext2D,
@@ -1999,7 +1912,7 @@ export class HUD {
 
   private getPauseMenuRect(width: number, height: number) {
     const panelW = 340;
-    const panelH = 200;
+    const panelH = 280;
     const px = (width - panelW) / 2;
     const py = (height - panelH) / 2;
     return { px, py, panelW, panelH };
@@ -2010,8 +1923,28 @@ export class HUD {
     const btnW = 200;
     const btnH = 36;
     const btnX = px + (panelW - btnW) / 2;
-    const btnY = py + 90;
+    const btnY = py + 80;
     return { x: btnX, y: btnY, w: btnW, h: btnH };
+  }
+
+  private getPauseMuteButtonRect(width: number, height: number) {
+    const { px, py, panelW } = this.getPauseMenuRect(width, height);
+    const btnSize = 40;
+    const gap = 20;
+    const totalW = btnSize * 2 + gap;
+    const startX = px + (panelW - totalW) / 2;
+    const btnY = py + 140;
+    return { x: startX, y: btnY, w: btnSize, h: btnSize };
+  }
+
+  private getPauseSettingsButtonRect(width: number, height: number) {
+    const { px, py, panelW } = this.getPauseMenuRect(width, height);
+    const btnSize = 40;
+    const gap = 20;
+    const totalW = btnSize * 2 + gap;
+    const startX = px + (panelW - totalW) / 2;
+    const btnY = py + 140;
+    return { x: startX + btnSize + gap, y: btnY, w: btnSize, h: btnSize };
   }
 
   private getQuitButtonRect(width: number, height: number) {
@@ -2019,7 +1952,7 @@ export class HUD {
     const btnW = 200;
     const btnH = 36;
     const btnX = px + (panelW - btnW) / 2;
-    const btnY = py + 140;
+    const btnY = py + 210;
     return { x: btnX, y: btnY, w: btnW, h: btnH };
   }
 
@@ -2033,7 +1966,17 @@ export class HUD {
     return clickX >= btn.x && clickX <= btn.x + btn.w && clickY >= btn.y && clickY <= btn.y + btn.h;
   }
 
-  renderPauseMenu(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  isPauseMuteButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    const btn = this.getPauseMuteButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  isPauseSettingsButtonHit(clickX: number, clickY: number, width: number, height: number): boolean {
+    const btn = this.getPauseSettingsButtonRect(width, height);
+    return clickX >= btn.x && clickX <= btn.x + btn.w && clickY >= btn.y && clickY <= btn.y + btn.h;
+  }
+
+  renderPauseMenu(ctx: CanvasRenderingContext2D, width: number, height: number, muted: boolean): void {
     ctx.save();
 
     ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
@@ -2068,6 +2011,34 @@ export class HUD {
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.fillText("RESUME", resumeBtn.x + resumeBtn.w / 2, resumeBtn.y + resumeBtn.h / 2);
+
+    const muteBtn = this.getPauseMuteButtonRect(width, height);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.12)";
+    this.roundedRect(ctx, muteBtn.x, muteBtn.y, muteBtn.w, muteBtn.h, 6);
+    ctx.fill();
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.25)";
+    ctx.lineWidth = 1;
+    this.roundedRect(ctx, muteBtn.x, muteBtn.y, muteBtn.w, muteBtn.h, 6);
+    ctx.stroke();
+    ctx.font = `16px ${RETRO_FONT}`;
+    ctx.fillStyle = "#fff";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(muted ? "\u{1F507}" : "\u{1F50A}", muteBtn.x + muteBtn.w / 2, muteBtn.y + muteBtn.h / 2);
+
+    const settingsBtn = this.getPauseSettingsButtonRect(width, height);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.12)";
+    this.roundedRect(ctx, settingsBtn.x, settingsBtn.y, settingsBtn.w, settingsBtn.h, 6);
+    ctx.fill();
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.25)";
+    ctx.lineWidth = 1;
+    this.roundedRect(ctx, settingsBtn.x, settingsBtn.y, settingsBtn.w, settingsBtn.h, 6);
+    ctx.stroke();
+    ctx.font = `16px ${RETRO_FONT}`;
+    ctx.fillStyle = "#fff";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("\u2699", settingsBtn.x + settingsBtn.w / 2, settingsBtn.y + settingsBtn.h / 2);
 
     const quitBtn = this.getQuitButtonRect(width, height);
     ctx.fillStyle = "rgba(231, 76, 60, 0.8)";


### PR DESCRIPTION
## PR: Move sound + settings controls into the ESC/pause menu (Issue #674)

### Summary / Why
This change relocates the **mute (sound)** and **settings (gear)** buttons from a **persistent top-right HUD overlay** into the **ESC/pause menu**.  
Previously, both icons were rendered every frame during gameplay and handled clicks globally. This PR aligns the UI with the intended design: **during gameplay, these controls should only be available when paused**, reducing on-screen clutter and preventing accidental clicks.

### What changed
- **Pause menu expanded** to include a new control row between **RESUME** and **QUIT TO MENU**.
- **Mute + Settings buttons are now rendered inside the pause menu** (with proper hit targets and updated layout).
- **Top-right mute/settings overlay is no longer shown during `playing` / `paused`**, but **remains available on non-gameplay screens** (e.g., menu, slot select, briefing, etc.).
- **Click handling updated** so:
  - In `paused`, clicks can toggle mute and open settings from within the pause menu.
  - In non-gameplay states, the existing top-right buttons still work as before.
- **Settings overlay behavior unchanged**: opening settings from pause overlays correctly, and ESC closes settings before unpausing (existing priority preserved).
- **Mute persistence unchanged**: toggling still persists via the existing settings persistence flow.

### Key files modified
- `src/games/raptor/rendering/HUD.ts`
  - Expanded pause menu panel sizing.
  - Added pause-menu button rects + hit-tests for mute/settings.
  - Updated `renderPauseMenu()` layout and adjusted RESUME/QUIT positioning.
- `src/games/raptor/RaptorGame.ts`
  - Conditional rendering: top-right mute/settings only on non-gameplay states.
  - Updated paused-state click handling to support new in-menu controls.
  - Guarded existing UI click detection so removed controls aren’t hit-tested during gameplay.

### Testing notes
Manual verification recommended (no new automated tests added):
- **Playing state**: confirm top-right mute/settings icons are not visible/clickable.
- **Pause (ESC)**: confirm pause menu shows **RESUME**, then **Mute + Settings row**, then **QUIT TO MENU**; buttons do not overlap and are usable.
- **Mute toggle in pause**: confirm icon updates and mute state persists after resume/reload.
- **Settings from pause**: confirm settings modal opens above pause menu; closing returns to pause menu.
- **ESC while settings open**: closes settings and remains paused (does not resume).
- **Non-gameplay screens** (`menu`, `slot_select`, `story_intro`, `briefing`, `level_complete`, `gameover`, `victory`): confirm top-right mute/settings are still rendered and functional.

Ref: https://github.com/asgardtech/archer/issues/674