### PR TITLE
during loading screens, the settings and audio buttons are visible, they shouldn't be

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -353,7 +353,7 @@ export class RaptorGame implements IGame {
 
     if (!this.input.wasClicked) return false;
 
-    if (this.state !== "playing" && this.state !== "paused") {
+    if (this.state !== "playing" && this.state !== "paused" && !this.slotLoadingInProgress) {
       if (this.hud.isSettingsButtonHit(this.input.mouseX, this.input.mouseY, this.width, HUD_RIGHT_PANEL_WIDTH)) {
         this.settingsOpen = true;
         this.input.consume();
@@ -1804,7 +1804,7 @@ export class RaptorGame implements IGame {
       this.player.empCooldownFraction,
       this.player.energy
     );
-    if (this.state !== "playing" && this.state !== "paused") {
+    if (this.state !== "playing" && this.state !== "paused" && !this.slotLoadingInProgress) {
       this.hud.renderMuteButton(this.ctx, this.audio.muted, this.width, HUD_RIGHT_PANEL_WIDTH);
       this.hud.renderSettingsButton(this.ctx, this.width, HUD_RIGHT_PANEL_WIDTH);
     }


### PR DESCRIPTION
## Fix: Hide settings + audio buttons during save-slot loading (Issue #702)

### Summary / Why
During the **save-slot loading transition** (`state === "slot_select"` while `slotLoadingInProgress === true`), the **settings (gear)** and **audio/mute (speaker)** buttons were still being **rendered and clickable**. This created a noisy loading screen and allowed unintended interactions.

This PR extends the existing UI guard conditions so these buttons are **neither drawn nor interactive** while a save slot load is in progress. Initial asset loading (`state === "loading"`) was already correct and remains unchanged.

### What changed
- **Render gating:** Suppress rendering of settings + mute buttons when `slotLoadingInProgress` is `true`.
- **Input gating:** Suppress click-handling/hit-testing for these buttons when `slotLoadingInProgress` is `true`.

### Key files modified
- `src/games/raptor/RaptorGame.ts`
  - **~line 356:** Updated click-handling condition to include `&& !this.slotLoadingInProgress`
  - **~line 1807:** Updated render condition to include `&& !this.slotLoadingInProgress`

### Testing notes
Manual verification:
- Start game (initial asset loading): buttons are **not visible** (unchanged behavior).
- From **slot select**, click an existing save slot to load:
  - During the loading transition, settings/audio buttons are **not visible**.
  - Clicking where the buttons normally appear does **nothing** (no settings panel, no mute toggle).
- After load completes:
  - Game transitions as expected and overlay buttons behave according to normal state rules.
- If slot loading fails and returns to slot select:
  - `slotLoadingInProgress` resets and buttons **reappear** on the slot select screen.

Ref: https://github.com/asgardtech/archer/issues/702