### PR TITLE
after 10 additions of the same weapon type, it gets homing, even the laser auto-targets

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1,4 +1,4 @@
-import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT, HUD_LEFT_PANEL_WIDTH, HUD_RIGHT_PANEL_WIDTH, HUD_TOP_BAR_HEIGHT, SAVE_FORMAT_VERSION, MAX_SAVE_SLOTS, MAX_WEAPON_TIER, WEAPON_SPEED_BONUS_THRESHOLD, WEAPON_SPEED_BONUS_PER_TYPE } from "./types";
+import { RaptorGameState, RaptorLevelConfig, Projectile, RaptorPowerUpType, WeaponType, RaptorSaveData, EnemyVariant, ENEMY_CONFIGS, ENEMY_WEAPON_CONFIGS, WEAPON_CONFIGS, SpeakerType, WEAPON_SLOT_ORDER, HUD_BAR_HEIGHT, HUD_LEFT_PANEL_WIDTH, HUD_RIGHT_PANEL_WIDTH, HUD_TOP_BAR_HEIGHT, SAVE_FORMAT_VERSION, MAX_SAVE_SLOTS, MAX_WEAPON_TIER, WEAPON_SPEED_BONUS_THRESHOLD, WEAPON_SPEED_BONUS_PER_TYPE } from "./types";
 import { MenuStateMachine } from "./systems/MenuStateMachine";
 import { detectSpeaker } from "./rendering/StoryRenderer";
 import { InputManager } from "./systems/InputManager";
