### PR TITLE
Achievement system: Add unlock notification toast UI

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -26,6 +26,7 @@ import { EnemyMissile } from "./entities/EnemyMissile";
 import { Explosion } from "./entities/Explosion";
 import { PowerUp, POWERUP_SPRITE_KEYS } from "./entities/PowerUp";
 import { HUD } from "./rendering/HUD";
+import { AchievementNotification } from "./rendering/AchievementNotification";
 import { AssetLoader } from "./rendering/AssetLoader";
 import { SpriteSheet, generateExplosionSheet, generateThrustSheet } from "./rendering/SpriteSheet";
 import { ShipRenderer } from "./rendering/ShipRenderer";
@@ -127,6 +128,7 @@ export class RaptorGame implements IGame {
   private perfManager: PerformanceManager;
   private statsTracker = new PlayerStatsTracker();
   private achievementManager: AchievementManager;
+  private achievementNotification: AchievementNotification;
   private achievementCheckTimer = 0;
   private skyGradientCanvas: HTMLCanvasElement | null = null;
   private cachedSkyGradient: [string, string] | null = null;
@@ -187,7 +189,11 @@ export class RaptorGame implements IGame {
 
     this.perfManager = new PerformanceManager();
     this.achievementManager = new AchievementManager(this.statsTracker);
-    this.achievementManager.onUnlock = (_a) => { this.saveAchievements(); };
+    this.achievementNotification = new AchievementNotification();
+    this.achievementManager.onUnlock = (a) => {
+      this.achievementNotification.show(a);
+      this.saveAchievements();
+    };
     this.initStars(60);
     this.setupResize();
   }
@@ -731,6 +737,7 @@ export class RaptorGame implements IGame {
       this.achievementManager.checkAchievements();
     }
     this.hud.updateWingmanTimer(dt);
+    this.achievementNotification.update(dt);
     this.input.updateFromKeyboard(dt, this.gameAreaWidth, this.gameAreaHeight, this.gameAreaX, this.gameAreaY);
     this.player.update(dt, this.input.targetX, this.input.targetY, this.gameAreaWidth, this.gameAreaHeight, this.gameAreaX, this.gameAreaY);
     if (this.player.alive) {
@@ -1918,6 +1925,8 @@ export class RaptorGame implements IGame {
         this.hasSaveData
       );
     }
+
+    this.achievementNotification.render(this.ctx, this.width, this.height);
 
     if (this.showFps) {
       const avgFrameTime = this.frameTimes.reduce((a, b) => a + b, 0) / this.frameTimes.length;

--- a/src/games/raptor/rendering/AchievementNotification.ts
+++ b/src/games/raptor/rendering/AchievementNotification.ts
@@ -1,0 +1,149 @@
+import type { AchievementDefinition } from "../types";
+import { HUD_TOP_BAR_HEIGHT, HUD_RIGHT_PANEL_WIDTH } from "../types";
+
+type NotificationPhase = "idle" | "sliding_in" | "holding" | "sliding_out";
+
+const SLIDE_IN_DURATION = 0.5;
+const HOLD_DURATION = 3.0;
+const SLIDE_OUT_DURATION = 0.5;
+const PANEL_WIDTH = 300;
+const PANEL_HEIGHT = 60;
+const MARGIN_RIGHT = 10;
+const MARGIN_TOP = 10;
+const SLIDE_DISTANCE = PANEL_WIDTH + MARGIN_RIGHT + HUD_RIGHT_PANEL_WIDTH;
+const CORNER_RADIUS = 8;
+const RETRO_FONT = "'Press Start 2P', monospace";
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function easeInCubic(t: number): number {
+  return t * t * t;
+}
+
+function truncateText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  const ellipsis = "...";
+  const ellipsisWidth = ctx.measureText(ellipsis).width;
+  let truncated = text;
+  while (
+    truncated.length > 0 &&
+    ctx.measureText(truncated).width + ellipsisWidth > maxWidth
+  ) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated + ellipsis;
+}
+
+export class AchievementNotification {
+  private queue: AchievementDefinition[] = [];
+  private current: AchievementDefinition | null = null;
+  private phase: NotificationPhase = "idle";
+  private timer = 0;
+
+  show(achievement: AchievementDefinition): void {
+    this.queue.push(achievement);
+  }
+
+  update(dt: number): void {
+    if (this.phase === "idle") {
+      if (this.queue.length > 0) {
+        this.current = this.queue.shift()!;
+        this.phase = "sliding_in";
+        this.timer = 0;
+      }
+      return;
+    }
+
+    this.timer += dt;
+
+    if (this.phase === "sliding_in" && this.timer >= SLIDE_IN_DURATION) {
+      this.phase = "holding";
+      this.timer = 0;
+    } else if (this.phase === "holding" && this.timer >= HOLD_DURATION) {
+      this.phase = "sliding_out";
+      this.timer = 0;
+    } else if (this.phase === "sliding_out" && this.timer >= SLIDE_OUT_DURATION) {
+      this.current = null;
+      this.phase = "idle";
+      this.timer = 0;
+    }
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    canvasWidth: number,
+    _canvasHeight: number,
+  ): void {
+    if (this.phase === "idle" || !this.current) return;
+
+    const restX = canvasWidth - HUD_RIGHT_PANEL_WIDTH - PANEL_WIDTH - MARGIN_RIGHT;
+    const topY = HUD_TOP_BAR_HEIGHT + MARGIN_TOP;
+
+    let slideOffset = 0;
+    let alpha = 1;
+
+    if (this.phase === "sliding_in") {
+      const progress = Math.min(this.timer / SLIDE_IN_DURATION, 1);
+      const eased = easeOutCubic(progress);
+      slideOffset = SLIDE_DISTANCE * (1 - eased);
+      alpha = eased;
+    } else if (this.phase === "sliding_out") {
+      const progress = Math.min(this.timer / SLIDE_OUT_DURATION, 1);
+      const eased = easeInCubic(progress);
+      slideOffset = SLIDE_DISTANCE * eased;
+      alpha = 1 - eased;
+    }
+
+    const drawX = restX + slideOffset;
+
+    ctx.save();
+    ctx.globalAlpha = alpha;
+
+    ctx.fillStyle = "rgba(0, 0, 0, 0.85)";
+    ctx.beginPath();
+    ctx.roundRect(drawX, topY, PANEL_WIDTH, PANEL_HEIGHT, CORNER_RADIUS);
+    ctx.fill();
+
+    ctx.strokeStyle = "#FFD700";
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.roundRect(drawX, topY, PANEL_WIDTH, PANEL_HEIGHT, CORNER_RADIUS);
+    ctx.stroke();
+
+    const iconSize = 40;
+    ctx.font = `${iconSize * 0.7}px serif`;
+    ctx.textBaseline = "middle";
+    ctx.textAlign = "center";
+    ctx.fillStyle = "#FFFFFF";
+    ctx.fillText(
+      this.current.icon,
+      drawX + 10 + iconSize / 2,
+      topY + PANEL_HEIGHT / 2,
+    );
+
+    const textX = drawX + 56;
+    const textMaxWidth = PANEL_WIDTH - 56 - 10;
+
+    ctx.font = `9px ${RETRO_FONT}`;
+    ctx.textAlign = "left";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = "#FFD700";
+    ctx.fillText(truncateText(ctx, this.current.name, textMaxWidth), textX, topY + 22);
+
+    ctx.font = `6px ${RETRO_FONT}`;
+    ctx.fillStyle = "#FFFFFF";
+    ctx.fillText(
+      truncateText(ctx, this.current.description, textMaxWidth),
+      textX,
+      topY + 40,
+    );
+
+    ctx.restore();
+  }
+}


### PR DESCRIPTION
## PR: Achievement system — Add unlock notification toast UI (Issue #718, Epic #608)

### Summary (what changed + why)
Adds an in-game, canvas-rendered toast notification that appears whenever an achievement is unlocked. The toast slides in from the right, displays the achievement icon/name/description, holds briefly, then slides out—without interrupting gameplay. This improves player feedback and makes achievement unlocks feel responsive and visible during play.

### Key changes / implementation details
- Introduced a new `AchievementNotification` renderer with a small internal state machine:
  `idle → sliding_in (0.5s) → holding (3.0s) → sliding_out (0.5s) → idle`
- Queue-based behavior ensures multiple unlocks display sequentially (FIFO), one toast at a time.
- Canvas-only rendering consistent with existing HUD patterns (no DOM/CSS overlays), including:
  - Dark semi-transparent panel with gold border
  - Retro HUD font (`'Press Start 2P'`)
  - Eased slide + fade via `globalAlpha`
- Text overflow handling: long titles/descriptions are truncated with ellipsis.
- Integrated into `RaptorGame` so:
  - `AchievementManager.onUnlock` enqueues a toast and still persists achievements
  - `update()` advances animation during gameplay
  - `render()` draws the toast above HUD/game elements but below the dev console overlay

### Key files modified
- **Added:** `src/games/raptor/rendering/AchievementNotification.ts`  
  New renderer component providing `show()`, `update(dt)`, and `render(ctx, w, h)` APIs, including animation, layout, queueing, and truncation.
- **Modified:** `src/games/raptor/RaptorGame.ts`  
  Instantiates `AchievementNotification`, wires `onUnlock` to `show()`, and calls notification `update()`/`render()` in the appropriate places.

### Testing notes
Manual verification:
- Unlock a single achievement during gameplay and confirm:
  - Slides in (0.5s), holds (~3s), slides out (0.5s)
  - Correct position: top-right, below HUD top bar; no overlap with top-bar buttons
  - Styling matches HUD (dark panel, gold border, retro font)
- Trigger multiple achievements in quick succession and confirm queue behavior (sequential display, no overlap).
- Verify long names/descriptions truncate with ellipsis.
- Pause during an active toast:
  - Animation freezes while paused (since `updatePlaying()` stops)
  - Continues correctly on resume
- Sanity check at multiple canvas sizes/DPR to ensure positioning stays within the visible canvas.

No automated tests were added (rendering/animation is canvas-based and currently validated via manual in-game checks).

Ref: https://github.com/asgardtech/archer/issues/718