### PR TITLE
Achievement system: Persist achievements and stats to storage

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -39,6 +39,7 @@ import { GAME_STORY, getActForLevel } from "./story";
 import { IGame } from "../../shared/types";
 import { AudioManager } from "../../shared/AudioManager";
 import { SettingsStorage } from "../../shared/storage";
+import { AchievementStorage } from "./systems/achievements/AchievementStorage";
 
 const DT_CAP = 0.1;
 const MAX_ENEMY_BULLETS = 30;
@@ -186,7 +187,7 @@ export class RaptorGame implements IGame {
 
     this.perfManager = new PerformanceManager();
     this.achievementManager = new AchievementManager(this.statsTracker);
-    this.achievementManager.onUnlock = (_a) => { /* future: toast notification */ };
+    this.achievementManager.onUnlock = (_a) => { this.saveAchievements(); };
     this.initStars(60);
     this.setupResize();
   }
@@ -285,6 +286,10 @@ export class RaptorGame implements IGame {
     this.audio.sfxVolume = settings.sfxVolume;
     if (settings.muted) this.audio.muted = true;
     this.showFps = settings.showFps;
+
+    const achievementData = await AchievementStorage.load();
+    this.achievementManager.loadUnlocked(achievementData.unlockedAchievements);
+    this.statsTracker.deserialize(achievementData.playerStats);
 
     await this.refreshSaveStatus();
     this.state = "menu";
@@ -1254,6 +1259,7 @@ export class RaptorGame implements IGame {
       this.statsTracker.recordDeath();
       this.totalScore += this.score;
       this.weaponSystem.laserBeam.active = false;
+      this.saveAchievements();
       this.sound.stopMusic();
       this.sound.play("game_over");
       this.state = "gameover";
@@ -1273,6 +1279,7 @@ export class RaptorGame implements IGame {
         this.achievementManager.fireEvent("level_under_2min");
       }
       this.achievementManager.checkAchievements();
+      this.saveAchievements();
 
       this.projectiles = [];
       this.enemyBullets = [];
@@ -1462,11 +1469,17 @@ export class RaptorGame implements IGame {
     }).catch(() => {});
   }
 
