### PR TITLE
Achievement system: Implement achievement evaluation engine

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -11,6 +11,7 @@ import { EnemyWeaponSystem } from "./systems/EnemyWeaponSystem";
 import { SaveSystem } from "./systems/SaveSystem";
 import { PerformanceManager } from "./systems/PerformanceManager";
 import { PlayerStatsTracker } from "./systems/achievements/PlayerStatsTracker";
+import { AchievementManager } from "./systems/achievements/AchievementManager";
 import { CommandRegistry, CommandContext, registerLevelCommands, registerWeaponCommands, registerPowerUpCommands, registerPlayerCommands, registerCombatCommands } from "./systems/CommandRegistry";
 import { Player } from "./entities/Player";
 import { Bullet } from "./entities/Bullet";
@@ -124,6 +125,8 @@ export class RaptorGame implements IGame {
   private nextStoryMessageIndex = 0;
   private perfManager: PerformanceManager;
   private statsTracker = new PlayerStatsTracker();
+  private achievementManager: AchievementManager;
+  private achievementCheckTimer = 0;
   private skyGradientCanvas: HTMLCanvasElement | null = null;
   private cachedSkyGradient: [string, string] | null = null;
   private playTimeSeconds = 0;
@@ -182,6 +185,8 @@ export class RaptorGame implements IGame {
     this.terrainRenderer = new TerrainRenderer(width, height, this.assets);
 
     this.perfManager = new PerformanceManager();
+    this.achievementManager = new AchievementManager(this.statsTracker);
+    this.achievementManager.onUnlock = (_a) => { /* future: toast notification */ };
     this.initStars(60);
     this.setupResize();
   }
@@ -715,6 +720,11 @@ export class RaptorGame implements IGame {
     this.levelElapsed += dt;
     this.playTimeSeconds += dt;
     this.statsTracker.addPlayTime(dt);
+    this.achievementCheckTimer += dt;
+    if (this.achievementCheckTimer >= 5) {
+      this.achievementCheckTimer = 0;
+      this.achievementManager.checkAchievements();
+    }
     this.hud.updateWingmanTimer(dt);
     this.input.updateFromKeyboard(dt, this.gameAreaWidth, this.gameAreaHeight, this.gameAreaX, this.gameAreaY);
     this.player.update(dt, this.input.targetX, this.input.targetY, this.gameAreaWidth, this.gameAreaHeight, this.gameAreaX, this.gameAreaY);
@@ -1085,6 +1095,9 @@ export class RaptorGame implements IGame {
           this.sound.play("enemy_missile_hit");
           this.vfx.triggerExplosionFlash(hit.bullet.pos.x, hit.bullet.pos.y, 15);
         }
+        if (this.player.armor > 0 && this.player.armor < this.player.maxArmor * 0.1) {
+          this.achievementManager.fireEvent("armor_below_10pct");
+        }
       }
     }
 
@@ -1113,10 +1126,15 @@ export class RaptorGame implements IGame {
         this.addExplosion(new Explosion(this.player.pos.x, this.player.pos.y, 3));
         this.vfx.triggerScreenShake(8, 0.4);
         this.weaponSystem.laserBeam.active = false;
-      } else if (this.enemyLaserHitSoundCooldown <= 0) {
-        this.sound.play("enemy_laser_hit");
-        this.vfx.triggerScreenShake(1, 0.05);
-        this.enemyLaserHitSoundCooldown = 0.15;
+      } else {
+        if (this.enemyLaserHitSoundCooldown <= 0) {
+          this.sound.play("enemy_laser_hit");
+          this.vfx.triggerScreenShake(1, 0.05);
+          this.enemyLaserHitSoundCooldown = 0.15;
+        }
+        if (this.player.armor > 0 && this.player.armor < this.player.maxArmor * 0.1) {
+          this.achievementManager.fireEvent("armor_below_10pct");
+        }
       }
     }
 
