### PR TITLE
Achievement system: Add unlock sound effect and VFX

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -195,6 +195,8 @@ export class RaptorGame implements IGame {
     this.achievementNotification = new AchievementNotification();
     this.achievementGallery = new AchievementGallery();
     this.achievementManager.onUnlock = (a) => {
+      this.sound.play("achievement_unlock");
+      this.vfx.triggerAchievementFlash(this.width, this.height);
       this.achievementNotification.show(a);
       this.saveAchievements();
     };

--- a/src/games/raptor/rendering/VFXManager.ts
+++ b/src/games/raptor/rendering/VFXManager.ts
@@ -42,6 +42,14 @@ interface MegaBombRing {
   elapsed: number;
 }
 
+interface AchievementFlash {
+  alpha: number;
+  duration: number;
+  elapsed: number;
+  width: number;
+  height: number;
+}
+
 interface EmpPulse {
   x: number;
   y: number;
@@ -76,6 +84,7 @@ export class VFXManager {
   private megaBombFlash: MegaBombFlash | null = null;
   private megaBombRing: MegaBombRing | null = null;
   private empPulse: EmpPulse | null = null;
+  private achievementFlash: AchievementFlash | null = null;
 
   constructor() {
     this.trailPool = new Array(TRAIL_CAPACITY);
@@ -116,6 +125,10 @@ export class VFXManager {
       duration: 0.3,
       elapsed: 0,
     };
+  }
+
+  triggerAchievementFlash(width: number, height: number): void {
+    this.achievementFlash = { alpha: 1, duration: 0.3, elapsed: 0, width, height };
   }
 
   triggerScreenShake(intensity: number, duration: number): void {
@@ -194,6 +207,16 @@ export class VFXManager {
         this.empPulse = null;
       }
     }
+
+    if (this.achievementFlash) {
+      this.achievementFlash.elapsed += dt;
+      this.achievementFlash.alpha = Math.max(
+        0, 1 - this.achievementFlash.elapsed / this.achievementFlash.duration
+      );
+      if (this.achievementFlash.elapsed >= this.achievementFlash.duration) {
+        this.achievementFlash = null;
+      }
+    }
   }
 
   applyPreRender(ctx: CanvasRenderingContext2D): void {
@@ -237,6 +260,20 @@ export class VFXManager {
       ctx.beginPath();
       ctx.arc(this.empPulse.x, this.empPulse.y, this.empPulse.radius, 0, Math.PI * 2);
       ctx.fill();
+      ctx.restore();
+    }
+
+    if (this.achievementFlash && this.achievementFlash.alpha > 0) {
+      ctx.save();
+      const a = this.achievementFlash;
+      const gradient = ctx.createRadialGradient(
+        a.width / 2, a.height / 2, Math.min(a.width, a.height) * 0.3,
+        a.width / 2, a.height / 2, Math.max(a.width, a.height) * 0.7
+      );
+      gradient.addColorStop(0, "rgba(255, 215, 0, 0)");
+      gradient.addColorStop(1, `rgba(255, 215, 0, ${a.alpha * 0.35})`);
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, a.width, a.height);
       ctx.restore();
     }
 
@@ -369,5 +406,6 @@ export class VFXManager {
     this.megaBombFlash = null;
     this.megaBombRing = null;
     this.empPulse = null;
+    this.achievementFlash = null;
   }
 }

--- a/src/games/raptor/systems/SoundSystem.ts
+++ b/src/games/raptor/systems/SoundSystem.ts
@@ -51,6 +51,7 @@ export class SoundSystem {
       case "plasma_hit": this.playPlasmaHit(); break;
       case "mega_bomb_fire": this.playMegaBombFire(); break;
       case "dodge": this.playDodge(); break;
+      case "achievement_unlock": this.playAchievementUnlock(); break;
     }
   }
 
@@ -250,6 +251,18 @@ export class SoundSystem {
       attack: 0.005, decay: 0.02, sustain: 0.3, release: 0.04,
     }, this.sfxNode);
     this.audio.playNoise(0.06, 5000, this.sfxNode);
+  }
+
+  private playAchievementUnlock(): void {
+    this.audio.playSequence([
+      { frequency: 659,  duration: 0.12, type: "triangle" },
+      { frequency: 831,  duration: 0.12, type: "triangle" },
+      { frequency: 988,  duration: 0.12, type: "triangle" },
+      { frequency: 1319, duration: 0.35, type: "triangle" },
+    ], 300, this.sfxNode);
+    this.audio.playToneSwept(2000, 4000, 0.15, "sine", {
+      attack: 0.005, decay: 0.02, sustain: 0.15, release: 0.05,
+    }, this.sfxNode);
   }
 
   private get musicNode(): AudioNode | undefined {

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -162,7 +162,8 @@ export type RaptorSoundEvent =
   | "mega_bomb_fire"
   | "dodge"
   | "emp_burst"
-  | "deflect";
+  | "deflect"
+  | "achievement_unlock";
 
 export type WeaponType = "machine-gun" | "missile" | "laser" | "plasma" | "ion-cannon" | "auto-gun" | "rocket";
 


### PR DESCRIPTION
## PR: Achievement system — Add unlock sound effect and VFX (Epic #608)

### Summary (what changed + why)
This PR adds satisfying audiovisual feedback when an achievement is unlocked:
- **New SFX:** a distinctive **“achievement_unlock”** procedural sound (E major arpeggio with a shimmer sweep) to make unlocks feel more rewarding and clearly different from existing power-up / level-complete cues.
- **New VFX:** a brief **gold screen-edge vignette flash** (0.3s fade, max ~0.35 opacity) to reinforce the moment without obscuring gameplay.
- **Wiring:** both effects are triggered from the existing `AchievementManager.onUnlock` callback **at the same time** as the achievement toast begins.

### Key files modified
- `src/games/raptor/types.ts`
  - Adds `"achievement_unlock"` to the `RaptorSoundEvent` union.
- `src/games/raptor/systems/SoundSystem.ts`
  - Routes the new `"achievement_unlock"` event.
  - Adds `playAchievementUnlock()` procedural sound: **E major arpeggio** (triangle wave, 300 BPM) + **high-frequency shimmer sweep**, respecting existing SFX routing/mute/volume and the system debounce behavior.
- `src/games/raptor/rendering/VFXManager.ts`
  - Adds an **achievement flash** effect rendered as a **gold radial-gradient vignette** in post-render, with timed fade-out and reset handling.
- `src/games/raptor/RaptorGame.ts`
  - Triggers `sound.play("achievement_unlock")` and `vfx.triggerAchievementFlash(...)` inside `onUnlock`, before showing the notification toast.

### Testing notes
Manual verification recommended:
- Unlock an achievement and confirm:
  - **Sound plays** and is audibly distinct from `power_up_collect` / `level_complete`.
  - **Sound respects SFX volume and mute** (muted = no audible output).
  - **Debounce works** (multiple unlocks in the same frame/within ~50ms only produce one sound).
- Confirm VFX:
  - Gold vignette flash appears on unlock, **does not block center gameplay**, fades out in ~0.3s, and does not persist after resets/new level.
- Confirm integration timing:
  - Sound + VFX start **simultaneously with** the achievement notification toast animation.

Ref: https://github.com/asgardtech/archer/issues/720