### PR TITLE
ship speeds should be a little slower

### DIFF
--- a/src/games/raptor/entities/Enemy.ts
+++ b/src/games/raptor/entities/Enemy.ts
@@ -1,4 +1,4 @@
-import { Vec2, EnemyVariant, EnemyConfig, EnemyWeaponType, GravityWell, ENEMY_CONFIGS } from "../types";
+import { Vec2, EnemyVariant, EnemyConfig, EnemyWeaponType, GravityWell, ENEMY_CONFIGS, SHIP_SPEED_SCALE } from "../types";
 
 export function isBossVariant(variant: EnemyVariant): boolean {
   return variant === "boss" || variant === "boss_gunship" || variant === "boss_dreadnought"
@@ -262,7 +262,7 @@ export class Enemy {
     this.height = config.height;
     this.weaponType = config.weaponType ?? "standard";
 
-    const actualSpeed = speed ?? config.speed;
+    const actualSpeed = (speed ?? config.speed) * SHIP_SPEED_SCALE;
     this.pos = { x, y };
     this.vel = { x: 0, y: actualSpeed };
   }
@@ -921,14 +921,14 @@ export class Enemy {
             (this.pos.x - this.vultureCenterX) / radiusX
           );
         } else {
-          const speed = 160 * dt;
+          const speed = 160 * SHIP_SPEED_SCALE * dt;
           this.pos.x += (dx / dist) * speed;
           this.pos.y += (dy / dist) * speed;
         }
       } else {
         const radiusX = vCw * 0.3;
         const radiusY = canvasHeight * 0.2;
-        const angularSpeed = 160 / Math.max(radiusX, radiusY);
+        const angularSpeed = (160 * SHIP_SPEED_SCALE) / Math.max(radiusX, radiusY);
         this.vultureOrbitAngle += angularSpeed * dt * (1 + 0.2 * Math.sin(this.time));
         this.pos.x = this.vultureCenterX + radiusX * Math.cos(this.vultureOrbitAngle);
         this.pos.y = this.vultureCenterY + radiusY * Math.sin(this.vultureOrbitAngle);

--- a/src/games/raptor/entities/Player.ts
+++ b/src/games/raptor/entities/Player.ts
@@ -1,8 +1,8 @@
-import { Vec2 } from "../types";
+import { Vec2, SHIP_SPEED_SCALE } from "../types";
 import { SpriteSheet } from "../rendering/SpriteSheet";
 import { ShipRenderer, ShipRenderState } from "../rendering/ShipRenderer";
 
-export const BASE_MOVE_SPEED = 500;
+export const BASE_MOVE_SPEED = 500 * SHIP_SPEED_SCALE;
 const MOVE_SPEED = BASE_MOVE_SPEED;
 const INVINCIBILITY_DURATION = 2.0;
 const HITBOX_INSET_X = 4;

--- a/src/games/raptor/types.ts
+++ b/src/games/raptor/types.ts
@@ -332,6 +332,9 @@ export const MAX_SAVE_SLOTS = 3;
 
 export const MIN_ENEMY_RENDER_SIZE = 24;
 
+/** Global multiplier applied to all ship movement speeds (enemy & player). */
+export const SHIP_SPEED_SCALE = 0.85;
+
 export interface SaveMigration {
   readonly fromVersion: number;
   readonly toVersion: number;


### PR DESCRIPTION
## PR: Reduce ship movement speeds via global scale factor (Issue #781)

### Summary (what & why)
This PR slightly slows down **all ship movement** (player + enemies) to improve pacing and give players more time to react, per Issue #781 (“ship speeds should be a little slower”).  

Instead of hand-tuning many per-enemy and per-level speed values, it introduces a single global multiplier **`SHIP_SPEED_SCALE`** set to **`0.85`** (~15% reduction) and applies it at the points where movement speed is consumed. This preserves existing relative difficulty curves and speed relationships across enemy types/levels while making tuning a one-line change going forward.

### Key changes
- Added **`SHIP_SPEED_SCALE = 0.85`** as the global tuning knob for ship movement speed.
- Applied the scale to:
  - Default enemy vertical movement speed during enemy initialization
  - Select hard-coded special-case enemy movement (e.g., vulture chase/orbit behavior) so those patterns slow down consistently
  - Player base movement speed

### Key files modified
- `src/games/raptor/types.ts`
  - Adds `SHIP_SPEED_SCALE` constant (0.85)
- `src/games/raptor/entities/Enemy.ts`
  - Multiplies computed enemy movement speed by `SHIP_SPEED_SCALE`
  - Scales specific hard-coded movement speeds used in special behaviors to keep them consistent with the global reduction
- `src/games/raptor/entities/Player.ts`
  - Scales `BASE_MOVE_SPEED` by `SHIP_SPEED_SCALE`

### What’s intentionally not changed
- Projectile speeds (`projectileSpeed`), aiming/cursor speed, terrain/parallax scroll, and other non-ship movement speeds are not affected.

### Testing notes
- Manual sanity checks recommended:
  - Spawn a few common enemies (e.g., scout/interceptor) and verify they traverse the screen more slowly (~15%).
  - Verify bosses still progress through movement/phase logic normally.
  - Verify player movement feels slightly less twitchy and still responsive with weapon-count speed bonus and other modifiers.
- No save/migration impact expected (speed values aren’t persisted).
- If there are tests asserting exact speed values, they may need updates to account for the `0.85` multiplier.

Closes: **#781**

Ref: https://github.com/asgardtech/archer/issues/781