### PR TITLE
achievement popup is weird, afaict instead of an image i see text that goes out the box

### DIFF
--- a/src/games/raptor/rendering/AchievementGallery.ts
+++ b/src/games/raptor/rendering/AchievementGallery.ts
@@ -1,5 +1,6 @@
 import type { AchievementCategory, AchievementDefinition, UnlockedAchievement } from "../types";
 import { formatRelativeDate } from "./formatDate";
+import { ICON_GLYPHS, FALLBACK_GLYPH } from "./iconGlyphs";
 
 interface AchievementEntry {
   definition: AchievementDefinition;
@@ -40,30 +41,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   progression: "PROGRESS",
   collection: "COLLECT",
   mastery: "MASTERY",
-};
-
-const ICON_GLYPHS: Record<string, string> = {
-  crosshair: "\u{1F3AF}",
-  skull: "\u{1F480}",
-  skull_fire: "\u{1F525}",
-  crown: "\u{1F451}",
-  explosion: "\u{1F4A5}",
-  shield: "\u{1F6E1}",
-  heart_crack: "\u{1F494}",
-  cat: "\u{1F431}",
-  wind: "\u{1F4A8}",
-  flag: "\u{1F3C1}",
-  map: "\u{1F5FA}",
-  trophy: "\u{1F3C6}",
-  star: "\u2B50",
-  gem: "\u{1F48E}",
-  zap: "\u26A1",
-  arsenal: "\u{1F52B}",
-  chevrons_up: "\u23EB",
-  bomb: "\u{1F4A3}",
-  bolt: "\u{1F329}",
-  rotate: "\u{1F504}",
-  timer: "\u23F1",
 };
 
 export class AchievementGallery {
@@ -343,7 +320,7 @@ export class AchievementGallery {
     ctx.textBaseline = "middle";
 
     if (unlocked) {
-      const glyph = ICON_GLYPHS[definition.icon] ?? "\u2753";
+      const glyph = ICON_GLYPHS[definition.icon] ?? FALLBACK_GLYPH;
       ctx.fillStyle = "#FFFFFF";
       ctx.fillText(glyph, iconX + 18, iconY);
     } else {

--- a/src/games/raptor/rendering/AchievementNotification.ts
+++ b/src/games/raptor/rendering/AchievementNotification.ts
@@ -1,5 +1,6 @@
 import type { AchievementDefinition } from "../types";
 import { HUD_TOP_BAR_HEIGHT, HUD_RIGHT_PANEL_WIDTH } from "../types";
+import { ICON_GLYPHS, FALLBACK_GLYPH } from "./iconGlyphs";
 
 type NotificationPhase = "idle" | "sliding_in" | "holding" | "sliding_out";
 
@@ -121,8 +122,9 @@ export class AchievementNotification {
     ctx.textBaseline = "middle";
     ctx.textAlign = "center";
     ctx.fillStyle = "#FFFFFF";
+    const glyph = ICON_GLYPHS[this.current.icon] ?? FALLBACK_GLYPH;
     ctx.fillText(
-      this.current.icon,
+      glyph,
       drawX + 10 + iconSize / 2,
       topY + PANEL_HEIGHT / 2,
     );

--- a/src/games/raptor/rendering/iconGlyphs.ts
+++ b/src/games/raptor/rendering/iconGlyphs.ts
@@ -1,0 +1,25 @@
+export const ICON_GLYPHS: Record<string, string> = {
+  crosshair: "\u{1F3AF}",
+  skull: "\u{1F480}",
+  skull_fire: "\u{1F525}",
+  crown: "\u{1F451}",
+  explosion: "\u{1F4A5}",
+  shield: "\u{1F6E1}",
+  heart_crack: "\u{1F494}",
+  cat: "\u{1F431}",
+  wind: "\u{1F4A8}",
+  flag: "\u{1F3C1}",
+  map: "\u{1F5FA}",
+  trophy: "\u{1F3C6}",
+  star: "\u2B50",
+  gem: "\u{1F48E}",
+  zap: "\u26A1",
+  arsenal: "\u{1F52B}",
+  chevrons_up: "\u23EB",
+  bomb: "\u{1F4A3}",
+  bolt: "\u{1F329}",
+  rotate: "\u{1F504}",
+  timer: "\u23F1",
+};
+
+export const FALLBACK_GLYPH = "\u2753";


### PR DESCRIPTION
## Fix achievement notification icon rendering (Issue #746)

### Summary / Why
Achievement unlock notifications were rendering the raw `icon` key string (e.g. `"crosshair"`, `"trophy"`) as literal text instead of the intended emoji glyph. Because those strings are longer than the icon area in the 300×60 popup, they overflowed the notification panel and looked broken.

This PR fixes the popup by resolving icon keys through the same `ICON_GLYPHS` mapping used by the Achievement Gallery, so notifications and the gallery stay consistent. Unknown icon keys now safely fall back to `❓` instead of overflowing.

Closes: **#746**

---

### What changed
- Extracted the `ICON_GLYPHS` lookup table into a shared module.
- Updated **AchievementNotification** rendering to look up the emoji glyph before calling `ctx.fillText`.
- Updated **AchievementGallery** to import the shared mapping (removing the duplicated local constant) and to use a shared fallback glyph constant.

---

### Key files modified
- **`src/games/raptor/rendering/iconGlyphs.ts`** *(new)*  
  Shared `ICON_GLYPHS` mapping + `FALLBACK_GLYPH` (`❓`).
- **`src/games/raptor/rendering/AchievementNotification.ts`**  
  Resolves `this.current.icon` key → emoji glyph via `ICON_GLYPHS`, falls back to `FALLBACK_GLYPH`, then renders the glyph.
- **`src/games/raptor/rendering/AchievementGallery.ts`**  
  Imports `ICON_GLYPHS`/`FALLBACK_GLYPH` from the shared module instead of maintaining its own copy.

---

### Testing notes
- **Manual / Visual**
  - Trigger an achievement unlock and confirm the popup shows an emoji icon (e.g. 🎯) rather than the raw key text.
  - Verify the icon and text remain within the 300×60 notification bounds (no overflow).
  - Confirm the icon shown in the notification matches the icon shown in the Achievement Gallery for the same achievement.
  - Temporarily set an achievement icon key to an unknown value and confirm the popup displays `❓`.

- **Automated**
  - No new automated tests included in this change (rendering is canvas-based); recommended follow-up is a small unit check ensuring all `ACHIEVEMENT_DEFINITIONS[].icon` keys exist in `ICON_GLYPHS`.

Ref: https://github.com/asgardtech/archer/issues/746