### PR TITLE
save system is weird; it autosaves my current run, I can play it once then it's gone

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1328,6 +1328,7 @@ export class RaptorGame implements IGame {
       this.saveAchievements();
       this.sound.stopMusic();
       this.sound.play("game_over");
+      SaveSystem.clearAutoSave(this.activeSlot).catch(console.error);
       this.state = "gameover";
       return;
     }
@@ -1366,6 +1367,7 @@ export class RaptorGame implements IGame {
             this.buildSaveData({ levelReached: this.currentLevel + 1 }),
             this.activeSlot
           ).catch(console.error);
+          SaveSystem.clearAutoSave(this.activeSlot).catch(console.error);
           this._hasSaveData = true;
         }
         this.storyRenderer.show([act.ending.join(" ")], "center", "pilot");
@@ -1379,6 +1381,7 @@ export class RaptorGame implements IGame {
           this.buildSaveData({ levelReached: this.currentLevel + 1 }),
           this.activeSlot
         ).catch(console.error);
+        SaveSystem.clearAutoSave(this.activeSlot).catch(console.error);
         this._hasSaveData = true;
       }
     }
@@ -1560,7 +1563,7 @@ export class RaptorGame implements IGame {
   }
 
   private async continueGame(): Promise<void> {
-    const data = await SaveSystem.load(this.activeSlot);
+    const data = await SaveSystem.loadBest(this.activeSlot);
     if (!data) {
       this.resetGame();
       return;
@@ -1575,6 +1578,10 @@ export class RaptorGame implements IGame {
     this.player.armor = data.armor ?? 200;
     this.player.energy = data.energy ?? 200;
 
+    if (data.isAutoSave && data.waveIndex !== undefined && data.waveIndex > 0) {
+      this.spawner.skipToWave(data.waveIndex);
+    }
+
     if (data.weaponInventory) {
       const inv = new Map<WeaponType, number>();
       for (const [key, val] of Object.entries(data.weaponInventory)) {
@@ -1586,7 +1593,6 @@ export class RaptorGame implements IGame {
       this.powerUpManager.setInventory(inv);
       this.powerUpManager.setActiveWeapon(data.weapon);
     } else {
-      // Backward compat: construct inventory from single weapon + tier
       const inv = new Map<WeaponType, number>([["machine-gun", 1]]);
       const tier = data.weaponTier ?? 1;
       if (data.weapon !== "machine-gun") {

--- a/src/games/raptor/rendering/HUD.ts
+++ b/src/games/raptor/rendering/HUD.ts
@@ -838,10 +838,35 @@ export class HUD {
     ctx.fillStyle = "#FFFFFF";
     ctx.fillText(`SLOT ${index + 1}`, leftX, card.y + 20);
 
+    const isAuto = slot.isAutoSave === true;
+    const badgeText = isAuto ? "AUTO-SAVE" : "CHECKPOINT";
+    const badgeColor = isAuto ? "rgba(230, 126, 34, 0.8)" : "rgba(46, 204, 113, 0.8)";
+
+    const slotLabelWidth = this.measureCtx.font === `8px ${RETRO_FONT}`
+      ? this.measureCtx.measureText(`SLOT ${index + 1}`).width
+      : 60;
+    const badgeX = leftX + slotLabelWidth + 12;
+    ctx.font = `5px ${RETRO_FONT}`;
+    const badgeTextWidth = this.measureCtx.measureText(badgeText).width + 8;
+    ctx.fillStyle = badgeColor;
+    this.roundedRect(ctx, badgeX, card.y + 14, badgeTextWidth, 12, 3);
+    ctx.fill();
+    ctx.fillStyle = "#FFFFFF";
+    ctx.textAlign = "left";
+    ctx.fillText(badgeText, badgeX + 4, card.y + 20);
+
     const levelName = LEVELS[slot.levelReached]?.name ?? "Unknown";
     ctx.font = `7px ${RETRO_FONT}`;
     ctx.fillStyle = "#FFD700";
+    ctx.textAlign = "left";
     ctx.fillText(`LEVEL ${slot.levelReached + 1}: ${levelName.toUpperCase()}`, leftX, card.y + 38);
+
+    if (isAuto && slot.waveIndex !== undefined) {
+      const totalWaves = LEVELS[slot.levelReached]?.waves.length ?? 0;
+      ctx.font = `6px ${RETRO_FONT}`;
+      ctx.fillStyle = "#B0C4DE";
+      ctx.fillText(`Wave ${slot.waveIndex}/${totalWaves}`, leftX, card.y + 54);
+    }
 
     const midX = card.x + 280;
     ctx.font = `7px ${RETRO_FONT}`;

--- a/src/games/raptor/systems/EnemySpawner.ts
+++ b/src/games/raptor/systems/EnemySpawner.ts
@@ -67,6 +67,16 @@ export class EnemySpawner {
     return spawned;
   }
 
+  skipToWave(waveIndex: number): void {
+    if (waveIndex <= 0 || this.waves.length === 0) return;
+    const clamped = Math.min(waveIndex, this.waves.length - 1);
+    for (let i = 0; i < clamped; i++) {
+      this.waves[i].started = true;
+      this.waves[i].complete = true;
+      this.waves[i].spawned = this.waves[i].config.count;
+    }
+  }
+
   get completedWaveCount(): number {
     let count = 0;
     for (const wave of this.waves) {

--- a/src/games/raptor/systems/SaveSystem.ts
+++ b/src/games/raptor/systems/SaveSystem.ts
@@ -46,6 +46,14 @@ export class SaveSystem {
     return `${this.storageKey(slot)}_backup`;
   }
 
+  private static autoSaveKey(slot: number): string {
+    return `raptor_save_${slot}_auto`;
+  }
+
+  private static autoSaveBackupKey(slot: number): string {
+    return `raptor_save_${slot}_auto_backup`;
+  }
+
   private static isValidSlot(slot: number): boolean {
     return Number.isInteger(slot) && slot >= 0 && slot < MAX_SAVE_SLOTS;
   }
@@ -99,12 +107,9 @@ export class SaveSystem {
     await backend.remove(this.LEGACY_STORAGE_KEY);
   }
 
-  static async save(data: RaptorSaveData, slot: number): Promise<void> {
-    if (!this.isValidSlot(slot)) return;
-    data.slotIndex = slot;
+  private static async writeToKey(key: string, bkKey: string, data: RaptorSaveData, slot: number): Promise<void> {
     const backend = getStorageBackend();
-
-    const existing = await backend.get(this.storageKey(slot));
+    const existing = await backend.get(key);
 
     delete data.checksum;
     const payload = JSON.stringify(data);
@@ -114,18 +119,26 @@ export class SaveSystem {
 
     if (existing) {
       try {
-        await backend.set(this.backupKey(slot), existing);
+        await backend.set(bkKey, existing);
       } catch {
         console.warn(`Save slot ${slot}: failed to write backup, continuing with save`);
       }
     }
 
-    await backend.set(this.storageKey(slot), finalPayload);
+    await backend.set(key, finalPayload);
+  }
+
+  static async save(data: RaptorSaveData, slot: number): Promise<void> {
+    if (!this.isValidSlot(slot)) return;
+    data.slotIndex = slot;
+    await this.writeToKey(this.storageKey(slot), this.backupKey(slot), data, slot);
   }
 
   static async autoSave(slot: number, data: RaptorSaveData): Promise<void> {
+    if (!this.isValidSlot(slot)) return;
     data.isAutoSave = true;
-    return this.save(data, slot);
+    data.slotIndex = slot;
+    await this.writeToKey(this.autoSaveKey(slot), this.autoSaveBackupKey(slot), data, slot);
   }
 
   static async load(slot: number): Promise<RaptorSaveData | null> {
@@ -178,30 +191,74 @@ export class SaveSystem {
     }
   }
 
+  private static async loadAutoSave(slot: number): Promise<RaptorSaveData | null> {
+    if (!this.isValidSlot(slot)) return null;
+    const backend = getStorageBackend();
+    const raw = await backend.get(this.autoSaveKey(slot));
+    if (!raw) return null;
+
+    try {
+      const parsed = this.verifyAndLoad(raw);
+      if (!parsed) {
+        const backupRaw = await backend.get(this.autoSaveBackupKey(slot));
+        if (!backupRaw) return null;
+        const backupParsed = this.verifyAndLoad(backupRaw);
+        if (!backupParsed) return null;
+        const migrated = this.runMigrations(backupParsed);
+        if (!migrated || !this.validate(migrated)) return null;
+        return migrated as RaptorSaveData;
+      }
+
+      const migrated = this.runMigrations(parsed);
+      if (!migrated) return null;
+      if (!this.validate(migrated)) return null;
+      return migrated as RaptorSaveData;
+    } catch {
+      return null;
+    }
+  }
+
+  static async loadBest(slot: number): Promise<RaptorSaveData | null> {
+    await this.runLegacyMigration();
+    const checkpoint = await this.load(slot);
+    const autoSave = await this.loadAutoSave(slot);
+
+    if (!checkpoint && !autoSave) return null;
+    if (!checkpoint) return autoSave;
+    if (!autoSave) return checkpoint;
+
+    if (autoSave.levelReached > checkpoint.levelReached) return autoSave;
+    return checkpoint;
+  }
+
+  static async clearAutoSave(slot: number): Promise<void> {
+    if (!this.isValidSlot(slot)) return;
+    const backend = getStorageBackend();
+    await backend.remove(this.autoSaveKey(slot));
+    await backend.remove(this.autoSaveBackupKey(slot));
+  }
+
   static async clear(slot: number): Promise<void> {
     if (!this.isValidSlot(slot)) return;
     const backend = getStorageBackend();
     await backend.remove(this.storageKey(slot));
     await backend.remove(this.backupKey(slot));
+    await backend.remove(this.autoSaveKey(slot));
+    await backend.remove(this.autoSaveBackupKey(slot));
   }
 
-  static async hasSave(slot: number): Promise<boolean> {
-    await this.runLegacyMigration();
-    if (!this.isValidSlot(slot)) return false;
-
+  private static async hasValidDataAtKey(key: string, bkKey: string): Promise<boolean> {
     const backend = getStorageBackend();
-    const raw = await backend.get(this.storageKey(slot));
+    const raw = await backend.get(key);
     if (!raw) return false;
 
     try {
       const parsed = this.verifyAndLoad(raw);
       if (!parsed) {
-        const backupRaw = await backend.get(this.backupKey(slot));
+        const backupRaw = await backend.get(bkKey);
         if (!backupRaw) return false;
-
         const backupParsed = this.verifyAndLoad(backupRaw);
         if (!backupParsed) return false;
-
         const backupMigrated = this.runMigrations(backupParsed);
         if (!backupMigrated) return false;
         return this.validate(backupMigrated);
@@ -213,6 +270,14 @@ export class SaveSystem {
     } catch {
       return false;
     }
+  }
+
+  static async hasSave(slot: number): Promise<boolean> {
+    await this.runLegacyMigration();
+    if (!this.isValidSlot(slot)) return false;
+
+    if (await this.hasValidDataAtKey(this.storageKey(slot), this.backupKey(slot))) return true;
+    return this.hasValidDataAtKey(this.autoSaveKey(slot), this.autoSaveBackupKey(slot));
   }
 
   static async restoreFromBackup(slot: number): Promise<RaptorSaveData | null> {
@@ -239,7 +304,7 @@ export class SaveSystem {
     await this.runLegacyMigration();
     const result: (RaptorSaveData | null)[] = [];
     for (let i = 0; i < MAX_SAVE_SLOTS; i++) {
-      result.push(await this.load(i));
+      result.push(await this.loadBest(i));
     }
     return result;
   }

--- a/tests/raptor-save.test.ts
+++ b/tests/raptor-save.test.ts
@@ -509,7 +509,7 @@ describe("Scenario: Starting a New Game clears existing save data", () => {
     expect(game.currentLevel).toBe(0);
     expect(game.totalScore).toBe(0);
     expect(game.player.lives).toBe(3);
-    const saved = await SaveSystem.load(0);
+    const saved = await SaveSystem.loadBest(0);
     expect(saved).not.toBeNull();
     expect(saved!.isAutoSave).toBe(true);
     expect(saved!.levelReached).toBe(0);
@@ -1134,7 +1134,7 @@ describe("Scenario: RaptorGame passes activeSlot to SaveSystem.clear on New Game
     await SaveSystem.clear(game.saveSlot);
     (game as any).resetGame();
 
-    const saved = await SaveSystem.load(1);
+    const saved = await SaveSystem.loadBest(1);
     expect(saved).not.toBeNull();
     expect(saved!.isAutoSave).toBe(true);
     expect(saved!.levelReached).toBe(0);
@@ -1221,16 +1221,17 @@ describe("Scenario: SaveSystem.autoSave sets isAutoSave flag", () => {
   test("autoSave sets isAutoSave to true on saved data", async () => {
     const data = validSaveData();
     await SaveSystem.autoSave(0, data);
-    const loaded = await SaveSystem.load(0);
+    const loaded = await SaveSystem.loadBest(0);
     expect(loaded).not.toBeNull();
     expect(loaded!.isAutoSave).toBe(true);
   });
 
-  test("autoSave delegates to save (same slot, same key)", async () => {
+  test("autoSave writes to the auto-save key, not the checkpoint key", async () => {
     const data = validSaveData();
     await SaveSystem.autoSave(1, data);
-    expect(mockBackend.data["raptor_save_1"]).toBeDefined();
-    const loaded = await SaveSystem.load(1);
+    expect(mockBackend.data["raptor_save_1_auto"]).toBeDefined();
+    expect(mockBackend.data["raptor_save_1"]).toBeUndefined();
+    const loaded = await SaveSystem.loadBest(1);
     expect(loaded!.slotIndex).toBe(1);
   });
 });
@@ -1396,7 +1397,7 @@ describe("Scenario: Auto-save triggers at level start", () => {
     game.currentLevel = 0;
     (game as any).startLevel(3);
 
-    const saved = await SaveSystem.load(0);
+    const saved = await SaveSystem.loadBest(0);
     expect(saved).not.toBeNull();
     expect(saved!.isAutoSave).toBe(true);
     expect(saved!.levelReached).toBe(3);
@@ -1406,7 +1407,7 @@ describe("Scenario: Auto-save triggers at level start", () => {
     const { game } = createPlayingGame();
     (game as any).startLevel(2);
 
-    const saved = await SaveSystem.load(0);
+    const saved = await SaveSystem.loadBest(0);
     expect(saved).not.toBeNull();
     expect(saved!.waveIndex).toBe(0);
   });
@@ -1416,7 +1417,7 @@ describe("Scenario: Auto-save triggers at level start", () => {
     (game as any).playTimeSeconds = 120;
     (game as any).startLevel(1);
 
-    const saved = await SaveSystem.load(0);
+    const saved = await SaveSystem.loadBest(0);
     expect(saved).not.toBeNull();
     expect(saved!.playTimeSeconds).toBe(120);
   });
@@ -1425,10 +1426,23 @@ describe("Scenario: Auto-save triggers at level start", () => {
     const { game } = createPlayingGame();
     (game as any).resetGame();
 
-    const saved = await SaveSystem.load(0);
+    const saved = await SaveSystem.loadBest(0);
     expect(saved).not.toBeNull();
     expect(saved!.isAutoSave).toBe(true);
     expect(saved!.levelReached).toBe(0);
+  });
+
+  test("auto-save at level start does not overwrite checkpoint key", async () => {
+    const { game } = createPlayingGame();
+    await SaveSystem.save(validSaveData({ levelReached: 3, armor: 200 }), 0);
+    (game as any).startLevel(3);
+
+    const checkpoint = await SaveSystem.load(0);
+    expect(checkpoint).not.toBeNull();
+    expect(checkpoint!.armor).toBe(200);
+    expect(checkpoint!.isAutoSave).toBeUndefined();
+
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeDefined();
   });
 });
 
@@ -1450,7 +1464,7 @@ describe("Scenario: Between-wave checkpoint auto-save", () => {
     const wavesBefore = game.spawner.completedWaveCount;
     if (wavesBefore > 0) {
       (game as any).updatePlaying(0.001);
-      const saved = await SaveSystem.load(0);
+      const saved = await SaveSystem.loadBest(0);
       expect(saved).not.toBeNull();
       expect(saved!.isAutoSave).toBe(true);
       expect(saved!.waveIndex).toBe(wavesBefore);
@@ -1473,7 +1487,7 @@ describe("Scenario: Between-wave checkpoint auto-save", () => {
     }
 
     (game as any).updatePlaying(0.001);
-    const saved = await SaveSystem.load(0);
+    const saved = await SaveSystem.loadBest(0);
     expect(saved).toBeNull();
   });
 });
@@ -1604,18 +1618,17 @@ describe("Scenario: Auto-save failure does not crash the game", () => {
   });
 });
 
-describe("Scenario: Loading an auto-save resumes at the beginning of the saved level", () => {
+describe("Scenario: Loading an auto-save resumes at the saved wave", () => {
   test("continueGame starts at the saved level with restored state", async () => {
     const { game } = createPlayingGame();
-    await SaveSystem.save(validSaveData({
-      isAutoSave: true,
+    await SaveSystem.autoSave(0, validSaveData({
       levelReached: 3,
       waveIndex: 2,
       totalScore: 500,
       lives: 2,
       weapon: "missile",
       playTimeSeconds: 150,
-    }), 0);
+    }));
 
     await (game as any).continueGame();
 
@@ -1624,6 +1637,20 @@ describe("Scenario: Loading an auto-save resumes at the beginning of the saved l
     expect(game.player.lives).toBe(2);
     expect(game.powerUpManager.currentWeapon).toBe("missile");
     expect((game as any).playTimeSeconds).toBe(150);
+  });
+
+  test("continueGame restores wave progress from auto-save", async () => {
+    const { game } = createPlayingGame();
+    await SaveSystem.autoSave(0, validSaveData({
+      levelReached: 2,
+      waveIndex: 3,
+      lives: 2,
+    }));
+
+    await (game as any).continueGame();
+
+    expect(game.currentLevel).toBe(2);
+    expect(game.spawner.completedWaveCount).toBe(3);
   });
 });
 
@@ -1788,30 +1815,47 @@ describe("Scenario: save() creates backup of previous save", () => {
 });
 
 describe("Scenario: autoSave also creates a backup", () => {
-  test("auto-save creates backup of previous save", async () => {
+  test("auto-save creates backup of previous auto-save", async () => {
     const dataA = validSaveData({ totalScore: 100 });
-    await SaveSystem.save(dataA, 0);
-    const firstSaveRaw = mockBackend.data["raptor_save_0"];
+    await SaveSystem.autoSave(0, dataA);
+    const firstAutoRaw = mockBackend.data["raptor_save_0_auto"];
 
     const dataB = validSaveData({ totalScore: 200 });
     await SaveSystem.autoSave(0, dataB);
 
-    expect(mockBackend.data["raptor_save_0_backup"]).toBe(firstSaveRaw);
+    expect(mockBackend.data["raptor_save_0_auto_backup"]).toBe(firstAutoRaw);
+  });
+
+  test("auto-save does not overwrite checkpoint backup", async () => {
+    const checkpoint = validSaveData({ totalScore: 500 });
+    await SaveSystem.save(checkpoint, 0);
+
+    const autoData = validSaveData({ totalScore: 200 });
+    await SaveSystem.autoSave(0, autoData);
+
+    expect(mockBackend.data["raptor_save_0_backup"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_0"]).toBeDefined();
   });
 });
 
 describe("Scenario: clear() removes both primary and backup", () => {
-  test("clear removes primary and backup keys", async () => {
+  test("clear removes checkpoint, auto-save, and all backup keys", async () => {
     await SaveSystem.save(validSaveData({ totalScore: 100 }), 0);
     await SaveSystem.save(validSaveData({ totalScore: 200 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ totalScore: 150 }));
+    await SaveSystem.autoSave(0, validSaveData({ totalScore: 250 }));
 
     expect(mockBackend.data["raptor_save_0"]).toBeDefined();
     expect(mockBackend.data["raptor_save_0_backup"]).toBeDefined();
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeDefined();
+    expect(mockBackend.data["raptor_save_0_auto_backup"]).toBeDefined();
 
     await SaveSystem.clear(0);
 
     expect(mockBackend.data["raptor_save_0"]).toBeUndefined();
     expect(mockBackend.data["raptor_save_0_backup"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_0_auto_backup"]).toBeUndefined();
   });
 });
 
@@ -2080,6 +2124,413 @@ describe("Scenario: Save and load preserves new HP values", () => {
     expect(loaded!.armor).toBe(200);
     expect(loaded!.energy).toBe(200);
     expect(loaded!.shieldBattery).toBe(200);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// ISSUE 749: DUAL-KEY SAVE SYSTEM
+// ════════════════════════════════════════════════════════════════
+
+describe("Scenario: Checkpoint save survives starting a new level", () => {
+  test("checkpoint is preserved when auto-save writes at level start", async () => {
+    const { game } = createPlayingGame();
+    await SaveSystem.save(validSaveData({ levelReached: 3, armor: 200, lives: 3 }), 0);
+
+    (game as any).startLevel(3);
+
+    const checkpoint = await SaveSystem.load(0);
+    expect(checkpoint).not.toBeNull();
+    expect(checkpoint!.levelReached).toBe(3);
+    expect(checkpoint!.armor).toBe(200);
+    expect(checkpoint!.isAutoSave).toBeUndefined();
+
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeDefined();
+  });
+});
+
+describe("Scenario: Checkpoint save survives game over", () => {
+  test("game over clears auto-save but preserves checkpoint", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 3, armor: 200 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 3, armor: 100, waveIndex: 2 }));
+
+    const { game } = createPlayingGame();
+    game.player.alive = false;
+    game.state = "playing";
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("gameover");
+    await new Promise(r => setTimeout(r, 0));
+
+    const checkpoint = await SaveSystem.load(0);
+    expect(checkpoint).not.toBeNull();
+    expect(checkpoint!.levelReached).toBe(3);
+    expect(checkpoint!.armor).toBe(200);
+
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: Player falls back to checkpoint after game over", () => {
+  test("loading after game over returns checkpoint with full state", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 3, armor: 200, lives: 3 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 3, armor: 50, lives: 1, waveIndex: 5 }));
+
+    await SaveSystem.clearAutoSave(0);
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.levelReached).toBe(3);
+    expect(best!.armor).toBe(200);
+    expect(best!.lives).toBe(3);
+    expect(best!.isAutoSave).toBeUndefined();
+  });
+});
+
+describe("Scenario: loadBest returns the best available save", () => {
+  test("returns checkpoint when only checkpoint exists", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 4 }), 0);
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.levelReached).toBe(4);
+    expect(best!.isAutoSave).toBeUndefined();
+  });
+
+  test("returns auto-save when only auto-save exists", async () => {
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 2, waveIndex: 3 }));
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.levelReached).toBe(2);
+    expect(best!.isAutoSave).toBe(true);
+  });
+
+  test("prefers checkpoint over auto-save at same levelReached", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 4, armor: 200 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 4, armor: 50, waveIndex: 2 }));
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.armor).toBe(200);
+    expect(best!.isAutoSave).toBeUndefined();
+  });
+
+  test("prefers higher levelReached regardless of save type", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 3 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 4, waveIndex: 0 }));
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.levelReached).toBe(4);
+    expect(best!.isAutoSave).toBe(true);
+  });
+
+  test("returns null when neither exists", async () => {
+    const best = await SaveSystem.loadBest(0);
+    expect(best).toBeNull();
+  });
+});
+
+describe("Scenario: clearAutoSave only removes auto-save", () => {
+  test("clearAutoSave preserves checkpoint", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 5 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 5, waveIndex: 2 }));
+
+    await SaveSystem.clearAutoSave(0);
+
+    const checkpoint = await SaveSystem.load(0);
+    expect(checkpoint).not.toBeNull();
+    expect(checkpoint!.levelReached).toBe(5);
+
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_0_auto_backup"]).toBeUndefined();
+  });
+
+  test("clearAutoSave is no-op for invalid slot", async () => {
+    await SaveSystem.autoSave(0, validSaveData());
+    await SaveSystem.clearAutoSave(-1);
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeDefined();
+  });
+});
+
+describe("Scenario: hasSave checks both checkpoint and auto-save", () => {
+  test("returns true when only auto-save exists", async () => {
+    await SaveSystem.autoSave(0, validSaveData());
+    expect(await SaveSystem.hasSave(0)).toBe(true);
+  });
+
+  test("returns true when only checkpoint exists", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+    expect(await SaveSystem.hasSave(0)).toBe(true);
+  });
+
+  test("returns true when both exist", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+    await SaveSystem.autoSave(0, validSaveData());
+    expect(await SaveSystem.hasSave(0)).toBe(true);
+  });
+
+  test("returns false after clearAutoSave when no checkpoint", async () => {
+    await SaveSystem.autoSave(0, validSaveData());
+    await SaveSystem.clearAutoSave(0);
+    expect(await SaveSystem.hasSave(0)).toBe(false);
+  });
+});
+
+describe("Scenario: listSlots returns best save per slot", () => {
+  test("returns checkpoint over auto-save at same level", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 4, armor: 200 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 4, armor: 50, waveIndex: 2 }));
+
+    const slots = await SaveSystem.listSlots();
+    expect(slots[0]).not.toBeNull();
+    expect(slots[0]!.armor).toBe(200);
+    expect(slots[0]!.isAutoSave).toBeUndefined();
+  });
+});
+
+describe("Scenario: Non-final level complete clears auto-save", () => {
+  test("level-complete writes checkpoint and clears auto-save", async () => {
+    const { game } = createPlayingGame();
+    game.currentLevel = 1;
+    game.totalScore = 200;
+    game.score = 100;
+    game.player.lives = 2;
+    game.spawner.configure(LEVELS[1]);
+
+    for (let t = 0; t < 100; t += 0.1) {
+      game.spawner.update(0.1, 800);
+    }
+    game.spawner.spawnBoss(800);
+    game.spawner.markBossDefeated();
+    game.enemies = [];
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("level_complete");
+    await new Promise(r => setTimeout(r, 0));
+
+    const checkpoint = await SaveSystem.load(0);
+    expect(checkpoint).not.toBeNull();
+    expect(checkpoint!.levelReached).toBe(2);
+    expect(checkpoint!.isAutoSave).toBeUndefined();
+
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: EnemySpawner skipToWave", () => {
+  test("skipToWave marks earlier waves as complete", () => {
+    const spawner = new EnemySpawner();
+    spawner.configure(LEVELS[0]);
+    spawner.skipToWave(3);
+    expect(spawner.completedWaveCount).toBe(3);
+  });
+
+  test("skipToWave(0) is a no-op", () => {
+    const spawner = new EnemySpawner();
+    spawner.configure(LEVELS[0]);
+    spawner.skipToWave(0);
+    expect(spawner.completedWaveCount).toBe(0);
+  });
+
+  test("skipToWave clamps to waves.length - 1", () => {
+    const spawner = new EnemySpawner();
+    const level = LEVELS[0];
+    spawner.configure(level);
+    spawner.skipToWave(100);
+    expect(spawner.completedWaveCount).toBe(level.waves.length - 1);
+  });
+
+  test("skipToWave with negative is a no-op", () => {
+    const spawner = new EnemySpawner();
+    spawner.configure(LEVELS[0]);
+    spawner.skipToWave(-1);
+    expect(spawner.completedWaveCount).toBe(0);
+  });
+});
+
+describe("Scenario: Legacy save without isAutoSave loads as checkpoint", () => {
+  test("legacy save at checkpoint key is treated as checkpoint", async () => {
+    const legacy = validSaveData({ levelReached: 5 });
+    await SaveSystem.save(legacy, 0);
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.isAutoSave).toBeUndefined();
+    expect(best!.levelReached).toBe(5);
+  });
+});
+
+describe("Scenario: Empty slot starts a new game", () => {
+  test("loadBest returns null for empty slot", async () => {
+    const best = await SaveSystem.loadBest(2);
+    expect(best).toBeNull();
+  });
+});
+
+describe("Scenario: Slot shows appropriate save type badge", () => {
+  test("HUD renders CHECKPOINT badge for checkpoint saves", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    const checkpointSlot = validSaveData({ levelReached: 4 });
+    hud.renderSlotSelect(ctx, [checkpointSlot, null, null], 800, 600, 0, 0);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    expect(fillTextCalls.some((c: any) => c.text === "CHECKPOINT")).toBe(true);
+  });
+
+  test("HUD renders AUTO-SAVE badge for auto-saves", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    const autoSlot = validSaveData({ levelReached: 2, isAutoSave: true, waveIndex: 3 });
+    hud.renderSlotSelect(ctx, [autoSlot, null, null], 800, 600, 0, 0);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    expect(fillTextCalls.some((c: any) => c.text === "AUTO-SAVE")).toBe(true);
+  });
+
+  test("HUD shows wave progress for auto-saves", () => {
+    const { HUD } = require("../src/games/raptor/rendering/HUD");
+    const hud = new HUD(false);
+    const canvas = createMockCanvas();
+    const ctx = (canvas as any).__ctx;
+
+    const totalWaves = LEVELS[2]?.waves.length ?? 0;
+    const autoSlot = validSaveData({ levelReached: 2, isAutoSave: true, waveIndex: 4 });
+    hud.renderSlotSelect(ctx, [autoSlot, null, null], 800, 600, 0, 0);
+
+    const fillTextCalls = (canvas as any).__fillTextCalls as Array<{ text: string }>;
+    expect(fillTextCalls.some((c: any) => c.text === `Wave 4/${totalWaves}`)).toBe(true);
+  });
+});
+
+describe("Scenario: Deleting a slot clears both checkpoint and auto-save", () => {
+  test("clear removes all keys for a slot", async () => {
+    await SaveSystem.save(validSaveData(), 1);
+    await SaveSystem.autoSave(1, validSaveData());
+
+    await SaveSystem.clear(1);
+
+    expect(await SaveSystem.hasSave(1)).toBe(false);
+    expect(await SaveSystem.loadBest(1)).toBeNull();
+    expect(mockBackend.data["raptor_save_1"]).toBeUndefined();
+    expect(mockBackend.data["raptor_save_1_auto"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: Final victory clears both checkpoint and auto-save", () => {
+  test("completing the final level clears save data", async () => {
+    await SaveSystem.save(validSaveData(), 0);
+    await SaveSystem.autoSave(0, validSaveData());
+    expect(await SaveSystem.hasSave(0)).toBe(true);
+
+    const { game } = createPlayingGame();
+    game.currentLevel = LEVELS.length - 1;
+    game.spawner.configure(LEVELS[LEVELS.length - 1]);
+
+    for (let t = 0; t < 200; t += 0.1) {
+      game.spawner.update(0.1, 800);
+    }
+    game.spawner.spawnBoss(800);
+    game.spawner.markBossDefeated();
+    game.enemies = [];
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("victory");
+    await new Promise(r => setTimeout(r, 0));
+    expect(await SaveSystem.hasSave(0)).toBe(false);
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: Auto-save waveIndex exceeds level wave count", () => {
+  test("skipToWave clamps to last wave", () => {
+    const spawner = new EnemySpawner();
+    const level = LEVELS[0];
+    spawner.configure(level);
+
+    spawner.skipToWave(10);
+
+    expect(spawner.completedWaveCount).toBe(level.waves.length - 1);
+    expect(spawner.allWavesComplete).toBe(false);
+  });
+});
+
+describe("Scenario: Save data is preserved on game over (checkpoint survives)", () => {
+  test("checkpoint survives when player dies, auto-save is cleared", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 2, armor: 200 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 2, armor: 50, waveIndex: 3 }));
+
+    const { game } = createPlayingGame();
+    game.player.alive = false;
+    game.state = "playing";
+
+    (game as any).updatePlaying(0.001);
+
+    expect(game.state).toBe("gameover");
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(await SaveSystem.hasSave(0)).toBe(true);
+    const checkpoint = await SaveSystem.load(0);
+    expect(checkpoint!.levelReached).toBe(2);
+    expect(checkpoint!.armor).toBe(200);
+
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeUndefined();
+  });
+});
+
+describe("Scenario: Auto-save is written to separate key at level start", () => {
+  test("level start auto-save uses auto key, not checkpoint key", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 2 }), 0);
+    const checkpointBefore = mockBackend.data["raptor_save_0"];
+
+    const { game } = createPlayingGame();
+    (game as any).startLevel(2);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(mockBackend.data["raptor_save_0"]).toBe(checkpointBefore);
+    expect(mockBackend.data["raptor_save_0_auto"]).toBeDefined();
+
+    const autoData = JSON.parse(mockBackend.data["raptor_save_0_auto"]);
+    expect(autoData.isAutoSave).toBe(true);
+    expect(autoData.waveIndex).toBe(0);
+  });
+});
+
+describe("Scenario: Slot prefers checkpoint over auto-save at same level", () => {
+  test("loadBest returns checkpoint state for same-level saves", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 4, armor: 200, lives: 3 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 4, armor: 50, lives: 1, waveIndex: 2 }));
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.armor).toBe(200);
+    expect(best!.lives).toBe(3);
+    expect(best!.isAutoSave).toBeUndefined();
+  });
+});
+
+describe("Scenario: Player quits mid-level without game over", () => {
+  test("auto-save persists; checkpoint also persists as fallback", async () => {
+    await SaveSystem.save(validSaveData({ levelReached: 4, armor: 200 }), 0);
+    await SaveSystem.autoSave(0, validSaveData({ levelReached: 4, armor: 100, waveIndex: 3 }));
+
+    const checkpoint = await SaveSystem.load(0);
+    expect(checkpoint).not.toBeNull();
+    expect(checkpoint!.armor).toBe(200);
+
+    const best = await SaveSystem.loadBest(0);
+    expect(best).not.toBeNull();
+    expect(best!.armor).toBe(200);
   });
 });
 