+  private saveAchievements(): void {
+    AchievementStorage.save(
+      this.achievementManager.getUnlocked(),
+      this.statsTracker.serialize(),
+    ).catch(console.error);
+  }
+
   private resetGame(): void {
     this.totalScore = 0;
     this.playTimeSeconds = 0;
-    this.statsTracker.resetAll();
-    this.achievementManager.reset();
+    this.statsTracker.resetLevelStats();
     this.vfx.reset();
     this.hud.setCompletionText(null);
     this.hud.setVictoryStoryActive(false);

--- a/src/games/raptor/systems/achievements/AchievementStorage.ts
+++ b/src/games/raptor/systems/achievements/AchievementStorage.ts
@@ -1,0 +1,242 @@
+import type { UnlockedAchievement } from "../../types";
+import type { PlayerStats } from "./PlayerStatsTracker";
+import { getStorageBackend } from "../../../../shared/storage";
+
+export const ACHIEVEMENT_SAVE_VERSION = 1;
+
+interface AchievementSaveData {
+  version: number;
+  unlockedAchievements: UnlockedAchievement[];
+  playerStats: PlayerStats;
+  checksum: string;
+}
+
+const MIGRATIONS: readonly {
+  fromVersion: number;
+  toVersion: number;
+  migrate(data: Record<string, unknown>): Record<string, unknown>;
+}[] = [];
+
+function defaultStats(): PlayerStats {
+  return {
+    totalKills: 0,
+    killsByVariant: {},
+    bossesDefeated: 0,
+    ramKills: 0,
+    totalScore: 0,
+    levelsCompleted: 0,
+    highestLevelCompleted: 0,
+    totalDeaths: 0,
+    totalDodgesUsed: 0,
+    totalEmpsUsed: 0,
+    totalPowerUpsCollected: 0,
+    powerUpsByType: {},
+    weaponsOwned: ["machine-gun"],
+    highestWeaponTier: 0,
+    projectilesReflected: 0,
+    totalPlayTimeSeconds: 0,
+    fastestLevelCompletionSeconds: {},
+    damageTakenThisLevel: 0,
+    lowestArmorSurvived: 100,
+  };
+}
+
+export class AchievementStorage {
+  private static readonly ACHIEVEMENTS_KEY = "raptor_achievements";
+
+  private static fnv1aHash(input: string): string {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+      hash ^= input.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+  }
+
+  private static computeChecksum(data: Record<string, unknown>): string {
+    const copy = { ...data };
+    delete copy.checksum;
+    return AchievementStorage.fnv1aHash(JSON.stringify(copy));
+  }
+
+  static async load(): Promise<{
+    unlockedAchievements: UnlockedAchievement[];
+    playerStats: PlayerStats;
+  }> {
+    const defaults = {
+      unlockedAchievements: [] as UnlockedAchievement[],
+      playerStats: defaultStats(),
+    };
+
+    try {
+      const backend = getStorageBackend();
+      const raw = await backend.get(AchievementStorage.ACHIEVEMENTS_KEY);
+      if (raw === null) return defaults;
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        console.warn("[AchievementStorage] Corrupted JSON, resetting to defaults");
+        return defaults;
+      }
+
+      if (typeof parsed !== "object" || parsed === null) return defaults;
+
+      // Checksum validation
+      if (parsed.checksum !== undefined) {
+        const stored = parsed.checksum;
+        const computed = AchievementStorage.computeChecksum(parsed);
+        if (computed !== stored) {
+          console.warn("[AchievementStorage] Achievement data integrity check failed, resetting to defaults");
+          return defaults;
+        }
+      }
+
+      // Version validation
+      const version = parsed.version;
+      if (typeof version !== "number" || !Number.isInteger(version) || version < 1) {
+        return defaults;
+      }
+      if (version > ACHIEVEMENT_SAVE_VERSION) {
+        console.warn("[AchievementStorage] Future version detected, resetting to defaults");
+        return defaults;
+      }
+
+      // Run migrations
+      let data = parsed;
+      let currentVersion = version;
+      for (const migration of MIGRATIONS) {
+        if (currentVersion === ACHIEVEMENT_SAVE_VERSION) break;
+        if (migration.fromVersion === currentVersion) {
+          data = migration.migrate(data);
+          currentVersion = data.version as number;
+        }
+      }
+      if (currentVersion !== ACHIEVEMENT_SAVE_VERSION) return defaults;
+
+      // Validate unlocked achievements
+      const rawAchievements = data.unlockedAchievements;
+      const validAchievements: UnlockedAchievement[] = [];
+      if (Array.isArray(rawAchievements)) {
+        for (const entry of rawAchievements) {
+          if (
+            entry &&
+            typeof entry === "object" &&
+            typeof (entry as Record<string, unknown>).id === "string" &&
+            (entry as Record<string, unknown>).id !== "" &&
+            typeof (entry as Record<string, unknown>).unlockedAt === "number" &&
+            Number.isFinite((entry as Record<string, unknown>).unlockedAt as number)
+          ) {
+            validAchievements.push({
+              id: (entry as Record<string, unknown>).id as string,
+              unlockedAt: (entry as Record<string, unknown>).unlockedAt as number,
+            });
+          }
+        }
+      }
+
+      // Validate player stats
+      const rawStats = data.playerStats;
+      const stats = defaultStats();
+      if (rawStats && typeof rawStats === "object" && !Array.isArray(rawStats)) {
+        const s = rawStats as Record<string, unknown>;
+
+        if (typeof s.totalKills === "number" && s.totalKills >= 0 && Number.isInteger(s.totalKills)) stats.totalKills = s.totalKills;
+        if (typeof s.bossesDefeated === "number" && s.bossesDefeated >= 0 && Number.isInteger(s.bossesDefeated)) stats.bossesDefeated = s.bossesDefeated;
+        if (typeof s.ramKills === "number" && s.ramKills >= 0 && Number.isInteger(s.ramKills)) stats.ramKills = s.ramKills;
+        if (typeof s.totalScore === "number" && s.totalScore >= 0) stats.totalScore = s.totalScore;
+        if (typeof s.levelsCompleted === "number" && s.levelsCompleted >= 0 && Number.isInteger(s.levelsCompleted)) stats.levelsCompleted = s.levelsCompleted;
+        if (typeof s.highestLevelCompleted === "number" && s.highestLevelCompleted >= 0 && Number.isInteger(s.highestLevelCompleted)) stats.highestLevelCompleted = s.highestLevelCompleted;
+        if (typeof s.totalDeaths === "number" && s.totalDeaths >= 0 && Number.isInteger(s.totalDeaths)) stats.totalDeaths = s.totalDeaths;
+        if (typeof s.totalDodgesUsed === "number" && s.totalDodgesUsed >= 0 && Number.isInteger(s.totalDodgesUsed)) stats.totalDodgesUsed = s.totalDodgesUsed;
+        if (typeof s.totalEmpsUsed === "number" && s.totalEmpsUsed >= 0 && Number.isInteger(s.totalEmpsUsed)) stats.totalEmpsUsed = s.totalEmpsUsed;
+        if (typeof s.totalPowerUpsCollected === "number" && s.totalPowerUpsCollected >= 0 && Number.isInteger(s.totalPowerUpsCollected)) stats.totalPowerUpsCollected = s.totalPowerUpsCollected;
+        if (typeof s.highestWeaponTier === "number" && s.highestWeaponTier >= 0 && s.highestWeaponTier <= 3 && Number.isInteger(s.highestWeaponTier)) stats.highestWeaponTier = s.highestWeaponTier;
+        if (typeof s.projectilesReflected === "number" && s.projectilesReflected >= 0 && Number.isInteger(s.projectilesReflected)) stats.projectilesReflected = s.projectilesReflected;
+        if (typeof s.totalPlayTimeSeconds === "number" && s.totalPlayTimeSeconds >= 0) stats.totalPlayTimeSeconds = s.totalPlayTimeSeconds;
+
+        if (s.killsByVariant && typeof s.killsByVariant === "object" && !Array.isArray(s.killsByVariant)) {
+          const merged: Record<string, number> = {};
+          for (const [k, v] of Object.entries(s.killsByVariant as Record<string, unknown>)) {
+            if (typeof v === "number" && v >= 0 && Number.isInteger(v)) merged[k] = v;
+          }
+          stats.killsByVariant = merged;
+        }
+
+        if (s.powerUpsByType && typeof s.powerUpsByType === "object" && !Array.isArray(s.powerUpsByType)) {
+          const merged: Record<string, number> = {};
+          for (const [k, v] of Object.entries(s.powerUpsByType as Record<string, unknown>)) {
+            if (typeof v === "number" && v >= 0 && Number.isInteger(v)) merged[k] = v;
+          }
+          stats.powerUpsByType = merged;
+        }
+
+        if (Array.isArray(s.weaponsOwned)) {
+          const valid = (s.weaponsOwned as unknown[]).filter(
+            (w): w is string => typeof w === "string" && w.length > 0,
+          );
+          stats.weaponsOwned = valid.length > 0 ? valid : ["machine-gun"];
+        }
+
+        if (s.fastestLevelCompletionSeconds && typeof s.fastestLevelCompletionSeconds === "object" && !Array.isArray(s.fastestLevelCompletionSeconds)) {
+          const merged: Record<number, number> = {};
+          for (const [k, v] of Object.entries(s.fastestLevelCompletionSeconds as Record<string, unknown>)) {
+            const key = Number(k);
+            if (!isNaN(key) && typeof v === "number" && v > 0) merged[key] = v;
+          }
+          stats.fastestLevelCompletionSeconds = merged;
+        }
+      }
+
+      // Per-level fields always reset
+      stats.damageTakenThisLevel = 0;
+      stats.lowestArmorSurvived = 100;
+
+      return {
+        unlockedAchievements: validAchievements,
+        playerStats: stats,
+      };
+    } catch {
+      return {
+        unlockedAchievements: [],
+        playerStats: defaultStats(),
+      };
+    }
+  }
+
+  static async save(
+    unlockedAchievements: UnlockedAchievement[],
+    playerStats: PlayerStats,
+  ): Promise<void> {
+    try {
+      const payload: Omit<AchievementSaveData, "checksum"> & { checksum?: string } = {
+        version: ACHIEVEMENT_SAVE_VERSION,
+        unlockedAchievements,
+        playerStats: {
+          ...playerStats,
+          damageTakenThisLevel: 0,
+          lowestArmorSurvived: 100,
+        },
+      };
+
+      const withoutChecksum = JSON.stringify(payload);
+      const checksum = AchievementStorage.fnv1aHash(withoutChecksum);
+      (payload as AchievementSaveData).checksum = checksum;
+
+      const backend = getStorageBackend();
+      await backend.set(AchievementStorage.ACHIEVEMENTS_KEY, JSON.stringify(payload));
+    } catch {
+      // silently ignore — consistent with SettingsStorage/SaveSystem
+    }
+  }
+
+  static async clear(): Promise<void> {
+    try {
+      const backend = getStorageBackend();
+      await backend.remove(AchievementStorage.ACHIEVEMENTS_KEY);
+    } catch {
+      // silently ignore
+    }
+  }
+}

