### PR TITLE
enemy rockets should be vulnerable to gun, lasers, rockets - everything but our own homing missiles

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1129,6 +1129,22 @@ export class RaptorGame implements IGame {
       }
     }
 
+    const missileInterceptHits = this.collisions.checkProjectilesEnemyMissiles(
+      this.projectiles, this.enemyBullets
+    );
+    for (const hit of missileInterceptHits) {
+      this.vfx.triggerExplosionFlash(hit.missile.pos.x, hit.missile.pos.y, 12);
+      this.sound.play("enemy_missile_hit");
+    }
+
+    const beamMissileKills = this.collisions.checkBeamEnemyMissiles(
+      this.weaponSystem.laserBeam, this.enemyBullets, dt
+    );
+    for (const missile of beamMissileKills) {
+      this.vfx.triggerExplosionFlash(missile.pos.x, missile.pos.y, 12);
+      this.sound.play("enemy_missile_hit");
+    }
+
     const bulletPlayerHits = this.collisions.checkEnemyBulletsPlayer(this.enemyBullets, this.player);
     for (const hit of bulletPlayerHits) {
       if (hit.reflected) {

--- a/src/games/raptor/systems/CollisionSystem.ts
+++ b/src/games/raptor/systems/CollisionSystem.ts
@@ -45,6 +45,11 @@ export interface ReflectedBulletHit {
   damage: number;
 }
 
+export interface ProjectileEnemyMissileHit {
+  projectile: Projectile;
+  missile: EnemyMissile;
+}
+
 export interface SplashHit {
   enemy: Enemy;
   destroyed: boolean;
@@ -313,6 +318,58 @@ export class CollisionSystem {
       }
     }
     return hits;
+  }
+
+  checkProjectilesEnemyMissiles(
+    projectiles: Projectile[],
+    enemyBullets: EnemyBullet[]
+  ): ProjectileEnemyMissileHit[] {
+    const hits: ProjectileEnemyMissileHit[] = [];
+
+    for (const eb of enemyBullets) {
+      if (!(eb instanceof EnemyMissile) || !eb.alive) continue;
+
+      for (const proj of projectiles) {
+        if (!proj.alive || proj instanceof Missile) continue;
+
+        if (this.aabb(proj.left, proj.top, proj.right, proj.bottom,
+                      eb.left, eb.top, eb.right, eb.bottom)) {
+          eb.alive = false;
+          if (!proj.piercing) {
+            proj.alive = false;
+          }
+          hits.push({ projectile: proj, missile: eb });
+          break;
+        }
+      }
+    }
+
+    return hits;
+  }
+
+  checkBeamEnemyMissiles(
+    beam: LaserBeam,
+    enemyBullets: EnemyBullet[],
+    dt: number
+  ): EnemyMissile[] {
+    if (!beam.active) return [];
+
+    const halfWidth = beam.beamWidth / 2;
+    const beamLeft = beam.pos.x - halfWidth;
+    const beamRight = beam.pos.x + halfWidth;
+    const destroyed: EnemyMissile[] = [];
+
+    for (const eb of enemyBullets) {
+      if (!(eb instanceof EnemyMissile) || !eb.alive) continue;
+      if (eb.pos.y > beam.pos.y) continue;
+
+      if (eb.right > beamLeft && eb.left < beamRight) {
+        eb.alive = false;
+        destroyed.push(eb);
+      }
+    }
+
+    return destroyed;
   }
 
   private aabb(


### PR DESCRIPTION
## PR: Enemy missiles can be shot down by player weapons (except homing missiles)

### Summary / Why
This change adds a defensive counter-play option by allowing **enemy rockets/missiles (`EnemyMissile`) to be destroyed by most player weapons** (guns, rockets, plasma, ion cannon, auto-gun, and the laser beam).  
**Player homing missiles (`Missile`) are intentionally excluded** so they remain focused as an anti-ship weapon rather than a universal projectile-clear tool.

### What changed
- Added a new collision path between **player projectiles** and **enemy missiles** (previously player projectiles only collided with `Enemy[]`, and `EnemyBullet[]` only collided with the player).
- Implemented missile interception for:
  - **Projectile vs EnemyMissile** (AABB checks)
  - **LaserBeam vs EnemyMissile** (beam overlap)
- **Scope is limited to `EnemyMissile` only** (regular `EnemyBullet` remains non-interactable).
- Enemy missiles are **one-hit kills** regardless of weapon damage.
- Respects **piercing** behavior (piercing projectiles continue; non-piercing projectiles are consumed).
- **No score is awarded** for destroying enemy missiles (prevents score farming).
- Added VFX/SFX hooks when an enemy missile is intercepted (`enemy_missile_hit` + small explosion flash).

### Key files modified
- `src/games/raptor/systems/CollisionSystem.ts`
  - Added `checkProjectilesEnemyMissiles()` for projectile interception (excluding `Missile` via `instanceof`).
  - Added `checkBeamEnemyMissiles()` for laser beam interception.
  - Added `ProjectileEnemyMissileHit` interface for reporting hits to the game loop.
- `src/games/raptor/RaptorGame.ts`
  - Wired the new collision checks into `updatePlaying()`.
  - Triggers interception VFX/SFX on missile destruction.

### Behavior notes
- **Allowed to destroy enemy missiles:** gun bullets, rockets, plasma, ion bolts, auto-gun tracking bullets, laser beam.
- **Not allowed:** player **homing missiles** (`Missile`) do *not* destroy `EnemyMissile`.
- **Not affected:** standard enemy bullets/mines remain invulnerable to player fire.
- Existing systems remain consistent:
  - EMP still clears `enemyBullets` (including missiles).
  - Deflector still does not reflect `EnemyMissile`.

### Testing notes
Manual verification recommended:
1. Spawn/fire an `EnemyMissile` and intercept it with:
   - machine gun
   - rockets
   - plasma
   - ion cannon (confirm ion bolt continues if `piercing`)
   - auto-gun
   - laser beam (beam remains active)
2. Fire player **homing missiles** through an `EnemyMissile` and confirm **no destruction** occurs.
3. Confirm **no score change** occurs when destroying enemy missiles.
4. Confirm regular `EnemyBullet` cannot be destroyed by player projectiles.

_No data model/save changes included._

Ref: https://github.com/asgardtech/archer/issues/748