### PR TITLE
rockets should not have splash damage, missiles should

### DIFF
--- a/src/games/raptor/systems/CollisionSystem.ts
+++ b/src/games/raptor/systems/CollisionSystem.ts
@@ -2,7 +2,6 @@ import { Projectile, WEAPON_CONFIGS } from "../types";
 import { Bullet } from "../entities/Bullet";
 import { Missile } from "../entities/Missile";
 import { PlasmaBolt } from "../entities/PlasmaBolt";
-import { Rocket } from "../entities/Rocket";
 import { LaserBeam } from "../entities/LaserBeam";
 import { EnemyLaserBeam } from "../entities/EnemyLaserBeam";
 import { Enemy, isBossVariant } from "../entities/Enemy";
@@ -167,20 +166,6 @@ export class CollisionSystem {
             }
           }
 
-          if (bullet instanceof Rocket) {
-            const cfg = WEAPON_CONFIGS["rocket"];
-            const splashDamage = Math.ceil(bullet.damage * cfg.splashDamageRatio);
-            const splashHits = this.applySplashDamage(enemy, enemies, cfg.splashRadius, splashDamage);
-            for (const sh of splashHits) {
-              hits.push({
-                bullet,
-                enemy: sh.enemy,
-                destroyed: sh.destroyed,
-                damage: splashDamage,
-                splash: true,
-              });
-            }
-          }
 
           if (!bullet.piercing) break;
         }

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -405,8 +405,8 @@ export const WEAPON_CONFIGS: Record<WeaponType, WeaponConfig> = {
     piercing: false,
     homing: false,
     homingStrength: 0,
-    splashRadius: 60,
-    splashDamageRatio: 0.6,
+    splashRadius: 0,
+    splashDamageRatio: 0,
     rapidFireBonus: 1.4,
     spreadShotBehavior: "multi-projectile",
     tiers: [

--- a/tests/raptor-weapons-qa.test.ts
+++ b/tests/raptor-weapons-qa.test.ts
@@ -1482,12 +1482,9 @@ describe("Weapon Balance Validation", () => {
     expect(WEAPON_CONFIGS["plasma"].fireRateMultiplier).toBe(0.7);
   });
 
-  test("Rocket splashRadius is 60 and largest of all weapons", () => {
-    const rocketSplash = WEAPON_CONFIGS["rocket"].splashRadius;
-    expect(rocketSplash).toBe(60);
-    for (const [key, cfg] of Object.entries(WEAPON_CONFIGS)) {
-      expect(rocketSplash).toBeGreaterThanOrEqual(cfg.splashRadius);
-    }
+  test("Rocket has no splash damage (splashRadius and splashDamageRatio are 0)", () => {
+    expect(WEAPON_CONFIGS["rocket"].splashRadius).toBe(0);
+    expect(WEAPON_CONFIGS["rocket"].splashDamageRatio).toBe(0);
   });
 
   test("Rocket fireRateMultiplier is 0.3", () => {
@@ -1586,9 +1583,10 @@ describe("Splash Damage Scaling", () => {
     expect(Math.ceil(cfg.damage * cfg.splashDamageRatio)).toBe(2);
   });
 
-  test("Rocket splash damage is ceil(5 * 0.6) = 3", () => {
+  test("Rocket has zero splash damage (splashRadius=0, splashDamageRatio=0)", () => {
     const cfg = WEAPON_CONFIGS["rocket"];
-    expect(Math.ceil(cfg.damage * cfg.splashDamageRatio)).toBe(3);
+    expect(cfg.splashRadius).toBe(0);
+    expect(cfg.splashDamageRatio).toBe(0);
   });
 
   test("Plasma splash damage is ceil(2 * 0.5) = 1", () => {
@@ -1608,5 +1606,65 @@ describe("Splash Damage Scaling", () => {
       expect(splashHits[0].damage).toBe(2);
       expect(splashHits[0].damage).not.toBe(1);
     }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SECTION 23: Rocket vs Missile Splash Differentiation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Rocket vs Missile Splash Differentiation", () => {
+  test("Rocket direct hit deals full damage but produces no splash hits", () => {
+    const cs = new CollisionSystem();
+    const rocket = new Rocket(200, 100);
+    const enemyA = makeEnemy(200, 100);
+    const enemyB = makeEnemy(215, 108);
+
+    const hits = cs.checkBulletsEnemies([rocket], [enemyA, enemyB]);
+    const directHits = hits.filter(h => !h.splash);
+    const splashHits = hits.filter(h => h.splash);
+
+    expect(directHits.length).toBe(1);
+    expect(directHits[0].enemy).toBe(enemyA);
+    expect(directHits[0].damage).toBe(5);
+    expect(splashHits.length).toBe(0);
+  });
+
+  test("Rocket hitting near a group of enemies only damages the directly-hit enemy", () => {
+    const cs = new CollisionSystem();
+    const rocket = new Rocket(200, 100);
+    const enemyA = makeEnemy(200, 100);
+    const enemyB = makeEnemy(210, 105);
+    const enemyC = makeEnemy(220, 110);
+
+    const hits = cs.checkBulletsEnemies([rocket], [enemyA, enemyB, enemyC]);
+
+    expect(hits.length).toBe(1);
+    expect(hits[0].enemy).toBe(enemyA);
+    expect(hits[0].splash).toBeFalsy();
+  });
+
+  test("Missile still deals splash damage to nearby enemies", () => {
+    const cs = new CollisionSystem();
+    const missile = new Missile(200, 100);
+    const enemyA = makeEnemy(200, 100);
+    const enemyB = makeEnemy(210, 105);
+
+    const hits = cs.checkBulletsEnemies([missile], [enemyA, enemyB]);
+    const splashHits = hits.filter(h => h.splash);
+
+    expect(splashHits.length).toBeGreaterThan(0);
+    expect(splashHits[0].damage).toBe(Math.ceil(WEAPON_CONFIGS["missile"].damage * WEAPON_CONFIGS["missile"].splashDamageRatio));
+  });
+
+  test("Only missile and plasma have splashRadius > 0", () => {
+    const splashWeapons = Object.entries(WEAPON_CONFIGS)
+      .filter(([_, cfg]) => cfg.splashRadius > 0)
+      .map(([key]) => key);
+
+    expect(splashWeapons).toHaveLength(2);
+    expect(splashWeapons).toContain("missile");
+    expect(splashWeapons).toContain("plasma");
+    expect(splashWeapons).not.toContain("rocket");
   });
 });


### PR DESCRIPTION
## PR: Rockets should not have splash damage, missiles should (Fixes #757)

### Summary / Why
This PR aligns projectile behavior with design intent by **removing splash (AoE) damage from rockets** while ensuring **missiles (and plasma) continue to apply splash damage**. Rockets are now pure single-target, direct-hit heavy damage; missiles remain the crowd-control / area-denial option.

### What changed
- **Rocket splash config disabled** by setting `splashRadius` and `splashDamageRatio` to `0` (config-driven source of truth).
- **Removed dead splash-application logic for rockets** from collision handling (no longer treats rockets as a splash projectile type).
- **Tests updated and expanded** to reflect the new rocket behavior and to prevent missile/plasma splash regressions.

### Key files modified
- `src/games/raptor/types.ts`
  - Updated `WEAPON_CONFIGS["rocket"]`:
    - `splashRadius: 0` (was `60`)
    - `splashDamageRatio: 0` (was `0.6`)
- `src/games/raptor/systems/CollisionSystem.ts`
  - Removed the `instanceof Rocket` splash-damage branch inside `checkBulletsEnemies()`
  - Removed the now-unused `Rocket` import
- `tests/raptor-weapons-qa.test.ts`
  - Updated rocket splash assertions to expect `0` radius/ratio
  - Added coverage:
    - Rocket direct-hit only (no nearby enemy damage, no splash hit records)
    - Missile splash regression guard
    - Enumeration check: only missile + plasma are splash weapons

### Testing notes
- **Automated:** Updated/added unit tests in `tests/raptor-weapons-qa.test.ts` to validate:
  - Rocket has no splash in config and produces no splash hits during collisions
  - Missile still applies splash damage within radius (regression)
  - Plasma splash remains unchanged (regression)
- **Manual (recommended quick sanity checks):**
  - Fire rockets into clustered enemies: only the directly hit target should take damage.
  - Fire missiles into clustered enemies: nearby enemies within radius should take splash damage.
  - Confirm rocket hit VFX/SFX still trigger as before (splash logic is separate from visuals/audio).

Ref: https://github.com/asgardtech/archer/issues/757