### PR TITLE
enemy lasers look strange when they turn; it looks like a rectangle being skewed, not like a beam that's rotating

### DIFF
--- a/src/games/raptor/entities/EnemyLaserBeam.ts
+++ b/src/games/raptor/entities/EnemyLaserBeam.ts
@@ -142,11 +142,29 @@ export class EnemyLaserBeam {
     bottomX: number, bottomY: number,
     halfWidth: number,
   ): void {
+    const dx = bottomX - topX;
+    const dy = bottomY - topY;
+    const len = Math.sqrt(dx * dx + dy * dy);
+
+    let perpX: number;
+    let perpY: number;
+
+    if (len < 0.001) {
+      perpX = 1;
+      perpY = 0;
+    } else {
+      perpX = -dy / len;
+      perpY = dx / len;
+    }
+
+    const offsetX = perpX * halfWidth;
+    const offsetY = perpY * halfWidth;
+
     ctx.beginPath();
-    ctx.moveTo(topX - halfWidth, topY);
-    ctx.lineTo(topX + halfWidth, topY);
-    ctx.lineTo(bottomX + halfWidth, bottomY);
-    ctx.lineTo(bottomX - halfWidth, bottomY);
+    ctx.moveTo(topX - offsetX, topY - offsetY);
+    ctx.lineTo(topX + offsetX, topY + offsetY);
+    ctx.lineTo(bottomX + offsetX, bottomY + offsetY);
+    ctx.lineTo(bottomX - offsetX, bottomY - offsetY);
     ctx.closePath();
   }
 

--- a/tests/raptor-enemy-laser-beam.test.ts
+++ b/tests/raptor-enemy-laser-beam.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for Issue #524: Enemy laser beam origin tracking and angled beam
+ * Tests for Enemy laser beam origin tracking, angled beam, and rotation rendering
  */
 
 import { EnemyLaserBeam, EnemyLaserBeamConfig } from "../src/games/raptor/entities/EnemyLaserBeam";