@@ -1129,6 +1147,8 @@ export class RaptorGame implements IGame {
       this.score += hit.enemy.scoreValue;
       this.statsTracker.recordRamKill(hit.enemy.variant, hit.enemy.scoreValue, isBossVariant(hit.enemy.variant));
       this.statsTracker.updateScore(this.score, this.totalScore + this.score);
+      this.achievementManager.fireEvent("ram_kill");
+      this.achievementManager.checkAchievements();
       if (isBossVariant(hit.enemy.variant)) {
         this.sound.play("boss_destroy");
         this.spawner.markBossDefeated();
@@ -1149,6 +1169,9 @@ export class RaptorGame implements IGame {
       } else {
         this.sound.play("player_hit");
         this.vfx.triggerScreenShake(4, 0.2);
+        if (this.player.armor > 0 && this.player.armor < this.player.maxArmor * 0.1) {
+          this.achievementManager.fireEvent("armor_below_10pct");
+        }
       }
     }
 
@@ -1196,6 +1219,9 @@ export class RaptorGame implements IGame {
           if (this.player.bombs < this.player.maxBombs) {
             this.player.bombs++;
           }
+          if (this.player.bombs >= this.player.maxBombs) {
+            this.achievementManager.fireEvent("bombs_at_max");
+          }
           break;
         case "shield-battery":
           if (this.player.shieldBattery >= this.player.maxShieldBattery) {
@@ -1211,6 +1237,7 @@ export class RaptorGame implements IGame {
           this.powerUpManager.activate("deflector");
           break;
       }
+      this.achievementManager.checkAchievements();
     }
 
     RaptorGame.compactAlive(this.projectiles);
@@ -1237,6 +1264,16 @@ export class RaptorGame implements IGame {
       this.totalScore += this.score;
       this.statsTracker.updateScore(this.score, this.totalScore);
       this.statsTracker.recordLevelComplete(this.currentLevel, this.levelElapsed, 0);
+
+      this.achievementManager.fireEvent("level_complete");
+      if (this.statsTracker.getStats().damageTakenThisLevel === 0) {
+        this.achievementManager.fireEvent("no_damage_level");
+      }
+      if (this.levelElapsed < 120) {
+        this.achievementManager.fireEvent("level_under_2min");
+      }
+      this.achievementManager.checkAchievements();
+
       this.projectiles = [];
       this.enemyBullets = [];
       this.powerUps = [];
@@ -1299,6 +1336,8 @@ export class RaptorGame implements IGame {
         this.spawnPowerUp(enemy.pos.x, enemy.pos.y);
       }
     }
+
+    this.achievementManager.checkAchievements();
   }
 
   private handleWeaponPickup(weaponType: WeaponType): void {
@@ -1311,6 +1350,10 @@ export class RaptorGame implements IGame {
       this.hud.triggerTierFlash();
     }
     this.statsTracker.recordWeaponUpgrade(weaponType, this.powerUpManager.weaponTier);
+    if (this.powerUpManager.weaponTier >= 3) {
+      this.achievementManager.fireEvent("weapon_tier_3");
+    }
+    this.achievementManager.checkAchievements();
   }
 
   private assignProjectileSprite(proj: Projectile): void {
@@ -1423,6 +1466,7 @@ export class RaptorGame implements IGame {
     this.totalScore = 0;
     this.playTimeSeconds = 0;
     this.statsTracker.resetAll();
+    this.achievementManager.reset();
     this.vfx.reset();
     this.hud.setCompletionText(null);
     this.hud.setVictoryStoryActive(false);
@@ -1605,6 +1649,7 @@ export class RaptorGame implements IGame {
     if (this.thrustSheet) this.player.setThrustSheet(this.thrustSheet);
 
     this.levelElapsed = 0;
+    this.achievementCheckTimer = 0;
     this.nextStoryMessageIndex = 0;
     this.hud.setCompletionText(null);
     this.hud.setVictoryStoryActive(false);

--- a/src/games/raptor/systems/achievements/AchievementManager.ts
+++ b/src/games/raptor/systems/achievements/AchievementManager.ts
@@ -1,0 +1,250 @@
+import type { AchievementDefinition, AchievementCondition, UnlockedAchievement } from "../../types";
+import type { PlayerStats } from "./PlayerStatsTracker";
+import type { PlayerStatsTracker } from "./PlayerStatsTracker";
+import { ACHIEVEMENT_DEFINITIONS } from "./AchievementDefinitions";
+
+export type AchievementEventType =
+  | "ram_kill"
+  | "no_damage_level"
+  | "armor_below_10pct"
+  | "level_complete"
+  | "weapon_tier_3"
+  | "bombs_at_max"
+  | "level_under_2min";
+
+const STAT_RESOLVERS: Record<string, (stats: PlayerStats) => number> = {
+  total_kills: (s) => s.totalKills,
+  bosses_killed: (s) => s.bossesDefeated,
+  levels_completed: (s) => s.levelsCompleted,
+  total_score: (s) => s.totalScore,
+  power_ups_collected: (s) => s.totalPowerUpsCollected,
+  unique_weapons_owned: (s) => s.weaponsOwned.length,
+  total_emps: (s) => s.totalEmpsUsed,
+  total_reflects: (s) => s.projectilesReflected,
+  deaths_survived: (s) => s.totalDeaths,
+  total_dodges: (s) => s.totalDodgesUsed,
+};
+
+function resolveStat(key: string, stats: PlayerStats): number {
+  const resolver = STAT_RESOLVERS[key];
+  if (resolver) return resolver(stats);
+  console.warn(`[AchievementManager] Unknown stat key: "${key}"`);
+  return 0;
+}
+
+export class AchievementManager {
+  private unlockedAchievements: Map<string, UnlockedAchievement> = new Map();
+  private statsTracker: PlayerStatsTracker;
+  private _onUnlock: ((achievement: AchievementDefinition) => void) | null = null;
+  private compositeEventState: Map<string, Set<string>> = new Map();
+
+  constructor(statsTracker: PlayerStatsTracker) {
+    this.statsTracker = statsTracker;
+  }
+
+  set onUnlock(callback: ((achievement: AchievementDefinition) => void) | null) {
+    this._onUnlock = callback;
+  }
+
+  get onUnlock(): ((achievement: AchievementDefinition) => void) | null {
+    return this._onUnlock;
+  }
+
+  checkAchievements(): AchievementDefinition[] {
+    const stats = this.statsTracker.getStats();
+    const newlyUnlocked: AchievementDefinition[] = [];
+
+    for (const def of ACHIEVEMENT_DEFINITIONS) {
+      if (this.unlockedAchievements.has(def.id)) continue;
+
+      if (def.condition.type === "single_event") continue;
+
+      if (this.evaluateCondition(def.id, def.condition, stats)) {
+        this.unlock(def);
+        newlyUnlocked.push(def);
+      }
+    }
+
+    return newlyUnlocked;
+  }
+
+  fireEvent(eventType: string): AchievementDefinition[] {
+    const newlyUnlocked: AchievementDefinition[] = [];
+
+    for (const def of ACHIEVEMENT_DEFINITIONS) {
+      if (this.unlockedAchievements.has(def.id)) continue;
+
+      if (def.condition.type === "single_event" && def.condition.eventType === eventType) {
+        this.unlock(def);
+        newlyUnlocked.push(def);
+        continue;
+      }
+
+      if (def.condition.type === "composite" && def.condition.conditions) {
+        let hasMatchingSingleEvent = false;
+        for (const sub of def.condition.conditions) {
+          if (sub.type === "single_event" && sub.eventType === eventType) {
+            hasMatchingSingleEvent = true;
+            break;
+          }
+        }
+        if (hasMatchingSingleEvent) {
+          let eventSet = this.compositeEventState.get(def.id);
+          if (!eventSet) {
+            eventSet = new Set();
+            this.compositeEventState.set(def.id, eventSet);
+          }
+          eventSet.add(eventType);
+
+          const stats = this.statsTracker.getStats();
+          if (this.evaluateCondition(def.id, def.condition, stats)) {
+            this.unlock(def);
+            newlyUnlocked.push(def);
+          }
+        }
+      }
+    }
+
+    return newlyUnlocked;
+  }
+
+  isUnlocked(id: string): boolean {
+    return this.unlockedAchievements.has(id);
+  }
+
+  getProgress(id: string): { current: number; target: number; percentage: number } {
+    const def = ACHIEVEMENT_DEFINITIONS.find((d) => d.id === id);
+    if (!def) return { current: 0, target: 0, percentage: 0 };
+
+    const condition = def.condition;
+
+    if (condition.type === "stat_threshold") {
+      const stats = this.statsTracker.getStats();
+      const current = resolveStat(condition.stat!, stats);
+      const target = condition.threshold!;
+      const percentage = target > 0 ? Math.min(100, (current / target) * 100) : 100;
+      return { current, target, percentage };
+    }
+
+    if (condition.type === "single_event") {
+      const unlocked = this.isUnlocked(id);
+      return {
+        current: unlocked ? 1 : 0,
+        target: 1,
+        percentage: unlocked ? 100 : 0,
+      };
+    }
+
+    if (condition.type === "composite" && condition.conditions) {
+      const stats = this.statsTracker.getStats();
+      const total = condition.conditions.length;
+      if (total === 0) return { current: 0, target: 0, percentage: 100 };
+
+      let satisfied = 0;
+      const eventSet = this.compositeEventState.get(id);
+      for (const sub of condition.conditions) {
+        if (this.evaluateSubCondition(id, sub, stats)) {
+          satisfied++;
+        }
+      }
+      if (this.isUnlocked(id)) satisfied = total;
+      const percentage = Math.min(100, (satisfied / total) * 100);
+      return { current: satisfied, target: total, percentage };
+    }
+
+    return { current: 0, target: 0, percentage: 0 };
+  }
+
+  getAllAchievements(): {
+    definition: AchievementDefinition;
+    unlocked: boolean;
+    progress: number;
+  }[] {
+    return ACHIEVEMENT_DEFINITIONS.map((def) => ({
+      definition: def,
+      unlocked: this.isUnlocked(def.id),
+      progress: this.getProgress(def.id).percentage,
+    }));
+  }
+
+  getUnlocked(): UnlockedAchievement[] {
+    return Array.from(this.unlockedAchievements.values());
+  }
+
+  loadUnlocked(achievements: UnlockedAchievement[]): void {
+    for (const a of achievements) {
+      if (!this.unlockedAchievements.has(a.id)) {
+        this.unlockedAchievements.set(a.id, a);
+      }
+    }
+  }
+
+  reset(): void {
+    this.unlockedAchievements.clear();
+    this.compositeEventState.clear();
+  }
+
+  private unlock(def: AchievementDefinition): void {
+    const unlocked: UnlockedAchievement = {
+      id: def.id,
+      unlockedAt: Date.now(),
+    };
+    this.unlockedAchievements.set(def.id, unlocked);
+    this.compositeEventState.delete(def.id);
+
+    if (this._onUnlock) {
+      try {
+        this._onUnlock(def);
+      } catch (err) {
+        console.error("[AchievementManager] onUnlock callback error:", err);
+      }
+    }
+  }
+
+  private evaluateCondition(
+    achievementId: string,
+    condition: AchievementCondition,
+    stats: PlayerStats,
+  ): boolean {
+    switch (condition.type) {
+      case "stat_threshold":
+        return resolveStat(condition.stat!, stats) >= (condition.threshold ?? 0);
+
+      case "single_event":
+        return this.isUnlocked(achievementId);
+
+      case "composite": {
+        const subs = condition.conditions ?? [];
+        return subs.every((sub) =>
+          this.evaluateSubCondition(achievementId, sub, stats),
+        );
+      }
+
+      default:
+        return false;
+    }
+  }
+
+  private evaluateSubCondition(
+    achievementId: string,
+    condition: AchievementCondition,
+    stats: PlayerStats,
+  ): boolean {
+    if (condition.type === "stat_threshold") {
+      return resolveStat(condition.stat!, stats) >= (condition.threshold ?? 0);
+    }
+
+    if (condition.type === "single_event") {
+      const eventSet = this.compositeEventState.get(achievementId);
+      return eventSet?.has(condition.eventType!) ?? false;
+    }
+
+    if (condition.type === "composite" && condition.conditions) {
+      return condition.conditions.every((sub) =>
+        this.evaluateSubCondition(achievementId, sub, stats),
+      );
+    }
+
+    return false;
+  }
+}

--- a/tests/raptor-achievement-manager.test.ts
+++ b/tests/raptor-achievement-manager.test.ts
@@ -1,0 +1,514 @@
+import { AchievementManager } from "../src/games/raptor/systems/achievements/AchievementManager";
+import { PlayerStatsTracker } from "../src/games/raptor/systems/achievements/PlayerStatsTracker";
+import { ACHIEVEMENT_DEFINITIONS } from "../src/games/raptor/systems/achievements/AchievementDefinitions";
+import type { AchievementDefinition } from "../src/games/raptor/types";
+
+describe("AchievementManager", () => {
+  let tracker: PlayerStatsTracker;
+  let manager: AchievementManager;
+  let unlockLog: AchievementDefinition[];
+
+  beforeEach(() => {
+    tracker = new PlayerStatsTracker();
+    manager = new AchievementManager(tracker);
+    unlockLog = [];
+    manager.onUnlock = (a) => unlockLog.push(a);
+  });
+
+  // ── stat_threshold evaluation ──────────────────────────────────
+
+  describe("stat_threshold evaluation", () => {
+    it("unlocks first_blood when total_kills >= 1", () => {
+      tracker.recordKill("scout", 10, false);
+      const unlocked = manager.checkAchievements();
+      expect(unlocked.some((a) => a.id === "first_blood")).toBe(true);
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+      expect(unlockLog.some((a) => a.id === "first_blood")).toBe(true);
+    });
+
+    it("does not unlock century_kills below threshold", () => {
+      for (let i = 0; i < 50; i++) tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("century_kills")).toBe(false);
+    });
+
+    it("unlocks century_kills when threshold is exceeded", () => {
+      for (let i = 0; i < 105; i++) tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("century_kills")).toBe(true);
+    });
+
+    it("unlocks high_scorer at exact threshold", () => {
+      tracker.updateScore(100000, 100000);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("high_scorer")).toBe(true);
+    });
+
+    it("unlocks boss_slayer when a boss is killed", () => {
+      tracker.recordKill("boss", 400, true);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("boss_slayer")).toBe(true);
+    });
+
+    it("unlocks nine_lives after 9 deaths", () => {
+      for (let i = 0; i < 9; i++) tracker.recordDeath();
+      manager.checkAchievements();
+      expect(manager.isUnlocked("nine_lives")).toBe(true);
+    });
+
+    it("unlocks dodge_master after 50 dodges", () => {
+      for (let i = 0; i < 50; i++) tracker.recordDodge();
+      manager.checkAchievements();
+      expect(manager.isUnlocked("dodge_master")).toBe(true);
+    });
+
+    it("unlocks halfway_there after 5 levels completed", () => {
+      for (let i = 0; i < 5; i++) tracker.recordLevelComplete(i, 100, 0);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("halfway_there")).toBe(true);
+    });
+
+    it("unlocks power_hungry after 50 power-ups collected", () => {
+      for (let i = 0; i < 50; i++) tracker.recordPowerUpCollected("repair-kit");
+      manager.checkAchievements();
+      expect(manager.isUnlocked("power_hungry")).toBe(true);
+    });
+
+    it("unlocks fully_loaded when 7 unique weapons owned", () => {
+      const weapons = ["missile", "laser", "plasma", "ion-cannon", "auto-gun", "rocket"];
+      for (const w of weapons) tracker.recordWeaponUpgrade(w, 1);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("fully_loaded")).toBe(true);
+    });
+
+    it("unlocks emp_expert after 25 EMPs", () => {
+      for (let i = 0; i < 25; i++) tracker.recordEmp();
+      manager.checkAchievements();
+      expect(manager.isUnlocked("emp_expert")).toBe(true);
+    });
+
+    it("unlocks deflector_pro after 10 reflects", () => {
+      for (let i = 0; i < 10; i++) tracker.recordReflect();
+      manager.checkAchievements();
+      expect(manager.isUnlocked("deflector_pro")).toBe(true);
+    });
+  });
+
+  // ── single_event evaluation ────────────────────────────────────
+
+  describe("single_event evaluation", () => {
+    it("unlocks ramming_speed on ram_kill event", () => {
+      const unlocked = manager.fireEvent("ram_kill");
+      expect(unlocked.some((a) => a.id === "ramming_speed")).toBe(true);
+      expect(manager.isUnlocked("ramming_speed")).toBe(true);
+      expect(unlockLog.some((a) => a.id === "ramming_speed")).toBe(true);
+    });
+
+    it("unlocks untouchable on no_damage_level event", () => {
+      manager.fireEvent("no_damage_level");
+      expect(manager.isUnlocked("untouchable")).toBe(true);
+    });
+
+    it("does not unlock untouchable without the event", () => {
+      manager.checkAchievements();
+      expect(manager.isUnlocked("untouchable")).toBe(false);
+    });
+
+    it("unlocks close_call on armor_below_10pct event", () => {
+      manager.fireEvent("armor_below_10pct");
+      expect(manager.isUnlocked("close_call")).toBe(true);
+    });
+
+    it("unlocks speedrunner on level_under_2min event", () => {
+      manager.fireEvent("level_under_2min");
+      expect(manager.isUnlocked("speedrunner")).toBe(true);
+    });
+
+    it("does not unlock speedrunner without the event", () => {
+      manager.checkAchievements();
+      expect(manager.isUnlocked("speedrunner")).toBe(false);
+    });
+
+    it("unlocks max_tier on weapon_tier_3 event", () => {
+      manager.fireEvent("weapon_tier_3");
+      expect(manager.isUnlocked("max_tier")).toBe(true);
+    });
+
+    it("unlocks bomb_hoarder on bombs_at_max event", () => {
+      manager.fireEvent("bombs_at_max");
+      expect(manager.isUnlocked("bomb_hoarder")).toBe(true);
+    });
+
+    it("unlocks first_sortie on level_complete event", () => {
+      manager.fireEvent("level_complete");
+      expect(manager.isUnlocked("first_sortie")).toBe(true);
+    });
+
+    it("checkAchievements does not unlock single_event achievements by stat alone", () => {
+      for (let i = 0; i < 100; i++) tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("ramming_speed")).toBe(false);
+    });
+  });
+
+  // ── Idempotency / no duplicates ────────────────────────────────
+
+  describe("idempotency", () => {
+    it("achievement unlocks exactly once despite repeated checkAchievements", () => {
+      for (let i = 0; i < 5; i++) tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      manager.checkAchievements();
+      manager.checkAchievements();
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+      const firstBloodCallbacks = unlockLog.filter((a) => a.id === "first_blood");
+      expect(firstBloodCallbacks.length).toBe(1);
+    });
+
+    it("firing the same event twice does not re-trigger unlock", () => {
+      manager.fireEvent("ram_kill");
+      manager.fireEvent("ram_kill");
+      expect(manager.isUnlocked("ramming_speed")).toBe(true);
+      const rammingCallbacks = unlockLog.filter((a) => a.id === "ramming_speed");
+      expect(rammingCallbacks.length).toBe(1);
+    });
+  });
+
+  // ── Progress tracking ─────────────────────────────────────────
+
+  describe("progress tracking", () => {
+    it("returns accurate partial progress for stat_threshold", () => {
+      for (let i = 0; i < 42; i++) tracker.recordKill("scout", 10, false);
+      const progress = manager.getProgress("century_kills");
+      expect(progress.current).toBe(42);
+      expect(progress.target).toBe(100);
+      expect(progress.percentage).toBe(42);
+    });
+
+    it("clamps percentage at 100 when stat exceeds threshold", () => {
+      for (let i = 0; i < 10; i++) tracker.recordKill("scout", 10, false);
+      const progress = manager.getProgress("first_blood");
+      expect(progress.current).toBe(10);
+      expect(progress.target).toBe(1);
+      expect(progress.percentage).toBe(100);
+    });
+
+    it("returns 0/1 for locked single_event achievement", () => {
+      const progress = manager.getProgress("ramming_speed");
+      expect(progress.current).toBe(0);
+      expect(progress.target).toBe(1);
+      expect(progress.percentage).toBe(0);
+    });
+
+    it("returns 1/1 for unlocked single_event achievement", () => {
+      manager.fireEvent("ram_kill");
+      const progress = manager.getProgress("ramming_speed");
+      expect(progress.current).toBe(1);
+      expect(progress.target).toBe(1);
+      expect(progress.percentage).toBe(100);
+    });
+
+    it("returns zeros for unknown achievement id", () => {
+      const progress = manager.getProgress("nonexistent_achievement");
+      expect(progress.current).toBe(0);
+      expect(progress.target).toBe(0);
+      expect(progress.percentage).toBe(0);
+    });
+  });
+
+  // ── getAllAchievements ──────────────────────────────────────────
+
+  describe("getAllAchievements", () => {
+    it("returns the full list of 21 achievements", () => {
+      const all = manager.getAllAchievements();
+      expect(all.length).toBe(ACHIEVEMENT_DEFINITIONS.length);
+      expect(all.length).toBe(21);
+    });
+
+    it("reflects unlock status correctly", () => {
+      tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      const all = manager.getAllAchievements();
+      const firstBlood = all.find((a) => a.definition.id === "first_blood");
+      const century = all.find((a) => a.definition.id === "century_kills");
+      expect(firstBlood?.unlocked).toBe(true);
+      expect(century?.unlocked).toBe(false);
+      expect(century?.progress).toBe(1);
+    });
+
+    it("shows progress for stat_threshold achievements", () => {
+      for (let i = 0; i < 50; i++) tracker.recordKill("scout", 10, false);
+      for (let i = 0; i < 20; i++) tracker.recordPowerUpCollected("repair-kit");
+      const all = manager.getAllAchievements();
+      const century = all.find((a) => a.definition.id === "century_kills");
+      const power = all.find((a) => a.definition.id === "power_hungry");
+      expect(century?.progress).toBe(50);
+      expect(power?.progress).toBe(40);
+    });
+  });
+
+  // ── Composite conditions ───────────────────────────────────────
+
+  describe("composite conditions", () => {
+    it("does not unlock when only some sub-conditions are met", () => {
+      const originalDefs = [...ACHIEVEMENT_DEFINITIONS];
+      const compositeDef: AchievementDefinition = {
+        id: "test_composite",
+        name: "Test Composite",
+        description: "Test",
+        icon: "test",
+        category: "combat",
+        condition: {
+          type: "composite",
+          conditions: [
+            { type: "stat_threshold", stat: "total_kills", threshold: 10 },
+            { type: "stat_threshold", stat: "total_score", threshold: 500 },
+          ],
+        },
+      };
+
+      (ACHIEVEMENT_DEFINITIONS as any).push(compositeDef);
+      try {
+        for (let i = 0; i < 10; i++) tracker.recordKill("scout", 10, false);
+        tracker.updateScore(200, 200);
+        manager.checkAchievements();
+        expect(manager.isUnlocked("test_composite")).toBe(false);
+      } finally {
+        (ACHIEVEMENT_DEFINITIONS as any).length = originalDefs.length;
+      }
+    });
+
+    it("unlocks when all sub-conditions are met", () => {
+      const originalLength = ACHIEVEMENT_DEFINITIONS.length;
+      const compositeDef: AchievementDefinition = {
+        id: "test_composite_2",
+        name: "Test Composite 2",
+        description: "Test",
+        icon: "test",
+        category: "combat",
+        condition: {
+          type: "composite",
+          conditions: [
+            { type: "stat_threshold", stat: "total_kills", threshold: 10 },
+            { type: "stat_threshold", stat: "total_score", threshold: 500 },
+          ],
+        },
+      };
+
+      (ACHIEVEMENT_DEFINITIONS as any).push(compositeDef);
+      try {
+        for (let i = 0; i < 10; i++) tracker.recordKill("scout", 10, false);
+        tracker.updateScore(500, 500);
+        manager.checkAchievements();
+        expect(manager.isUnlocked("test_composite_2")).toBe(true);
+      } finally {
+        (ACHIEVEMENT_DEFINITIONS as any).length = originalLength;
+      }
+    });
+
+    it("tracks single_event sub-conditions in composite achievements", () => {
+      const originalLength = ACHIEVEMENT_DEFINITIONS.length;
+      const compositeDef: AchievementDefinition = {
+        id: "test_composite_event",
+        name: "Test Composite Event",
+        description: "Test",
+        icon: "test",
+        category: "combat",
+        condition: {
+          type: "composite",
+          conditions: [
+            { type: "single_event", eventType: "ram_kill" },
+            { type: "stat_threshold", stat: "total_kills", threshold: 5 },
+          ],
+        },
+      };
+
+      (ACHIEVEMENT_DEFINITIONS as any).push(compositeDef);
+      try {
+        manager.fireEvent("ram_kill");
+        for (let i = 0; i < 3; i++) tracker.recordKill("scout", 10, false);
+        manager.checkAchievements();
+        expect(manager.isUnlocked("test_composite_event")).toBe(false);
+
+        for (let i = 0; i < 2; i++) tracker.recordKill("scout", 10, false);
+        manager.checkAchievements();
+        expect(manager.isUnlocked("test_composite_event")).toBe(true);
+      } finally {
+        (ACHIEVEMENT_DEFINITIONS as any).length = originalLength;
+      }
+    });
+
+    it("empty composite conditions array unlocks immediately", () => {
+      const originalLength = ACHIEVEMENT_DEFINITIONS.length;
+      const compositeDef: AchievementDefinition = {
+        id: "test_empty_composite",
+        name: "Test Empty",
+        description: "Test",
+        icon: "test",
+        category: "combat",
+        condition: { type: "composite", conditions: [] },
+      };
+
+      (ACHIEVEMENT_DEFINITIONS as any).push(compositeDef);
+      try {
+        manager.checkAchievements();
+        expect(manager.isUnlocked("test_empty_composite")).toBe(true);
+      } finally {
+        (ACHIEVEMENT_DEFINITIONS as any).length = originalLength;
+      }
+    });
+  });
+
+  // ── Callback error isolation ───────────────────────────────────
+
+  describe("callback error isolation", () => {
+    it("onUnlock callback error does not prevent other unlocks", () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      manager.onUnlock = () => {
+        throw new Error("callback error");
+      };
+
+      tracker.recordKill("scout", 10, false);
+      tracker.recordLevelComplete(0, 100, 0);
+      manager.fireEvent("level_complete");
+      manager.checkAchievements();
+
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+      expect(manager.isUnlocked("first_sortie")).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── Save/load support ─────────────────────────────────────────
+
+  describe("save/load support", () => {
+    it("loadUnlocked restores previously unlocked achievements", () => {
+      manager.loadUnlocked([
+        { id: "first_blood", unlockedAt: 1710000000000 },
+        { id: "boss_slayer", unlockedAt: 1710000100000 },
+      ]);
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+      expect(manager.isUnlocked("boss_slayer")).toBe(true);
+      expect(unlockLog.length).toBe(0);
+    });
+
+    it("loadUnlocked merges with runtime unlocks", () => {
+      tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+
+      manager.loadUnlocked([{ id: "boss_slayer", unlockedAt: 1710000000000 }]);
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+      expect(manager.isUnlocked("boss_slayer")).toBe(true);
+    });
+
+    it("loadUnlocked does not overwrite existing runtime unlocks", () => {
+      tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+
+      const beforeTimestamp = manager.getUnlocked().find((a) => a.id === "first_blood")?.unlockedAt;
+      manager.loadUnlocked([{ id: "first_blood", unlockedAt: 1710000000000 }]);
+      const afterTimestamp = manager.getUnlocked().find((a) => a.id === "first_blood")?.unlockedAt;
+
+      expect(afterTimestamp).toBe(beforeTimestamp);
+    });
+
+    it("getUnlocked returns all unlocked achievements", () => {
+      tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      manager.fireEvent("ram_kill");
+
+      const unlocked = manager.getUnlocked();
+      expect(unlocked.some((a) => a.id === "first_blood")).toBe(true);
+      expect(unlocked.some((a) => a.id === "ramming_speed")).toBe(true);
+    });
+  });
+
+  // ── Reset ──────────────────────────────────────────────────────
+
+  describe("reset", () => {
+    it("clears all unlocked achievements", () => {
+      tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+
+      manager.reset();
+      expect(manager.isUnlocked("first_blood")).toBe(false);
+      expect(manager.getUnlocked().length).toBe(0);
+    });
+  });
+
+  // ── Stat resolution edge cases ────────────────────────────────
+
+  describe("stat resolution edge cases", () => {
+    it("derived stat unique_weapons_owned resolves from array length", () => {
+      const weapons = ["missile", "laser", "plasma", "ion-cannon", "auto-gun", "rocket"];
+      for (const w of weapons) tracker.recordWeaponUpgrade(w, 1);
+      manager.checkAchievements();
+      expect(manager.isUnlocked("fully_loaded")).toBe(true);
+    });
+
+    it("unknown stat key resolves to 0 without crashing", () => {
+      const originalLength = ACHIEVEMENT_DEFINITIONS.length;
+      const badDef: AchievementDefinition = {
+        id: "test_unknown_stat",
+        name: "Bad Stat",
+        description: "Test",
+        icon: "test",
+        category: "combat",
+        condition: { type: "stat_threshold", stat: "nonexistent_stat", threshold: 1 },
+      };
+
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      (ACHIEVEMENT_DEFINITIONS as any).push(badDef);
+      try {
+        expect(() => manager.checkAchievements()).not.toThrow();
+        expect(manager.isUnlocked("test_unknown_stat")).toBe(false);
+      } finally {
+        (ACHIEVEMENT_DEFINITIONS as any).length = originalLength;
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  // ── isUnlocked edge cases ─────────────────────────────────────
+
+  describe("isUnlocked edge cases", () => {
+    it("returns false for unknown achievement id", () => {
+      expect(manager.isUnlocked("does_not_exist")).toBe(false);
+    });
+  });
+
+  // ── Multiple simultaneous unlocks ──────────────────────────────
+
+  describe("multiple simultaneous unlocks", () => {
+    it("unlocks multiple achievements in a single checkAchievements call", () => {
+      tracker.recordKill("boss", 400, true);
+      tracker.updateScore(100000, 100000);
+      const unlocked = manager.checkAchievements();
+      expect(unlocked.some((a) => a.id === "first_blood")).toBe(true);
+      expect(unlocked.some((a) => a.id === "boss_slayer")).toBe(true);
+      expect(unlocked.some((a) => a.id === "high_scorer")).toBe(true);
+    });
+  });
+
+  // ── onUnlock setter ────────────────────────────────────────────
+
+  describe("onUnlock setter", () => {
+    it("can be set to null to disable callback", () => {
+      manager.onUnlock = null;
+      tracker.recordKill("scout", 10, false);
+      expect(() => manager.checkAchievements()).not.toThrow();
+      expect(manager.isUnlocked("first_blood")).toBe(true);
+    });
+
+    it("callback receives the correct achievement definition", () => {
+      tracker.recordKill("scout", 10, false);
+      manager.checkAchievements();
+      const firstBloodCb = unlockLog.find((a) => a.id === "first_blood");
+      expect(firstBloodCb).toBeDefined();
+      expect(firstBloodCb?.name).toBe("First Blood");
+      expect(firstBloodCb?.category).toBe("combat");
+    });
+  });
+});


### PR DESCRIPTION
## PR: Achievement system — Implement achievement evaluation engine (Issue #716, epic #608)

### Summary (what changed & why)
This PR introduces the **runtime achievement evaluation engine** for Raptor by adding an `AchievementManager` that bridges **player stat tracking** (`PlayerStatsTracker`) with **static achievement definitions** (`ACHIEVEMENT_DEFINITIONS`).  

Key goals:
- Evaluate achievement conditions against current player stats and/or game events.
- Unlock achievements **exactly once**, firing an `onUnlock` callback for newly unlocked achievements.
- Expose **progress data** for UI rendering (current/target/%), including composite progress.
- Provide basic **save/load hooks** (`getUnlocked` / `loadUnlocked`) for future persistence work.

### Key changes
- Added `AchievementManager` with support for:
  - `stat_threshold` conditions (stat >= threshold)
  - `single_event` conditions (unlock via explicit `fireEvent(eventType)`)
  - `composite` conditions (all sub-conditions satisfied; tracks fired events per achievement)
- Implemented a **stat resolver map** to safely map definition `snake_case` stat keys to `PlayerStats` camelCase fields and derived values (e.g., `unique_weapons_owned → weaponsOwned.length`).
- Integrated achievement checks/events into `RaptorGame.ts` at the intended gameplay milestones (kills, level completion, powerups, score updates, damage events, and periodic polling).
- Added unit test coverage for all condition types, idempotency, progress reporting, callback error isolation, save/load behavior, and edge cases.

### Files changed / added
- **Added:** `src/games/raptor/systems/achievements/AchievementManager.ts`  
  Core engine implementation (evaluation, unlock state, progress, events, composite tracking, save/load helpers).
- **Modified:** `src/games/raptor/RaptorGame.ts`  
  Instantiates and wires `AchievementManager`, fires achievement events, triggers checks at key integration points, adds a 5s periodic evaluation timer, resets manager on new game.
- **Added/Updated:** Unit tests (48 total) covering evaluation logic, progress calculation, and integration-related behaviors (exact test file paths depend on repo test layout).

### Behavior notes / implementation highlights
- **Idempotent evaluation:** repeated `checkAchievements()` / `fireEvent()` calls will not duplicate unlocks.
- **Callback safety:** `onUnlock` is wrapped with try/catch so a failing callback won’t block other unlocks.
- **Progress reporting:**
  - Threshold: `{ current, target, percentage }` with percentage clamped to 100.
  - Single-event: 0/1 or 1/1 progress.
  - Composite: percentage based on satisfied sub-conditions.
- **Forward-compatible persistence:** `loadUnlocked()` merges without re-firing `onUnlock`.

### Testing notes
- **Unit tests:** Added **48 tests** covering:
  - `stat_threshold`, `single_event`, and `composite` evaluation (including composites with event sub-conditions)
  - Unlock idempotency (no duplicate unlocks / callbacks)
  - `getProgress()` accuracy & clamping
  - `getAllAchievements()` status/progress output
  - Unknown stat keys and unknown achievement IDs (safe defaults, no crash)
  - Callback error isolation
  - `loadUnlocked()` merge behavior without triggering callbacks
- **Manual sanity checks (recommended):**
  - Start a run, trigger kill/score/powerup thresholds and confirm unlocks occur once.
  - Verify level-complete events (`level_complete`, `no_damage_level`, `level_under_2min`) fire appropriately.
  - Trigger event-based unlocks: `ram_kill`, `armor_below_10pct`, `weapon_tier_3`, `bombs_at_max`.
  - Let gameplay run >5 seconds to confirm periodic checks execute without side effects.

--- 

### Related
- Depends on prior work for **achievement definitions** (#714) and **player stats tracking** (merged via #723).

Ref: https://github.com/asgardtech/archer/issues/716