@@ -1117,15 +1117,18 @@ export class RaptorGame implements IGame {
     }
 
     for (const proj of this.projectiles) {
+      const weaponCfg = WEAPON_CONFIGS[proj.sourceWeapon];
+      const homingEnemies = weaponCfg.homing ? this.enemies : undefined;
+
       if (proj instanceof TrackingBullet) {
-        proj.update(dt, this.width, this.height, this.enemies);
+        proj.update(dt, this.width, this.height, homingEnemies);
         const exhaust = proj.getExhaustPosition();
         this.vfx.addTrail(exhaust.x, exhaust.y, "rgba(168, 224, 108, 0.4)", 1.5);
       } else if (proj instanceof Bullet) {
         proj.update(dt, this.width);
         this.vfx.addTrail(proj.pos.x, proj.pos.y + 4, "rgba(255, 220, 0, 0.4)", 1.5);
       } else if (proj instanceof Missile) {
-        proj.update(dt, this.width, this.height, this.enemies);
+        proj.update(dt, this.width, this.height, homingEnemies);
         const exhaust = proj.getExhaustPosition();
         this.vfx.addMissileTrail(exhaust.x, exhaust.y, proj.heading);
       } else if (proj instanceof PlasmaBolt) {
@@ -1499,6 +1502,7 @@ export class RaptorGame implements IGame {
 
   private handleWeaponPickup(weaponType: WeaponType): void {
     const result = this.powerUpManager.setWeapon(weaponType);
+    this.weaponSystem.setWeapon(this.powerUpManager.currentWeapon);
     if (result === "switched") {
       this.sound.play("weapon_switch");
     } else if (result === "upgraded") {

--- a/src/games/raptor/entities/Bullet.ts
+++ b/src/games/raptor/entities/Bullet.ts
@@ -1,4 +1,4 @@
-import { Vec2, Projectile } from "../types";
+import { Vec2, Projectile, WeaponType } from "../types";
 
 const BULLET_SPEED = 500;
 
@@ -9,6 +9,7 @@ export class Bullet implements Projectile {
   public height = 10;
   public damage = 1;
   public piercing = false;
+  public sourceWeapon: WeaponType = "machine-gun";
 
   private angle: number;
   private sprite: HTMLImageElement | null = null;

--- a/src/games/raptor/entities/IonBolt.ts
+++ b/src/games/raptor/entities/IonBolt.ts
@@ -1,4 +1,4 @@
-import { Vec2, Projectile } from "../types";
+import { Vec2, Projectile, WeaponType } from "../types";
 
 const ION_SPEED = 600;
 
@@ -7,6 +7,7 @@ export class IonBolt implements Projectile {
   public alive = true;
   public damage: number;
   public piercing = true;
+  public sourceWeapon: WeaponType = "ion-cannon";
   public width: number;
   public height: number;
   public chargeLevel: number;

--- a/src/games/raptor/entities/LaserBeam.ts
+++ b/src/games/raptor/entities/LaserBeam.ts
@@ -31,6 +31,7 @@ export class LaserBeam {
     this.damage = 1 * tierDamageMultiplier;
   }
 
+  /** Always anchored to player x-position — never accepts enemy positions or tracking data. */
   updatePosition(playerX: number, playerTopY: number): void {
     this.pos.x = playerX;
     this.pos.y = playerTopY;

--- a/src/games/raptor/entities/Missile.ts
+++ b/src/games/raptor/entities/Missile.ts
@@ -1,4 +1,4 @@
-import { Vec2, Projectile } from "../types";
+import { Vec2, Projectile, WeaponType } from "../types";
 import { Enemy } from "./Enemy";
 
 const MISSILE_SPEED = 350;
@@ -10,6 +10,7 @@ export class Missile implements Projectile {
   public height = 14;
   public damage = 3;
   public piercing = false;
+  public sourceWeapon: WeaponType = "missile";
 
   private angle: number;
   private vx: number;

--- a/src/games/raptor/entities/PlasmaBolt.ts
+++ b/src/games/raptor/entities/PlasmaBolt.ts
@@ -1,4 +1,4 @@
-import { Vec2, Projectile } from "../types";
+import { Vec2, Projectile, WeaponType } from "../types";
 
 const PLASMA_SPEED = 400;
 
@@ -9,6 +9,7 @@ export class PlasmaBolt implements Projectile {
   public height = 8;
   public damage = 2;
   public piercing = false;
+  public sourceWeapon: WeaponType = "plasma";
 
   private angle: number;
   private sprite: HTMLImageElement | null = null;

--- a/src/games/raptor/entities/Rocket.ts
+++ b/src/games/raptor/entities/Rocket.ts
@@ -1,4 +1,4 @@
-import { Vec2, Projectile } from "../types";
+import { Vec2, Projectile, WeaponType } from "../types";
 
 const ROCKET_SPEED = 450;
 
@@ -9,6 +9,7 @@ export class Rocket implements Projectile {
   public height = 18;
   public damage = 5;
   public piercing = false;
+  public sourceWeapon: WeaponType = "rocket";
 
   private angle: number;
   private vx: number;

--- a/src/games/raptor/entities/TrackingBullet.ts
+++ b/src/games/raptor/entities/TrackingBullet.ts
@@ -1,4 +1,4 @@
-import { Vec2, Projectile } from "../types";
+import { Vec2, Projectile, WeaponType } from "../types";
 import { Enemy } from "./Enemy";
 
 const TRACKING_BULLET_SPEED = 480;
@@ -10,6 +10,7 @@ export class TrackingBullet implements Projectile {
   public height = 8;
   public damage = 1;
   public piercing = false;
+  public sourceWeapon: WeaponType = "auto-gun";
 
   private angle: number;
   private vx: number;

--- a/src/games/raptor/systems/PowerUpManager.ts
+++ b/src/games/raptor/systems/PowerUpManager.ts
@@ -41,13 +41,12 @@ export class PowerUpManager {
 
     if (type === this._currentWeapon) {
       if (existingTier >= MAX_WEAPON_TIER) return "maxed";
-      this._inventory.set(type, existingTier + 1);
+      this._inventory.set(type, Math.min(existingTier + 1, MAX_WEAPON_TIER));
       return "upgraded";
     }
 
-    // Owned but not active: upgrade tier and switch to it
     if (existingTier < MAX_WEAPON_TIER) {
-      this._inventory.set(type, existingTier + 1);
+      this._inventory.set(type, Math.min(existingTier + 1, MAX_WEAPON_TIER));
       this._currentWeapon = type;
       return "upgraded";
     }
@@ -91,7 +90,10 @@ export class PowerUpManager {
   }
 
   setInventory(inventory: Map<WeaponType, number>): void {
-    this._inventory = new Map(inventory);
+    this._inventory = new Map();
+    for (const [type, tier] of inventory) {
+      this._inventory.set(type, Math.max(1, Math.min(MAX_WEAPON_TIER, Math.floor(tier))));
+    }
     if (!this._inventory.has("machine-gun")) {
       this._inventory.set("machine-gun", 1);
     }

--- a/src/games/raptor/systems/WeaponSystem.ts
+++ b/src/games/raptor/systems/WeaponSystem.ts
@@ -107,6 +107,7 @@ export class WeaponSystem {
           totalProjectiles + newProjectiles.length, MAX_PROJECTILES
         );
         for (const proj of result.projectiles) {
+          proj.sourceWeapon = "auto-turret";
           newProjectiles.push(proj);
         }
         if (result.fired) {
@@ -291,6 +292,7 @@ export class WeaponSystem {
 
   private createBullet(x: number, y: number, angle = 0, damage?: number): Bullet {
     const b = new Bullet(x, y, angle);
+    b.sourceWeapon = this.currentWeapon;
     if (damage !== undefined) b.damage = damage;
     return b;
   }
@@ -298,12 +300,14 @@ export class WeaponSystem {
   private createMissile(x: number, y: number, angle = 0, damage?: number): Missile {
     const config = WEAPON_CONFIGS["missile"];
     const m = new Missile(x, y, angle, config.homingStrength);
+    m.sourceWeapon = this.currentWeapon;
     if (damage !== undefined) m.damage = damage;
     return m;
   }
 
   private createPlasmaBolt(x: number, y: number, angle = 0, damage?: number): PlasmaBolt {
     const p = new PlasmaBolt(x, y, angle);
+    p.sourceWeapon = this.currentWeapon;
     if (damage !== undefined) p.damage = damage;
     return p;
   }
@@ -311,18 +315,21 @@ export class WeaponSystem {
   private createTrackingBullet(x: number, y: number, angle = 0, damage?: number): TrackingBullet {
     const config = WEAPON_CONFIGS["auto-gun"];
     const t = new TrackingBullet(x, y, angle, config.homingStrength);
+    t.sourceWeapon = this.currentWeapon;
     if (damage !== undefined) t.damage = damage;
     return t;
   }
 
   private createRocket(x: number, y: number, angle = 0, damage?: number): Rocket {
     const r = new Rocket(x, y, angle);
+    r.sourceWeapon = this.currentWeapon;
     if (damage !== undefined) r.damage = damage;
     return r;
   }
 
   private createIonBolt(x: number, y: number, chargeLevel: number, angle = 0, damage?: number): IonBolt {
     const bolt = new IonBolt(x, y, chargeLevel, angle);
+    bolt.sourceWeapon = this.currentWeapon;
     if (damage !== undefined) bolt.damage = damage;
     return bolt;
   }

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -428,6 +428,7 @@ export interface Projectile {
   readonly bottom: number;
   damage: number;
   piercing: boolean;
+  sourceWeapon: WeaponType;
   update(dt: number, canvasWidth: number, canvasHeight: number, enemies?: import("./entities/Enemy").Enemy[]): void;
   render(ctx: CanvasRenderingContext2D): void;
 }


### PR DESCRIPTION
## Fix: Non-homing weapons could incorrectly start homing after repeated pickups (Issue #756)

### Summary (what changed & why)
Non-homing weapons (e.g., machine-gun, plasma, ion, rocket, and especially the laser beam) could begin exhibiting homing/auto-targeting behavior after repeatedly collecting the same weapon pickup past max tier. This happened because the projectile update loop decided whether to pass enemy targets based on `instanceof` checks (projectile class), not on the weapon’s declared `WeaponConfig.homing` setting.

This PR fixes the bug by:
- **Tagging every projectile with the weapon that spawned it** (`sourceWeapon`)
- **Guarding homing behavior at runtime** by only providing enemy target data to projectiles when `WEAPON_CONFIGS[sourceWeapon].homing === true`
- **Reducing mid-frame weapon state desync** by syncing `WeaponSystem` immediately after weapon pickup handling
- **Clamping weapon tier values defensively** to prevent invalid tiers (e.g., corrupt saves) from exceeding `MAX_WEAPON_TIER`

Result: non-homing weapons always fly straight, and the **laser remains a fixed vertical column** anchored to the player, regardless of pickup count.

---

### Key changes / implementation notes
- **Projectile homing is now config-driven at runtime**
  - The game loop checks `WEAPON_CONFIGS[proj.sourceWeapon].homing` before passing `enemies` into `proj.update(...)`.
- **Projectiles now carry origin metadata**
  - Added `sourceWeapon` to the `Projectile` interface and populated it for all projectile entities at creation time.
- **Weapon pickup sync timing**
  - Weapon system sync is performed immediately after pickup application to avoid a same-frame mismatch between `PowerUpManager` and `WeaponSystem`.
- **Tier cap enforcement**
  - Tier increments and inventory tier sets are capped to `MAX_WEAPON_TIER` to prevent overflow or bad data from affecting behavior.

---

### Files modified (high level)
- `src/games/raptor/types.ts`
  - Add `sourceWeapon` to `Projectile` interface
- `src/games/raptor/systems/WeaponSystem.ts`
  - Tag created projectiles with `sourceWeapon` (including drone-fired projectiles)
- `src/games/raptor/RaptorGame.ts`
  - Refactor projectile update loop to enforce homing via `WeaponConfig.homing`
  - Sync weapon system after pickup handling to avoid mid-frame desync
- `src/games/raptor/systems/PowerUpManager.ts`
  - Clamp inventory tier writes and tier increments to `MAX_WEAPON_TIER`
- Projectile entities updated to include/propagate `sourceWeapon`:
  - `src/games/raptor/entities/Bullet.ts`
  - `src/games/raptor/entities/Missile.ts`
  - `src/games/raptor/entities/TrackingBullet.ts`
  - `src/games/raptor/entities/PlasmaBolt.ts`
  - `src/games/raptor/entities/IonBolt.ts`
  - `src/games/raptor/entities/Rocket.ts`
- `src/games/raptor/entities/LaserBeam.ts`
  - Defensive documentation to reinforce non-homing expectations (no behavioral change intended)

---

### Testing notes
Manual verification recommended (no automated tests included in this commit):

- **Repro regression (fixed):**
  - Pick up the same non-homing weapon 10+ times (tier remains capped at 5)
  - Fire and confirm projectiles **do not curve toward enemies**
  - Confirm **laser beam stays vertically aligned to player X** and never targets enemies
- **Homing weapons unchanged:**
  - Missiles still home at/after max tier
  - Auto-gun tracking bullets still home
  - Auto-turret drones still auto-target as configured
- **State sync check:**
  - Pick up a weapon mid-combat and confirm weapon switch behavior is consistent and projectiles already in-flight keep their original behavior (based on `sourceWeapon`)
- **Tier clamp sanity:**
  - Simulate/force invalid tier values (e.g., save/dev tooling) and confirm tiers are clamped to `MAX_WEAPON_TIER` and behavior remains correct

---

Ref: https://github.com/asgardtech/archer/issues/756