@@ -155,5 +155,198 @@ describe("EnemyLaserBeam reset on enemy destruction", () => {
     expect(beam.originX).toBe(0);
     expect(beam.originY).toBe(0);
     expect(beam.beamX).toBe(0);
+  });
+});
+
+// --- Rendering geometry tests for issue #676 ---
+
+interface RecordedPath {
+  points: { x: number; y: number }[];
+  closed: boolean;
+  filled: boolean;
+}
+
+function createMockContext(): CanvasRenderingContext2D & { _paths: RecordedPath[] } {
+  const paths: RecordedPath[] = [];
+  let current: { x: number; y: number }[] = [];
+
+  return {
+    _paths: paths,
+    save: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(() => { current = []; }),
+    moveTo: jest.fn((x: number, y: number) => { current.push({ x, y }); }),
+    lineTo: jest.fn((x: number, y: number) => { current.push({ x, y }); }),
+    closePath: jest.fn(() => { paths.push({ points: [...current], closed: true, filled: false }); }),
+    fill: jest.fn(() => { if (paths.length > 0) paths[paths.length - 1].filled = true; }),
+    stroke: jest.fn(),
+    set fillStyle(_v: string) {},
+    set strokeStyle(_v: string) {},
+    set lineWidth(_v: number) {},
+  } as unknown as CanvasRenderingContext2D & { _paths: RecordedPath[] };
+}
+
+function distance(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
+}
+
+function edgeLengths(points: { x: number; y: number }[]): number[] {
+  return [
+    distance(points[0], points[1]),
+    distance(points[1], points[2]),
+    distance(points[2], points[3]),
+    distance(points[3], points[0]),
+  ];
+}
+
+describe("EnemyLaserBeam fillTrapezoid rendering geometry", () => {
+  test("vertical beam renders as a rectangle with correct width", () => {
+    const beam = createBeam({ warmupDuration: 0.1, beamWidth: 12 });
+    beam.activate(200, 50, 200);
+    beam.update(0.15, 200, 50, 200);
+    expect(beam.phase).toBe("active");
+
+    const ctx = createMockContext();
+    beam.render(ctx, 600);
+
+    expect(ctx._paths.length).toBe(3);
+
+    const corePath = ctx._paths[2];
+    const pts = corePath.points;
+    expect(pts).toHaveLength(4);
+
+    const topEdge = distance(pts[0], pts[1]);
+    const bottomEdge = distance(pts[2], pts[3]);
+    expect(topEdge).toBeCloseTo(bottomEdge);
+
+    const midTopX = (pts[0].x + pts[1].x) / 2;
+    expect(midTopX).toBeCloseTo(200);
+  });
+
+  test("angled beam has edges perpendicular to beam direction", () => {
+    const beam = createBeam({ warmupDuration: 0.1, beamWidth: 12, trackingSpeed: 10000 });
+    beam.activate(200, 50, 400);
+    beam.update(0.15, 200, 50, 400);
+    expect(beam.phase).toBe("active");
+
+    beam.update(0.1, 200, 50, 400);
+
+    const ctx = createMockContext();
+    beam.render(ctx, 600);
+
+    expect(ctx._paths.length).toBe(3);
+
+    const beamPath = ctx._paths[1];
+    const pts = beamPath.points;
+    expect(pts).toHaveLength(4);
+
+    const beamDirX = beam.beamX - beam.originX;
+    const beamDirY = 600 - beam.originY;
+    const len = Math.sqrt(beamDirX * beamDirX + beamDirY * beamDirY);
+
+    const topEdgeDx = pts[1].x - pts[0].x;
+    const topEdgeDy = pts[1].y - pts[0].y;
+
+    const dot = topEdgeDx * beamDirX / len + topEdgeDy * beamDirY / len;
+    expect(dot).toBeCloseTo(0, 5);
+  });
+
+  test("angled beam has uniform width (rotated rectangle, not skewed parallelogram)", () => {
+    const beam = createBeam({ warmupDuration: 0.1, beamWidth: 12, trackingSpeed: 10000 });
+    beam.activate(200, 50, 400);
+    beam.update(0.15, 200, 50, 400);
+    beam.update(0.1, 200, 50, 400);
+
+    const ctx = createMockContext();
+    beam.render(ctx, 600);
+
+    const beamPath = ctx._paths[1];
+    const pts = beamPath.points;
+
+    const edges = edgeLengths(pts);
+    const topEdge = edges[0];
+    const bottomEdge = edges[2];
+    const leftEdge = edges[3];
+    const rightEdge = edges[1];
+
+    expect(topEdge).toBeCloseTo(bottomEdge, 5);
+    expect(leftEdge).toBeCloseTo(rightEdge, 5);
+  });
+
+  test("beam corners are offset by halfWidth perpendicular to center line", () => {
+    const beam = createBeam({ warmupDuration: 0.1, beamWidth: 12, trackingSpeed: 10000 });
+    beam.activate(200, 50, 400);
+    beam.update(0.15, 200, 50, 400);
+    beam.update(0.5, 200, 50, 400);
+
+    const ctx = createMockContext();
+    beam.render(ctx, 600);
+
+    const beamPath = ctx._paths[1];
+    const pts = beamPath.points;
+    const halfWidth = 12 / 2;
+
+    const topMidX = (pts[0].x + pts[1].x) / 2;
+    const topMidY = (pts[0].y + pts[1].y) / 2;
+    expect(topMidX).toBeCloseTo(beam.originX);
+    expect(topMidY).toBeCloseTo(beam.originY);
+
+    const topEdgeLen = distance(pts[0], pts[1]);
+    expect(topEdgeLen).toBeCloseTo(halfWidth * 2, 3);
+  });
+
+  test("all three glow layers rotate consistently", () => {
+    const beam = createBeam({ warmupDuration: 0.1, beamWidth: 12, trackingSpeed: 10000 });
+    beam.activate(200, 50, 400);
+    beam.update(0.15, 200, 50, 400);
+    beam.update(0.1, 200, 50, 400);
+
+    const ctx = createMockContext();
+    beam.render(ctx, 600);
+
+    expect(ctx._paths.length).toBe(3);
+
+    const beamDirX = beam.beamX - beam.originX;
+    const beamDirY = 600 - beam.originY;
+    const len = Math.sqrt(beamDirX * beamDirX + beamDirY * beamDirY);
+
+    for (const path of ctx._paths) {
+      const pts = path.points;
+      const topEdgeDx = pts[1].x - pts[0].x;
+      const topEdgeDy = pts[1].y - pts[0].y;
+
+      const dot = topEdgeDx * beamDirX / len + topEdgeDy * beamDirY / len;
+      expect(dot).toBeCloseTo(0, 5);
+    }
+  });
+
+  test("degenerate zero-length beam does not produce NaN", () => {
+    const beam = createBeam({ warmupDuration: 0.1, beamWidth: 12 });
+    beam.activate(200, 600, 200);
+    beam.update(0.15, 200, 600, 200);
+    expect(beam.phase).toBe("active");
+
+    const ctx = createMockContext();
+    beam.render(ctx, 600);
+
+    for (const path of ctx._paths) {
+      for (const pt of path.points) {
+        expect(Number.isNaN(pt.x)).toBe(false);
+        expect(Number.isNaN(pt.y)).toBe(false);
+      }
+    }
+  });
+
+  test("warning line during warmup is unaffected by fillTrapezoid changes", () => {
+    const beam = createBeam({ warmupDuration: 1.0 });
+    beam.activate(200, 50, 300);
+    beam.update(0.1, 200, 50, 300);
+    expect(beam.phase).toBe("warmup");
+
+    const ctx = createMockContext();
+    beam.render(ctx, 600);
+
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(ctx._paths.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Fix enemy laser beam skewing when tracking (Issue #676)

### Summary / Why
Enemy laser beams looked visually wrong when rotating to track the player—appearing like a horizontally *sheared* rectangle (parallelogram) instead of a rigid beam rotating around its origin.  
This was caused by the beam quad being constructed by offsetting its width purely along the **X axis**, which only works for perfectly vertical beams.

This PR updates the beam geometry so width is measured **perpendicular to the beam’s center line**, producing a proper rotated rectangle at any angle while keeping the beam uniformly wide.

### What changed
- Rewrote `EnemyLaserBeam.fillTrapezoid()` to compute beam corners using a **perpendicular unit vector** derived from the beam direction `(dx, dy)`.
- Added a safety fallback for **near-zero length** beams to avoid division-by-zero / NaNs.
- Added unit tests covering:
  - angled-beam geometry (perpendicular edges, uniform width),
  - consistent rotation across glow/core layers,
  - degenerate zero-length rendering safety.

### Key files modified
- `src/games/raptor/entities/EnemyLaserBeam.ts`
  - Updated `fillTrapezoid()` to use perpendicular offsets instead of horizontal offsets.
- `tests/raptor-enemy-laser-beam.test.ts`
  - New/updated geometry-focused rendering tests.

### Notes / Non-goals
- No collision changes: collision logic still uses a horizontal-width approximation along the beam center line, which remains acceptable for typical (near-vertical) gameplay angles and is out of scope for this visual fix.
- Warmup warning line rendering is unaffected (it uses stroke logic, not the filled trapezoid).

### Testing
- Automated: `tests/raptor-enemy-laser-beam.test.ts` verifies correct corner computation, perpendicularity, constant width, glow layer alignment, and degenerate-case handling.
- Manual: In-game, move the player horizontally while an enemy laser tracks—beam should now rotate smoothly as a rigid bar with no skewing/shearing artifact.

Ref: https://github.com/asgardtech/archer/issues/676