### PR DESCRIPTION
## PR: Fix “play once then it’s gone” save behavior by separating checkpoint + auto-save (Issue #749)

### Summary (what changed & why)
This PR fixes a set of save-system design issues where **auto-saves were overwriting clean checkpoint saves**, leading to the “I can load my run once and then it’s gone / degraded” experience.

Key changes:
- **Separate storage for checkpoint vs auto-save per slot** so starting a level no longer destroys the last “level-complete” checkpoint.
- **Auto-saves now restore mid-level progress** by resuming at the saved `waveIndex` instead of always restarting the level from wave 0.
- **Game over clears only the auto-save**, preserving the last checkpoint as a reliable fallback.
- **Slot select UI now indicates what you’re loading** (CHECKPOINT vs AUTO-SAVE) and shows wave progress for auto-saves.

### Behavior changes (player-facing)
- After completing a level, the **checkpoint remains intact** even after starting the next level.
- If you die and hit game over, the game **falls back to the last checkpoint** rather than a degraded mid-run auto-save.
- Loading an auto-save resumes **from the saved wave**, making auto-saves meaningful.
- Slot cards now display **type badges** and **wave progress** for auto-saves.

---

### Key files modified
- `src/games/raptor/systems/SaveSystem.ts`
  - Introduces dual-key save layout (checkpoint + auto-save)
  - Adds `loadBest()` to choose the best available save (prefers checkpoint when tied)
  - Adds `clearAutoSave()` and updates `clear()`, `hasSave()`, `listSlots()`, and `autoSave()`

