### PR TITLE
after level 5, each addition of a weapon type adds 1% speed

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,4 +1,4 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT, HUD_LEFT_PANEL_WIDTH, HUD_RIGHT_PANEL_WIDTH, HUD_TOP_BAR_HEIGHT, SAVE_FORMAT_VERSION, MAX_SAVE_SLOTS, MAX_WEAPON_TIER } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT, HUD_LEFT_PANEL_WIDTH, HUD_RIGHT_PANEL_WIDTH, HUD_TOP_BAR_HEIGHT, SAVE_FORMAT_VERSION, MAX_SAVE_SLOTS, MAX_WEAPON_TIER, WEAPON_SPEED_BONUS_THRESHOLD, WEAPON_SPEED_BONUS_PER_TYPE } from "./types";
 import { MenuStateMachine } from "./systems/MenuStateMachine";
 import { detectSpeaker } from "./rendering/StoryRenderer";
 import { InputManager } from "./systems/InputManager";
@@ -844,7 +844,13 @@ export class RaptorGame implements IGame {
     this.hud.updateWingmanTimer(dt);
     this.achievementNotification.update(dt);
     this.input.updateFromKeyboard(dt, this.gameAreaWidth, this.gameAreaHeight, this.gameAreaX, this.gameAreaY);
-    this.player.update(dt, this.input.targetX, this.input.targetY, this.gameAreaWidth, this.gameAreaHeight, this.gameAreaX, this.gameAreaY);
+    const levelNumber = this.currentLevelConfig.level;
+    const weaponTypeCount = this.powerUpManager.inventory.size;
+    const speedMultiplier = levelNumber > WEAPON_SPEED_BONUS_THRESHOLD
+      ? 1 + weaponTypeCount * WEAPON_SPEED_BONUS_PER_TYPE
+      : 1;
+
+    this.player.update(dt, this.input.targetX, this.input.targetY, this.gameAreaWidth, this.gameAreaHeight, this.gameAreaX, this.gameAreaY, speedMultiplier);
     if (this.player.alive) {
       this.vfx.addEngineTrail(this.player.pos.x, this.player.pos.y + this.player.height / 2, ShipRenderer.getEngineSpacing(this.player.width));
     }

--- a/src/games/raptor/entities/Player.ts
+++ b/src/games/raptor/entities/Player.ts
@@ -2,7 +2,8 @@ import { Vec2 } from "../types";
 import { SpriteSheet } from "../rendering/SpriteSheet";
 import { ShipRenderer, ShipRenderState } from "../rendering/ShipRenderer";
 
-const MOVE_SPEED = 500;
+export const BASE_MOVE_SPEED = 500;
+const MOVE_SPEED = BASE_MOVE_SPEED;
 const INVINCIBILITY_DURATION = 2.0;
 const HITBOX_INSET_X = 4;
 const HITBOX_INSET_Y = 5;
@@ -97,7 +98,7 @@ export class Player {
       && this.energyRegenTimer >= ENERGY_REGEN_DELAY;
   }
 
-  update(dt: number, targetX: number, targetY: number, canvasWidth: number, canvasHeight: number, offsetX = 0, offsetY = 0): void {
+  update(dt: number, targetX: number, targetY: number, canvasWidth: number, canvasHeight: number, offsetX = 0, offsetY = 0, speedMultiplier = 1): void {
     if (!this.alive) return;
 
     if (this.invincibilityTimer > 0) {
@@ -116,7 +117,8 @@ export class Player {
     const dist = Math.sqrt(dx * dx + dy * dy);
 
     if (dist > 2) {
-      const moveAmount = Math.min(MOVE_SPEED * dt, dist);
+      const effectiveSpeed = MOVE_SPEED * speedMultiplier;
+      const moveAmount = Math.min(effectiveSpeed * dt, dist);
       this.pos.x += (dx / dist) * moveAmount;
       this.pos.y += (dy / dist) * moveAmount;
       this.lastDx = dx / dist;

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -182,6 +182,9 @@ export const SAVE_FORMAT_VERSION = 4;
 
 export const MAX_WEAPON_TIER = 5;
 
+export const WEAPON_SPEED_BONUS_THRESHOLD = 5;
+export const WEAPON_SPEED_BONUS_PER_TYPE = 0.01;
+
 export const MAX_SAVE_SLOTS = 3;
 
 export interface SaveMigration {


### PR DESCRIPTION
## PR: Weapon-diversity speed bonus after Level 5 (Issue #755)

### Summary / Why
Implements the requested late-game movement bonus: **starting on level 6**, the player gains **+1% movement speed per distinct weapon type** currently owned. This rewards weapon variety after level 5 and matches the spec (dynamic, derived from existing inventory + current level, persists naturally across levels/saves).

Design choice: the speed bonus is computed in `RaptorGame.updatePlaying()` and passed into `Player.update()` as a `speedMultiplier`, keeping `Player` decoupled from level progression and inventory state.

---

### What changed
- Added configurable constants for the feature (threshold and per-weapon bonus).
- Updated `Player.update()` to accept an optional `speedMultiplier` (defaulting to `1` for backward compatibility) and apply it to movement speed.
- Computed the multiplier during gameplay update based on:
  - `config.level` (1-indexed; bonus activates when `level > 5`)
  - `powerUpManager.inventory.size` (distinct weapon type count; includes machine-gun)

Bonus formula:
- `speedMultiplier = 1 + (weaponTypeCount * 0.01)` when `level >= 6`, else `1`

---

### Key files modified
- `src/games/raptor/types.ts`
  - Added:
    - `WEAPON_SPEED_BONUS_THRESHOLD = 5`
    - `WEAPON_SPEED_BONUS_PER_TYPE = 0.01`
- `src/games/raptor/entities/Player.ts`
  - `update()` now accepts `speedMultiplier` (optional, default `1`)
  - Movement speed uses `MOVE_SPEED * speedMultiplier`
  - Exported `BASE_MOVE_SPEED = 500` for testability
- `src/games/raptor/RaptorGame.ts`
  - Computes the weapon-diversity speed multiplier in `updatePlaying()`
  - Passes the multiplier into `player.update(...)`

---

### Testing notes
- Manual verification scenarios:
  - Level 5 with multiple weapon types → **no speed bonus**
  - Level 6 with only machine-gun (inventory size = 1) → **+1% speed** (500 → 505 px/s)
  - Level 6 with 4 weapon types → **+4% speed** (500 → 520 px/s)
  - Acquiring a new weapon type on level 6+ immediately increases speed (dynamic recalculation each frame)
  - Level transitions on level 6+ preserve the bonus as inventory persists
  - Loading a save on level 6+ restores the correct bonus automatically (computed from existing saved state)

No save/load schema changes and no HUD updates included.

Ref: https://github.com/asgardtech/archer/issues/755