### PR TITLE
missiles should not have auto-homing by default

### DIFF
--- a/src/games/raptor/RaptorGame.ts
+++ b/src/games/raptor/RaptorGame.ts
@@ -1117,10 +1117,9 @@ export class RaptorGame implements IGame {
     }
 
     for (const proj of this.projectiles) {
-      const weaponCfg = WEAPON_CONFIGS[proj.sourceWeapon];
-      const homingEnemies = weaponCfg.homing ? this.enemies : undefined;
-
       if (proj instanceof TrackingBullet) {
+        const weaponCfg = WEAPON_CONFIGS[proj.sourceWeapon];
+        const homingEnemies = weaponCfg.homing ? this.enemies : undefined;
         proj.update(dt, this.width, this.height, homingEnemies);
         const exhaust = proj.getExhaustPosition();
         this.vfx.addTrail(exhaust.x, exhaust.y, "rgba(168, 224, 108, 0.4)", 1.5);
@@ -1128,7 +1127,8 @@ export class RaptorGame implements IGame {
         proj.update(dt, this.width);
         this.vfx.addTrail(proj.pos.x, proj.pos.y + 4, "rgba(255, 220, 0, 0.4)", 1.5);
       } else if (proj instanceof Missile) {
-        proj.update(dt, this.width, this.height, homingEnemies);
+        const missileHomingEnemies = (proj as Missile).homingStrength > 0 ? this.enemies : undefined;
+        proj.update(dt, this.width, this.height, missileHomingEnemies);
         const exhaust = proj.getExhaustPosition();
         this.vfx.addMissileTrail(exhaust.x, exhaust.y, proj.heading);
       } else if (proj instanceof PlasmaBolt) {

--- a/src/games/raptor/entities/Missile.ts
+++ b/src/games/raptor/entities/Missile.ts
@@ -15,11 +15,11 @@ export class Missile implements Projectile {
   private angle: number;
   private vx: number;
   private vy: number;
-  private homingStrength: number;
+  public readonly homingStrength: number;
   private sprite: HTMLImageElement | null = null;
   private time = 0;
 
-  constructor(x: number, y: number, angle = 0, homingStrength = 1.8) {
+  constructor(x: number, y: number, angle = 0, homingStrength = 0) {
     this.pos = { x, y };
     this.angle = angle;
     this.homingStrength = homingStrength;
@@ -50,7 +50,7 @@ export class Missile implements Projectile {
     if (!this.alive) return;
     this.time += dt;
 
-    if (enemies && enemies.length > 0) {
+    if (this.homingStrength > 0 && enemies && enemies.length > 0) {
       const target = this.findNearestEnemy(enemies);
       if (target) {
         const desiredAngle = Math.atan2(target.pos.x - this.pos.x, -(target.pos.y - this.pos.y));

--- a/src/games/raptor/systems/CommandRegistry.ts
+++ b/src/games/raptor/systems/CommandRegistry.ts
@@ -162,7 +162,10 @@ export function registerWeaponCommands(registry: CommandRegistry): void {
           parts.push("BEAM");
         }
 
-        if (cfg.homing) parts.push("HOMING");
+        const invTierForHoming = inventory.get(name) ?? 1;
+        const tierIdxForHoming = Math.max(0, Math.min(MAX_WEAPON_TIER - 1, invTierForHoming - 1));
+        const tierHS = cfg.tiers[tierIdxForHoming].homingStrength ?? 0;
+        if (cfg.homing || tierHS > 0) parts.push(`HOMING(${tierHS > 0 ? tierHS.toFixed(1) : cfg.homingStrength.toFixed(1)})`);
         if (cfg.piercing) parts.push("PIERCING");
 
         const invTier = inventory.get(name);

--- a/src/games/raptor/systems/WeaponSystem.ts
+++ b/src/games/raptor/systems/WeaponSystem.ts
@@ -181,17 +181,18 @@ export class WeaponSystem {
         }
         soundEvent = "player_shoot";
       } else if (this.currentWeapon === "missile") {
+        const effectiveHomingStrength = tierConfig.homingStrength ?? weaponConfig.homingStrength;
         if (spreadShot) {
           this.spawnProjectilesWithSpread(
             tierConfig, player.pos.x, player.top,
             [-0.25, 0, 0.25],
-            (x, y, angle) => this.createMissile(x, y, angle, tierDamage),
+            (x, y, angle) => this.createMissile(x, y, angle, tierDamage, effectiveHomingStrength),
             newProjectiles
           );
         } else {
           this.spawnProjectiles(
             tierConfig, player.pos.x, player.top,
-            (x, y, angle) => this.createMissile(x, y, angle, tierDamage),
+            (x, y, angle) => this.createMissile(x, y, angle, tierDamage, effectiveHomingStrength),
             newProjectiles
           );
         }
@@ -297,9 +298,8 @@ export class WeaponSystem {
     return b;
   }
 
-  private createMissile(x: number, y: number, angle = 0, damage?: number): Missile {
-    const config = WEAPON_CONFIGS["missile"];
-    const m = new Missile(x, y, angle, config.homingStrength);
+  private createMissile(x: number, y: number, angle = 0, damage?: number, homingStrength?: number): Missile {
+    const m = new Missile(x, y, angle, homingStrength ?? 0);
     m.sourceWeapon = this.currentWeapon;
     if (damage !== undefined) m.damage = damage;
     return m;

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -235,6 +235,7 @@ export interface WeaponTierConfig {
   projectileCount: number;
   projectileSpread: number;
   visualScale: number;
+  homingStrength?: number;
 }
 
 export interface WeaponConfig {
@@ -282,8 +283,8 @@ export const WEAPON_CONFIGS: Record<WeaponType, WeaponConfig> = {
     fireRateMultiplier: 0.35,
     projectileSpeed: 350,
     piercing: false,
-    homing: true,
-    homingStrength: 1.8,
+    homing: false,
+    homingStrength: 0,
     splashRadius: 30,
     splashDamageRatio: 0.4,
     rapidFireBonus: 1.3,
@@ -291,9 +292,9 @@ export const WEAPON_CONFIGS: Record<WeaponType, WeaponConfig> = {
     tiers: [
       TIER_1,
       { damageMultiplier: 1.33, fireRateMultiplier: 1, projectileCount: 1, projectileSpread: 0, visualScale: 1 },
-      { damageMultiplier: 1.33, fireRateMultiplier: 1, projectileCount: 2, projectileSpread: 0.15, visualScale: 1 },
-      { damageMultiplier: 1.67, fireRateMultiplier: 1, projectileCount: 2, projectileSpread: 0.15, visualScale: 1 },
-      { damageMultiplier: 2.0, fireRateMultiplier: 1.2, projectileCount: 3, projectileSpread: 0.12, visualScale: 1 },
+      { damageMultiplier: 1.33, fireRateMultiplier: 1, projectileCount: 2, projectileSpread: 0.15, visualScale: 1, homingStrength: 1.0 },
+      { damageMultiplier: 1.67, fireRateMultiplier: 1, projectileCount: 2, projectileSpread: 0.15, visualScale: 1, homingStrength: 1.4 },
+      { damageMultiplier: 2.0, fireRateMultiplier: 1.2, projectileCount: 3, projectileSpread: 0.12, visualScale: 1, homingStrength: 1.8 },
     ],
   },
   "laser": {


### PR DESCRIPTION
## Fix: Missiles no longer auto-home by default (Issue #758)

### Summary (what changed + why)
Player-fired missiles were previously homing unconditionally because the missile weapon config enabled `homing: true` and the `Missile` entity constructor defaulted `homingStrength` to `1.8`. This made homing a “free” baseline behavior rather than an earned upgrade.

This PR changes missiles to fire as **straight, unguided projectiles by default**, and **unlocks homing via weapon tier progression**:
- **Tier 1–2:** no homing (straight-fire)
- **Tier 3:** weak homing (`homingStrength: 1.0`)
- **Tier 4:** medium homing (`homingStrength: 1.4`)
- **Tier 5:** full homing (`homingStrength: 1.8`, matches previous default)

This preserves the intended upgrade curve and keeps auto-gun/auto-turret homing behavior unchanged.

---

### Key changes / implementation notes
- Added **tier-level `homingStrength` override** to weapon tier config so behavior can scale per tier without affecting other weapons.
- Set missile weapon-level defaults to **no homing** (`homing: false`, `homingStrength: 0`), with tier overrides for tiers 3–5.
- Updated missile creation to use the **tier-resolved effective homing strength** at spawn time (in-flight missiles keep the value they were created with).
- Updated the main projectile update loop to decide whether to provide enemies to missiles based on the **missile instance’s `homingStrength`** (rather than weapon-level `cfg.homing`).
- Updated dev console weapon info output to reflect **tier-based homing** status/strength.

---

### Files modified
- `src/games/raptor/types.ts`
  - Add `homingStrength?: number` to `WeaponTierConfig`
  - Update missile `WEAPON_CONFIGS`: weapon-level homing off; add tier 3–5 `homingStrength`
- `src/games/raptor/entities/Missile.ts`
  - Default constructor `homingStrength` to `0`
  - Expose `homingStrength` as `public readonly`
  - Add explicit guard to skip homing logic when `homingStrength <= 0`
- `src/games/raptor/systems/WeaponSystem.ts`
  - Resolve `effectiveHomingStrength = tier.homingStrength ?? weapon.homingStrength`
  - Pass resolved strength into `createMissile(...)`
- `src/games/raptor/RaptorGame.ts`
  - In projectile loop, pass enemies to `Missile.update()` only when `missile.homingStrength > 0`
- `src/games/raptor/systems/CommandRegistry.ts`
  - Update `weapon` command output to display `HOMING(x.y)` when tier enables it

---

### Testing notes
Manual verification recommended (no automated tests included in this change):
- Equip **missiles at tier 1**: missiles travel straight and do not steer toward enemies.
- Upgrade to **tier 3/4/5**: missiles progressively home with strengths **1.0 / 1.4 / 1.8**.
- Confirm **splash damage** still applies (radius `30`) at all tiers.
- Confirm **spread-shot** still fans missiles by angle at tiers 1–2 (and missiles remain straight).
- Confirm **auto-gun / tracking bullets** homing behavior is unchanged.
- Confirm **enemy missiles** are unaffected.
- Confirm dev console `weapon` info reflects tier-based homing (no HOMING at tiers 1–2; shows `HOMING(1.0)` at tier 3, etc.).
- Load an older save to ensure no migration issues (tier `homingStrength` is optional; save format unchanged).

Ref: https://github.com/asgardtech/archer/issues/758