--- a/src/games/raptor/systems/achievements/PlayerStatsTracker.ts
+++ b/src/games/raptor/systems/achievements/PlayerStatsTracker.ts
@@ -135,6 +135,95 @@ export class PlayerStatsTracker {
     this.stats = defaultStats();
   }
 
+  serialize(): PlayerStats {
+    const stats = this.getStats();
+    stats.damageTakenThisLevel = 0;
+    stats.lowestArmorSurvived = 100;
+    return stats;
+  }
+
+  deserialize(saved: Partial<PlayerStats>): void {
+    if (!saved || typeof saved !== "object") return;
+
+    const s = this.stats;
+
+    if (typeof saved.totalKills === "number" && saved.totalKills >= 0 && Number.isInteger(saved.totalKills)) {
+      s.totalKills = saved.totalKills;
+    }
+    if (typeof saved.bossesDefeated === "number" && saved.bossesDefeated >= 0 && Number.isInteger(saved.bossesDefeated)) {
+      s.bossesDefeated = saved.bossesDefeated;
+    }
+    if (typeof saved.ramKills === "number" && saved.ramKills >= 0 && Number.isInteger(saved.ramKills)) {
+      s.ramKills = saved.ramKills;
+    }
+    if (typeof saved.totalScore === "number" && saved.totalScore >= 0) {
+      s.totalScore = saved.totalScore;
+    }
+    if (typeof saved.levelsCompleted === "number" && saved.levelsCompleted >= 0 && Number.isInteger(saved.levelsCompleted)) {
+      s.levelsCompleted = saved.levelsCompleted;
+    }
+    if (typeof saved.highestLevelCompleted === "number" && saved.highestLevelCompleted >= 0 && Number.isInteger(saved.highestLevelCompleted)) {
+      s.highestLevelCompleted = saved.highestLevelCompleted;
+    }
+    if (typeof saved.totalDeaths === "number" && saved.totalDeaths >= 0 && Number.isInteger(saved.totalDeaths)) {
+      s.totalDeaths = saved.totalDeaths;
+    }
+    if (typeof saved.totalDodgesUsed === "number" && saved.totalDodgesUsed >= 0 && Number.isInteger(saved.totalDodgesUsed)) {
+      s.totalDodgesUsed = saved.totalDodgesUsed;
+    }
+    if (typeof saved.totalEmpsUsed === "number" && saved.totalEmpsUsed >= 0 && Number.isInteger(saved.totalEmpsUsed)) {
+      s.totalEmpsUsed = saved.totalEmpsUsed;
+    }
+    if (typeof saved.totalPowerUpsCollected === "number" && saved.totalPowerUpsCollected >= 0 && Number.isInteger(saved.totalPowerUpsCollected)) {
+      s.totalPowerUpsCollected = saved.totalPowerUpsCollected;
+    }
+    if (typeof saved.highestWeaponTier === "number" && saved.highestWeaponTier >= 0 && saved.highestWeaponTier <= 3 && Number.isInteger(saved.highestWeaponTier)) {
+      s.highestWeaponTier = saved.highestWeaponTier;
+    }
+    if (typeof saved.projectilesReflected === "number" && saved.projectilesReflected >= 0 && Number.isInteger(saved.projectilesReflected)) {
+      s.projectilesReflected = saved.projectilesReflected;
+    }
+    if (typeof saved.totalPlayTimeSeconds === "number" && saved.totalPlayTimeSeconds >= 0) {
+      s.totalPlayTimeSeconds = saved.totalPlayTimeSeconds;
+    }
+
+    if (saved.killsByVariant && typeof saved.killsByVariant === "object" && !Array.isArray(saved.killsByVariant)) {
+      const merged: Record<string, number> = {};
+      for (const [k, v] of Object.entries(saved.killsByVariant)) {
+        if (typeof v === "number" && v >= 0 && Number.isInteger(v)) {
+          merged[k] = v;
+        }
+      }
+      s.killsByVariant = merged;
+    }
+
+    if (saved.powerUpsByType && typeof saved.powerUpsByType === "object" && !Array.isArray(saved.powerUpsByType)) {
+      const merged: Record<string, number> = {};
+      for (const [k, v] of Object.entries(saved.powerUpsByType)) {
+        if (typeof v === "number" && v >= 0 && Number.isInteger(v)) {
+          merged[k] = v;
+        }
+      }
+      s.powerUpsByType = merged;
+    }
+
+    if (Array.isArray(saved.weaponsOwned)) {
+      const valid = saved.weaponsOwned.filter((w): w is string => typeof w === "string" && w.length > 0);
+      s.weaponsOwned = valid.length > 0 ? valid : ["machine-gun"];
+    }
+
+    if (saved.fastestLevelCompletionSeconds && typeof saved.fastestLevelCompletionSeconds === "object" && !Array.isArray(saved.fastestLevelCompletionSeconds)) {
+      const merged: Record<number, number> = {};
+      for (const [k, v] of Object.entries(saved.fastestLevelCompletionSeconds)) {
+        const key = Number(k);
+        if (!isNaN(key) && typeof v === "number" && v > 0) {
+          merged[key] = v;
+        }
+      }
+      s.fastestLevelCompletionSeconds = merged;
+    }
+  }
+
   getStats(): PlayerStats {
     return {
       ...this.stats,

--- a/tests/raptor-achievement-storage.test.ts
+++ b/tests/raptor-achievement-storage.test.ts
@@ -1,0 +1,593 @@
+import { AchievementStorage, ACHIEVEMENT_SAVE_VERSION } from "../src/games/raptor/systems/achievements/AchievementStorage";
+import { PlayerStatsTracker } from "../src/games/raptor/systems/achievements/PlayerStatsTracker";
+import type { PlayerStats } from "../src/games/raptor/systems/achievements/PlayerStatsTracker";
+import { AchievementManager } from "../src/games/raptor/systems/achievements/AchievementManager";
+import type { UnlockedAchievement } from "../src/games/raptor/types";
+import { StorageBackend, setStorageBackend } from "../src/shared/storage";
+
+// ─── Mock StorageBackend ────────────────────────────────────────
+
+class MockStorageBackend implements StorageBackend {
+  data: Record<string, string> = {};
+
+  async get(key: string): Promise<string | null> {
+    return this.data[key] ?? null;
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.data[key] = value;
+  }
+
+  async remove(key: string): Promise<void> {
+    delete this.data[key];
+  }
+}
+
+// ─── Test Helpers ───────────────────────────────────────────────
+
+let mockBackend: MockStorageBackend;
+
+beforeEach(() => {
+  mockBackend = new MockStorageBackend();
+  setStorageBackend(mockBackend);
+});
+
+function fnv1aHash(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function sampleAchievements(): UnlockedAchievement[] {
+  return [
+    { id: "first_blood", unlockedAt: 1700000000000 },
+    { id: "boss_slayer", unlockedAt: 1700000001000 },
+  ];
+}
+
+function sampleStats(): PlayerStats {
+  return {
+    totalKills: 150,
+    killsByVariant: { scout: 80, fighter: 50, bomber: 20 },
+    bossesDefeated: 3,
+    ramKills: 5,
+    totalScore: 25000,
+    levelsCompleted: 7,
+    highestLevelCompleted: 6,
+    totalDeaths: 4,
+    totalDodgesUsed: 30,
+    totalEmpsUsed: 10,
+    totalPowerUpsCollected: 45,
+    powerUpsByType: { "repair-kit": 15, "spread-shot": 10, "weapon-missile": 20 },
+    weaponsOwned: ["machine-gun", "missile", "laser"],
+    highestWeaponTier: 2,
+    projectilesReflected: 12,
+    totalPlayTimeSeconds: 3600,
+    fastestLevelCompletionSeconds: { 0: 85.3, 1: 110.7 },
+    damageTakenThisLevel: 45,
+    lowestArmorSurvived: 22,
+  };
+}
+
+// ════════════════════════════════════════════════════════════════
+// ROUND-TRIP TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Save and load round-trip preserves all data", () => {
+  test("save then load returns matching achievements and stats", async () => {
+    const achievements = sampleAchievements();
+    const stats = sampleStats();
+
+    await AchievementStorage.save(achievements, stats);
+    const loaded = await AchievementStorage.load();
+
+    expect(loaded.unlockedAchievements).toEqual(achievements);
+    expect(loaded.playerStats.totalKills).toBe(150);
+    expect(loaded.playerStats.killsByVariant).toEqual({ scout: 80, fighter: 50, bomber: 20 });
+    expect(loaded.playerStats.bossesDefeated).toBe(3);
+    expect(loaded.playerStats.weaponsOwned).toEqual(["machine-gun", "missile", "laser"]);
+    expect(loaded.playerStats.fastestLevelCompletionSeconds).toEqual({ 0: 85.3, 1: 110.7 });
+    expect(loaded.playerStats.totalPlayTimeSeconds).toBe(3600);
+  });
+
+  test("per-level transient fields are zeroed in saved data", async () => {
+    const stats = sampleStats();
+    expect(stats.damageTakenThisLevel).toBe(45);
+    expect(stats.lowestArmorSurvived).toBe(22);
+
+    await AchievementStorage.save([], stats);
+    const loaded = await AchievementStorage.load();
+
+    expect(loaded.playerStats.damageTakenThisLevel).toBe(0);
+    expect(loaded.playerStats.lowestArmorSurvived).toBe(100);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// EMPTY STORAGE TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Missing storage key returns defaults", () => {
+  test("load from empty storage returns empty achievements and default stats", async () => {
+    const loaded = await AchievementStorage.load();
+
+    expect(loaded.unlockedAchievements).toEqual([]);
+    expect(loaded.playerStats.totalKills).toBe(0);
+    expect(loaded.playerStats.bossesDefeated).toBe(0);
+    expect(loaded.playerStats.weaponsOwned).toEqual(["machine-gun"]);
+    expect(loaded.playerStats.damageTakenThisLevel).toBe(0);
+    expect(loaded.playerStats.lowestArmorSurvived).toBe(100);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CHECKSUM TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Valid checksum allows data to load", () => {
+  test("saved data contains a valid checksum field", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+
+    expect(raw.checksum).toBeDefined();
+    expect(raw.checksum).toMatch(/^[0-9a-f]{8}$/);
+
+    const storedChecksum = raw.checksum;
+    delete raw.checksum;
+    const expected = fnv1aHash(JSON.stringify(raw));
+    expect(storedChecksum).toBe(expected);
+  });
+
+  test("all saved achievements and stats are restored with valid checksum", async () => {
+    const achievements = sampleAchievements();
+    await AchievementStorage.save(achievements, sampleStats());
+    const loaded = await AchievementStorage.load();
+
+    expect(loaded.unlockedAchievements).toHaveLength(2);
+    expect(loaded.playerStats.totalKills).toBe(150);
+  });
+});
+
+describe("Scenario: Tampered data is rejected due to checksum mismatch", () => {
+  test("modified JSON without updated checksum returns defaults", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+    raw.unlockedAchievements.push({ id: "hacked", unlockedAt: 0 });
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toEqual([]);
+    expect(loaded.playerStats.totalKills).toBe(0);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CORRUPTION HANDLING TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Corrupted JSON is handled gracefully", () => {
+  test("invalid JSON string returns defaults", async () => {
+    mockBackend.data["raptor_achievements"] = "not-json{{{";
+    const loaded = await AchievementStorage.load();
+
+    expect(loaded.unlockedAchievements).toEqual([]);
+    expect(loaded.playerStats.totalKills).toBe(0);
+  });
+
+  test("game does not crash on corrupted data", async () => {
+    mockBackend.data["raptor_achievements"] = "not-json{{{";
+    await expect(AchievementStorage.load()).resolves.toBeDefined();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// VERSION HANDLING TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Data includes a version field for future migrations", () => {
+  test("saved data contains version field set to ACHIEVEMENT_SAVE_VERSION", async () => {
+    await AchievementStorage.save([], sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+    expect(raw.version).toBe(ACHIEVEMENT_SAVE_VERSION);
+    expect(ACHIEVEMENT_SAVE_VERSION).toBe(1);
+  });
+});
+
+describe("Scenario: Future version data is rejected gracefully", () => {
+  test("version 999 returns defaults", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+    raw.version = 999;
+    delete raw.checksum;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toEqual([]);
+    expect(loaded.playerStats.totalKills).toBe(0);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// PARTIAL / INVALID STATS VALIDATION
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Partially invalid stats fields fall back to defaults", () => {
+  test("negative totalKills is reset to 0", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+
+    raw.playerStats.totalKills = -5;
+    delete raw.checksum;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.playerStats.totalKills).toBe(0);
+    expect(loaded.playerStats.bossesDefeated).toBe(3);
+  });
+
+  test("NaN stat value falls back to default", async () => {
+    await AchievementStorage.save([], sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+
+    raw.playerStats.totalScore = "not-a-number";
+    delete raw.checksum;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.playerStats.totalScore).toBe(0);
+  });
+
+  test("highestWeaponTier > 3 falls back to default", async () => {
+    await AchievementStorage.save([], sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+
+    raw.playerStats.highestWeaponTier = 5;
+    delete raw.checksum;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.playerStats.highestWeaponTier).toBe(0);
+  });
+
+  test("missing playerStats object returns defaults", async () => {
+    const raw = {
+      version: 1,
+      unlockedAchievements: [{ id: "first_blood", unlockedAt: 1700000000000 }],
+    } as Record<string, unknown>;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toHaveLength(1);
+    expect(loaded.playerStats.totalKills).toBe(0);
+    expect(loaded.playerStats.weaponsOwned).toEqual(["machine-gun"]);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// INVALID ACHIEVEMENT ENTRIES
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Invalid achievement entries are filtered out", () => {
+  test("entries with missing id are excluded", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+
+    raw.unlockedAchievements.push({ unlockedAt: 123 });
+    raw.unlockedAchievements.push({ id: "", unlockedAt: 456 });
+    delete raw.checksum;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toHaveLength(2);
+    expect(loaded.unlockedAchievements[0].id).toBe("first_blood");
+    expect(loaded.unlockedAchievements[1].id).toBe("boss_slayer");
+  });
+
+  test("entries with missing unlockedAt are excluded", async () => {
+    await AchievementStorage.save([], sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+
+    raw.unlockedAchievements = [
+      { id: "valid", unlockedAt: 1700000000000 },
+      { id: "no_timestamp" },
+    ];
+    delete raw.checksum;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toHaveLength(1);
+    expect(loaded.unlockedAchievements[0].id).toBe("valid");
+  });
+
+  test("null entries are excluded", async () => {
+    await AchievementStorage.save([], sampleStats());
+    const raw = JSON.parse(mockBackend.data["raptor_achievements"]);
+
+    raw.unlockedAchievements = [null, { id: "valid", unlockedAt: 123 }, undefined];
+    delete raw.checksum;
+    const payload = JSON.stringify(raw);
+    raw.checksum = fnv1aHash(payload);
+    mockBackend.data["raptor_achievements"] = JSON.stringify(raw);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toHaveLength(1);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// PLAYERSTATS TRACKER SERIALIZE / DESERIALIZE
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: PlayerStatsTracker.serialize() zeroes per-level fields", () => {
+  test("serialize resets damageTakenThisLevel and lowestArmorSurvived", () => {
+    const tracker = new PlayerStatsTracker();
+    tracker.recordDamageTaken(50, 30);
+    const stats = tracker.getStats();
+    expect(stats.damageTakenThisLevel).toBe(50);
+    expect(stats.lowestArmorSurvived).toBe(30);
+
+    const serialized = tracker.serialize();
+    expect(serialized.damageTakenThisLevel).toBe(0);
+    expect(serialized.lowestArmorSurvived).toBe(100);
+  });
+
+  test("serialize preserves lifetime fields", () => {
+    const tracker = new PlayerStatsTracker();
+    for (let i = 0; i < 10; i++) tracker.recordKill("scout", 10, false);
+    tracker.recordKill("boss", 400, true);
+    tracker.recordLevelComplete(0, 90, 0);
+
+    const serialized = tracker.serialize();
+    expect(serialized.totalKills).toBe(11);
+    expect(serialized.bossesDefeated).toBe(1);
+    expect(serialized.levelsCompleted).toBe(1);
+  });
+});
+
+describe("Scenario: PlayerStatsTracker.deserialize() restores lifetime fields", () => {
+  test("deserialize merges saved stats into tracker", () => {
+    const tracker = new PlayerStatsTracker();
+    tracker.deserialize({
+      totalKills: 200,
+      bossesDefeated: 5,
+      totalScore: 50000,
+      weaponsOwned: ["machine-gun", "laser", "plasma"],
+      highestWeaponTier: 3,
+    });
+
+    const stats = tracker.getStats();
+    expect(stats.totalKills).toBe(200);
+    expect(stats.bossesDefeated).toBe(5);
+    expect(stats.totalScore).toBe(50000);
+    expect(stats.weaponsOwned).toEqual(["machine-gun", "laser", "plasma"]);
+    expect(stats.highestWeaponTier).toBe(3);
+  });
+
+  test("deserialize does not restore per-level fields", () => {
+    const tracker = new PlayerStatsTracker();
+    tracker.deserialize({
+      totalKills: 100,
+      damageTakenThisLevel: 999,
+      lowestArmorSurvived: 5,
+    } as PlayerStats);
+
+    const stats = tracker.getStats();
+    expect(stats.totalKills).toBe(100);
+    expect(stats.damageTakenThisLevel).toBe(0);
+    expect(stats.lowestArmorSurvived).toBe(100);
+  });
+
+  test("deserialize rejects invalid field values", () => {
+    const tracker = new PlayerStatsTracker();
+    tracker.deserialize({
+      totalKills: -5,
+      bossesDefeated: 1.5,
+      totalScore: "not-a-number",
+      highestWeaponTier: 5,
+    } as unknown as PlayerStats);
+
+    const stats = tracker.getStats();
+    expect(stats.totalKills).toBe(0);
+    expect(stats.bossesDefeated).toBe(0);
+    expect(stats.totalScore).toBe(0);
+    expect(stats.highestWeaponTier).toBe(0);
+  });
+
+  test("deserialize handles empty weaponsOwned array", () => {
+    const tracker = new PlayerStatsTracker();
+    tracker.deserialize({ weaponsOwned: [] } as unknown as PlayerStats);
+
+    const stats = tracker.getStats();
+    expect(stats.weaponsOwned).toEqual(["machine-gun"]);
+  });
+
+  test("deserialize validates killsByVariant entries", () => {
+    const tracker = new PlayerStatsTracker();
+    tracker.deserialize({
+      killsByVariant: { scout: 10, fighter: -3, bomber: "invalid" },
+    } as unknown as PlayerStats);
+
+    const stats = tracker.getStats();
+    expect(stats.killsByVariant).toEqual({ scout: 10 });
+  });
+
+  test("deserialize validates fastestLevelCompletionSeconds", () => {
+    const tracker = new PlayerStatsTracker();
+    tracker.deserialize({
+      fastestLevelCompletionSeconds: { 0: 85.5, 1: -10, 2: 0 },
+    } as unknown as PlayerStats);
+
+    const stats = tracker.getStats();
+    expect(stats.fastestLevelCompletionSeconds).toEqual({ 0: 85.5 });
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CLEAR TESTS
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Clear removes all persisted achievement data", () => {
+  test("clear then load returns defaults", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+    await AchievementStorage.clear();
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toEqual([]);
+    expect(loaded.playerStats.totalKills).toBe(0);
+  });
+
+  test("storage key is removed after clear", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+    expect(mockBackend.data["raptor_achievements"]).toBeDefined();
+
+    await AchievementStorage.clear();
+    expect(mockBackend.data["raptor_achievements"]).toBeUndefined();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// INTEGRATION: ONUNLOCK TRIGGERS SAVE
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Saving triggers when a new achievement is unlocked", () => {
+  test("onUnlock callback can trigger AchievementStorage.save", async () => {
+    const tracker = new PlayerStatsTracker();
+    const manager = new AchievementManager(tracker);
+
+    manager.onUnlock = () => {
+      AchievementStorage.save(
+        manager.getUnlocked(),
+        tracker.serialize(),
+      ).catch(console.error);
+    };
+
+    tracker.recordKill("scout", 10, false);
+    manager.checkAchievements();
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const raw = mockBackend.data["raptor_achievements"];
+    expect(raw).toBeDefined();
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements.some(a => a.id === "first_blood")).toBe(true);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// GLOBAL STORAGE (NOT PER-SLOT)
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Achievement data is independent of save slots", () => {
+  test("achievements use global key not tied to save slots", async () => {
+    await AchievementStorage.save(sampleAchievements(), sampleStats());
+    expect(mockBackend.data["raptor_achievements"]).toBeDefined();
+
+    mockBackend.data["raptor_save_0"] = "{}";
+    delete mockBackend.data["raptor_save_0"];
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toHaveLength(2);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// STORAGE FAILURE HANDLING
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Storage write failure does not crash", () => {
+  test("save does not throw when backend fails", async () => {
+    const failingBackend: StorageBackend = {
+      async get(): Promise<string | null> { return null; },
+      async set(): Promise<void> { throw new Error("storage full"); },
+      async remove(): Promise<void> {},
+    };
+    setStorageBackend(failingBackend);
+
+    await expect(
+      AchievementStorage.save(sampleAchievements(), sampleStats())
+    ).resolves.toBeUndefined();
+  });
+
+  test("load returns defaults when backend fails", async () => {
+    const failingBackend: StorageBackend = {
+      async get(): Promise<string | null> { throw new Error("read error"); },
+      async set(): Promise<void> {},
+      async remove(): Promise<void> {},
+    };
+    setStorageBackend(failingBackend);
+
+    const loaded = await AchievementStorage.load();
+    expect(loaded.unlockedAchievements).toEqual([]);
+    expect(loaded.playerStats.totalKills).toBe(0);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// COMPLEX ROUND-TRIP FIDELITY
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Complex stats round-trip", () => {
+  test("5 achievements and complex stats survive save/load", async () => {
+    const achievements: UnlockedAchievement[] = [
+      { id: "first_blood", unlockedAt: 1000 },
+      { id: "boss_slayer", unlockedAt: 2000 },
+      { id: "century_kills", unlockedAt: 3000 },
+      { id: "high_scorer", unlockedAt: 4000 },
+      { id: "dodge_master", unlockedAt: 5000 },
+    ];
+
+    const stats = sampleStats();
+    await AchievementStorage.save(achievements, stats);
+    const loaded = await AchievementStorage.load();
+
+    expect(loaded.unlockedAchievements).toHaveLength(5);
+    expect(loaded.unlockedAchievements).toEqual(achievements);
+    expect(loaded.playerStats.totalKills).toBe(stats.totalKills);
+    expect(loaded.playerStats.killsByVariant).toEqual(stats.killsByVariant);
+    expect(loaded.playerStats.bossesDefeated).toBe(stats.bossesDefeated);
+    expect(loaded.playerStats.ramKills).toBe(stats.ramKills);
+    expect(loaded.playerStats.totalScore).toBe(stats.totalScore);
+    expect(loaded.playerStats.levelsCompleted).toBe(stats.levelsCompleted);
+    expect(loaded.playerStats.highestLevelCompleted).toBe(stats.highestLevelCompleted);
+    expect(loaded.playerStats.totalDeaths).toBe(stats.totalDeaths);
+    expect(loaded.playerStats.totalDodgesUsed).toBe(stats.totalDodgesUsed);
+    expect(loaded.playerStats.totalEmpsUsed).toBe(stats.totalEmpsUsed);
+    expect(loaded.playerStats.totalPowerUpsCollected).toBe(stats.totalPowerUpsCollected);
+    expect(loaded.playerStats.powerUpsByType).toEqual(stats.powerUpsByType);
+    expect(loaded.playerStats.weaponsOwned).toEqual(stats.weaponsOwned);
+    expect(loaded.playerStats.highestWeaponTier).toBe(stats.highestWeaponTier);
+    expect(loaded.playerStats.projectilesReflected).toBe(stats.projectilesReflected);
+    expect(loaded.playerStats.totalPlayTimeSeconds).toBe(stats.totalPlayTimeSeconds);
+    expect(loaded.playerStats.fastestLevelCompletionSeconds).toEqual(stats.fastestLevelCompletionSeconds);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// ACHIEVEMENT_SAVE_VERSION EXPORT
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: ACHIEVEMENT_SAVE_VERSION is exported correctly", () => {
+  test("ACHIEVEMENT_SAVE_VERSION is a number equal to 1", () => {
+    expect(typeof ACHIEVEMENT_SAVE_VERSION).toBe("number");
+    expect(ACHIEVEMENT_SAVE_VERSION).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds **global persistence** for the Raptor achievement system so that **unlocked achievements and lifetime player stats survive across sessions and save-slot deletion**.

Key points:
- Introduces a new `AchievementStorage` static utility that saves/loads a single atomic payload under the **global** storage key `raptor_achievements`.
- The payload includes a **version field** (starting at `1`) and an **FNV-1a checksum** to detect corruption/tampering; invalid or future-version data safely falls back to defaults.
- Updates `PlayerStatsTracker` to clearly separate **lifetime stats** (persisted) from **per-level transient stats** (not persisted).
- Integrates persistence into `RaptorGame` lifecycle: load on startup; save on unlock, level completion, game over, and victory.
- Ensures `resetGame()` no longer wipes global achievement/stat progress—only per-level state is reset.

Why:
- Addresses the issue requirement that achievement progress is **not per save slot** and should remain even if a save slot is deleted.
- Improves reliability via checksum validation + defensive parsing/validation.

---

## Key files modified

- **`src/games/raptor/systems/achievements/AchievementStorage.ts`** (new)
  - Static `load() / save() / clear()` API using `getStorageBackend()`
  - Stores achievements + lifetime stats together (atomic) in `raptor_achievements`
  - FNV-1a checksum validation, `version` field, and migration scaffolding
  - Robust validation/filtering of unlocked achievement entries and stats

- **`src/games/raptor/systems/achievements/PlayerStatsTracker.ts`**
  - Adds `serialize()` (zeros per-level transient fields before persisting)
  - Adds `deserialize(saved)` with type checks / clamping and safe merging of lifetime fields

- **`src/games/raptor/RaptorGame.ts`**
  - Loads persisted achievement/stats data during startup and hydrates:
    - `achievementManager.loadUnlocked(...)`
    - `statsTracker.deserialize(...)`
  - Adds save triggers on:
    - achievement unlock (`onUnlock`)
    - level complete
    - game over
    - victory
  - Updates `resetGame()` to preserve global progress:
    - removes `achievementManager.reset()`
    - replaces `statsTracker.resetAll()` with `statsTracker.resetLevelStats()`

- **`tests/raptor-achievement-storage.test.ts`** (new)
  - Unit tests covering round-trip save/load, checksum mismatch, corrupted JSON, version handling, partial/invalid stats, filtering invalid achievement entries, and tracker serialize/deserialize behavior.

---

## Storage / compatibility notes

- Uses existing storage backend (`getStorageBackend()`) and stores one combined JSON blob under:
  - **`raptor_achievements`** (contains both unlocked achievements + lifetime stats + checksum + version)
- Data is **global** (not per save slot), unlike `raptor_save_0/1/2`.
- On checksum failure, parse failure, or unsupported future version, the system **logs a warning and falls back to defaults** (no crash).

---

## Testing notes

- **Added unit tests** in `tests/raptor-achievement-storage.test.ts` using the project’s mock storage pattern.
- Manual smoke test suggestions:
  1. Unlock an achievement, reload the app → verify it remains unlocked.
  2. Accumulate lifetime stats (kills, levels completed), reload → verify stats persist.
  3. Delete a save slot → verify achievements remain intact.
  4. Start a new run via `resetGame()` → verify achievements/lifetime stats are preserved while per-level stats reset.

Ref: https://github.com/asgardtech/archer/issues/717