### PR TITLE
Achievement system: Implement player statistics tracking

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1071,8 +1071,8 @@ export class RaptorGame implements IGame {
         this.statsTracker.recordReflect();
         continue;
       }
-      this.statsTracker.recordDamageTaken(hit.bullet.damage, this.player.armor);
       const dead = this.player.takeDamage(hit.bullet.damage);
+      this.statsTracker.recordDamageTaken(hit.bullet.damage, this.player.armor);
       if (dead) {
         this.sound.play("player_destroy");
         this.addExplosion(new Explosion(this.player.pos.x, this.player.pos.y, 3));
@@ -1106,8 +1106,8 @@ export class RaptorGame implements IGame {
       this.enemyWeaponSystem.getActiveLasers(), this.player, this.height, dt
     );
     for (const hit of beamHits) {
-      this.statsTracker.recordDamageTaken(hit.damage, this.player.armor);
       const dead = this.player.takeDamage(hit.damage);
+      this.statsTracker.recordDamageTaken(hit.damage, this.player.armor);
       if (dead) {
         this.sound.play("player_destroy");
         this.addExplosion(new Explosion(this.player.pos.x, this.player.pos.y, 3));
@@ -1139,8 +1139,8 @@ export class RaptorGame implements IGame {
           this.spawnPowerUp(hit.enemy.pos.x, hit.enemy.pos.y);
         }
       }
-      this.statsTracker.recordDamageTaken(50, this.player.armor);
       const dead = this.player.takeDamage(50);
+      this.statsTracker.recordDamageTaken(50, this.player.armor);
       if (dead) {
         this.sound.play("player_destroy");
         this.addExplosion(new Explosion(this.player.pos.x, this.player.pos.y, 3));
@@ -1236,7 +1236,7 @@ export class RaptorGame implements IGame {
     if (this.spawner.isLevelComplete && this.enemies.length === 0) {
       this.totalScore += this.score;
       this.statsTracker.updateScore(this.score, this.totalScore);
-      this.statsTracker.recordLevelComplete(this.currentLevel, this.levelElapsed, this.statsTracker.getStats().damageTakenThisLevel);
+      this.statsTracker.recordLevelComplete(this.currentLevel, this.levelElapsed, 0);
       this.projectiles = [];
       this.enemyBullets = [];
       this.powerUps = [];

--- a/src/games/raptor/systems/achievements/PlayerStatsTracker.ts
+++ b/src/games/raptor/systems/achievements/PlayerStatsTracker.ts
@@ -58,7 +58,7 @@ function defaultStats(): PlayerStats {
 export class PlayerStatsTracker {
   private stats: PlayerStats = defaultStats();
 
-  recordKill(variant: string, scoreValue: number, isBoss: boolean): void {
+  recordKill(variant: string, _scoreValue: number, isBoss: boolean): void {
     this.stats.totalKills++;
     this.stats.killsByVariant[variant] = (this.stats.killsByVariant[variant] ?? 0) + 1;
     if (isBoss) {
@@ -66,7 +66,7 @@ export class PlayerStatsTracker {
     }
   }
 
-  recordRamKill(variant: string, scoreValue: number, isBoss = false): void {
+  recordRamKill(variant: string, _scoreValue: number, isBoss = false): void {
     this.stats.totalKills++;
     this.stats.ramKills++;
     this.stats.killsByVariant[variant] = (this.stats.killsByVariant[variant] ?? 0) + 1;
@@ -96,7 +96,7 @@ export class PlayerStatsTracker {
     this.stats.projectilesReflected++;
   }
 
-  recordLevelComplete(levelIndex: number, elapsedSeconds: number, damageTaken: number): void {
+  recordLevelComplete(levelIndex: number, elapsedSeconds: number, _damageTaken: number): void {
     this.stats.levelsCompleted++;
     this.stats.highestLevelCompleted = Math.max(this.stats.highestLevelCompleted, levelIndex);
 
@@ -122,7 +122,7 @@ export class PlayerStatsTracker {
     this.stats.totalPlayTimeSeconds += dt;
   }
 
-  updateScore(currentScore: number, totalScore: number): void {
+  updateScore(_currentScore: number, totalScore: number): void {
     this.stats.totalScore = totalScore;
   }
 

--- a/tests/raptor-player-stats-tracker.test.ts
+++ b/tests/raptor-player-stats-tracker.test.ts
@@ -85,6 +85,15 @@ describe("PlayerStatsTracker", () => {
       expect(s.killsByVariant["bomber"]).toBe(1);
     });
 
+    it("records a boss ram kill", () => {
+      tracker.recordRamKill("boss", 400, true);
+      const s = tracker.getStats();
+      expect(s.totalKills).toBe(1);
+      expect(s.ramKills).toBe(1);
+      expect(s.bossesDefeated).toBe(1);
+      expect(s.killsByVariant["boss"]).toBe(1);
+    });
+
     it("does not double-count with recordKill", () => {
       tracker.recordRamKill("scout", 10);
       tracker.recordKill("fighter", 25, false);


### PR DESCRIPTION
## PR: Achievement system — Implement player statistics tracking

### Why
Achievements in epic **#608** need reliable gameplay telemetry (kills, deaths, power-ups, level times, etc.) to evaluate conditions. This PR adds a dedicated, **side-effect-free** stats accumulator that can be queried safely without mutating internal state.

### What changed
- Added a new **`PlayerStatsTracker`** system that records and exposes a snapshot of player statistics required for achievement evaluation.
- Integrated the tracker into **`RaptorGame`** at all relevant gameplay points (combat, damage, abilities, pickups, level completion, score/time).
- Implemented **per-level vs lifetime** stat scoping:
  - Per-level stats (`damageTakenThisLevel`, `lowestArmorSurvived`) reset on `startLevel()`.
  - Lifetime/session totals accumulate across levels and reset only on `resetGame()`.
- Added comprehensive unit tests covering initialization, increments, reset behavior, snapshot isolation, and edge cases.

### Key files modified / added
- **Added:** `src/games/raptor/systems/achievements/PlayerStatsTracker.ts`
  - Defines `PlayerStats` and `PlayerStatsTracker` (`record*`, `resetLevelStats`, `resetAll`, `getStats` deep-copy snapshot).
- **Modified:** `src/games/raptor/RaptorGame.ts`
  - Instantiates `PlayerStatsTracker`
  - Calls tracker methods for:
    - enemy kills / boss defeats
    - ram kills + damage taken
    - bullet/beam damage taken
    - projectile reflections
    - dodge / EMP usage
    - power-up collection
    - weapon pickup/upgrade tracking
    - level completion (including fastest completion per level)
    - play time accumulation (playing state only)
    - score updates
    - level start resets and full game reset
- **Added:** `tests/raptor-player-stats-tracker.test.ts`
  - 31 Jest tests for all stat categories, reset semantics, and snapshot isolation

### Testing notes
- **Automated:** `jest` (adds `tests/raptor-player-stats-tracker.test.ts`)
  - Covers: initialization defaults, all `record*` methods, fastest-time-wins logic, per-level reset vs full reset, snapshot immutability, and edge cases (unknown variants/types, repeated completions).
- **Manual sanity check (recommended):**
  - Play through a level and verify no gameplay behavior changes (tracker is passive).
  - Trigger dodge/EMP, collect power-ups, take damage, complete a level, and confirm stats update via `getStats()` if inspected in debug/logging.

### Notes / scope
- Tracker is **in-memory only** (no persistence/UI/achievement evaluation in this PR). Those are handled in follow-up work within epic **#608**.

Ref: https://github.com/asgardtech/archer/issues/715