- `src/games/raptor/RaptorGame.ts`
  - Updates `startLevel()` to write auto-saves to the auto-save key (not the checkpoint key)
  - Updates `continueGame()` to restore `waveIndex` when loading an auto-save
  - Clears auto-save on game over; clears auto-save after writing a checkpoint on level complete
  - Ensures checkpoint saves don’t get tagged as `isAutoSave`

- `src/games/raptor/systems/EnemySpawner.ts`
  - Adds `skipToWave(index: number)` to advance spawner state without spawning

- `src/games/raptor/rendering/HUD.ts`
  - Slot select UI: displays **CHECKPOINT/AUTO-SAVE** badge
  - Auto-save cards show **Wave X/Y** progress

- `tests/raptor-save.test.ts`
  - Adds coverage for dual-key behavior, `loadBest()` selection, game-over auto-save clearing, and wave restoration

---

### Storage/layout notes
Per slot `N`:
- Checkpoint: `raptor_save_{N}`
- Auto-save: `raptor_save_{N}_auto`
- Backups maintained per sub-key (e.g. `raptor_save_{N}_auto_backup`)

This is backward compatible: existing saves in `raptor_save_{N}` load as checkpoints; auto-save keys start empty.

---

### Testing notes
- Added/updated automated tests in `tests/raptor-save.test.ts` covering:
  - Checkpoints are not overwritten by auto-saves
  - `loadBest()` preference logic (checkpoint over auto-save at same level)
  - Auto-save cleared on game over while checkpoint remains
  - Restoring from auto-save resumes at saved `waveIndex` via `skipToWave()`

Recommended manual verification:
1. Complete a level → confirm checkpoint persists after starting next level.
2. Die after starting the next level → confirm auto-save clears and loading returns to the checkpoint state.
3. Quit mid-level after a few waves → confirm loading resumes at the expected wave and slot UI shows AUTO-SAVE + wave progress.

Ref: https://github.com/asgardtech/archer/issues/749